### PR TITLE
Establish canonical VULCAN runtime kernel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -280,7 +280,9 @@ RUN chmod 0555 /app/entrypoint.sh
 
 # Application database location environment variable example (SQLite default)
 ENV SQLALCHEMY_DATABASE_URI="sqlite:///graphix_api.db"
-ENV PYTHONPATH=/app
+# Production imports one package identity only.  Do not add /app here: doing so
+# makes the same VULCAN source importable as both ``src.vulcan`` and ``vulcan``.
+ENV PYTHONPATH=/app/src
 ENV VULCAN_ENV=production
 ENV VULCAN_SAFETY_LEVEL=strict
 ENV VULCAN_ENABLE_SELF_IMPROVEMENT=false
@@ -308,11 +310,8 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=600s --retries=3 \
 # Entrypoint ensures runtime secrets are provided securely
 ENTRYPOINT ["/app/entrypoint.sh"]
 
-# Default command - runs the full platform which includes:
-# - Graphix Registry API
-# - VULCAN cognitive platform with /vulcan/v1/chat endpoint
-# - All 71+ services integrated behind the chat interface
+# Default command - runs the single statically composed VULCAN runtime.
 # Note: The PORT environment variable is used for flexibility (default 8000)
 # PRODUCTION MODE: --workers 1 ensures singleton process (no split-brain)
 # DO NOT use --reload in production as it spawns a parent watcher + child worker
-CMD ["sh", "-c", "uvicorn src.full_platform:app --host 0.0.0.0 --port ${PORT:-8000} --workers 1"]
+CMD ["sh", "-c", "uvicorn vulcan.runtime.app:app --host 0.0.0.0 --port ${PORT:-8000} --workers 1"]

--- a/docs/architecture/adr-003-canonical-runtime.md
+++ b/docs/architecture/adr-003-canonical-runtime.md
@@ -1,0 +1,27 @@
+# ADR 003: Canonical runtime composition
+
+## Decision
+
+Docker runs `vulcan.runtime.app:app` with `PYTHONPATH=/app/src`.  `vulcan` is
+the sole production package root.  Its static ASGI route table is complete
+before lifespan starts.  Lifespan calls `compose_runtime()` once and attaches
+only `RuntimeContainer` plus readiness metadata to application state.
+
+`RuntimeContainer` owns the existing `ProductionDeployment`, its one injected
+World Model (the canonical World State for this migration), safety validator,
+legacy memory facade, and `CognitiveKernel`.  The kernel accepts framework-free
+`KernelRequest` values and one request-scoped `CognitiveCase`; its compatibility
+adapter is the only route to the retained legacy executor.
+
+`/v1/chat`, `/v1/chat/orchestrated`, and `/vulcan/v1/chat` are aliases for one
+handler and one kernel call.  The old `src.full_platform` parent/mounted child
+composition and Graphix language-layer coordinators are not in Docker's
+production import closure.  They remain research/legacy code pending deletion;
+rollback is selecting the prior container image/commit, not mutating a running
+container.
+
+## Limits
+
+The legacy executor is a bounded compatibility adapter while semantic ingress,
+evidence, memory reconstruction, and output firewall work are deferred.  It is
+not a claim of production readiness or correctness.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,9 @@ addopts = [
     "--disable-warnings",
 ]
 testpaths = ["tests", "src/vulcan/tests"]
-pythonpath = ["."]
+# Tests retain ``src.*`` compatibility imports while exercising the canonical
+# installed-package identity used by the container.
+pythonpath = [".", "src"]
 filterwarnings = [
     "ignore::coverage.exceptions.CoverageWarning",
 ]

--- a/src/vulcan/endpoints/unified_chat.py
+++ b/src/vulcan/endpoints/unified_chat.py
@@ -457,8 +457,7 @@ async def _execute_with_enhanced_prompt(
     )
 
 
-@router.post("/v1/chat", response_model=None)
-async def unified_chat(request: Request, body: UnifiedChatRequest) -> Dict[str, Any]:
+async def legacy_unified_chat(request: Request, body: UnifiedChatRequest) -> Dict[str, Any]:
     """
     Unified chat endpoint that integrates the ENTIRE VulcanAMI platform.
 
@@ -2436,7 +2435,38 @@ async def unified_chat(request: Request, body: UnifiedChatRequest) -> Dict[str, 
         }, {"source": "deterministic_error", "authority_source": "error"})
 
 
+@router.post("/v1/chat", response_model=None)
 @router.post("/v1/chat/orchestrated", response_model=None)
+async def unified_chat(request: Request, body: UnifiedChatRequest) -> Dict[str, Any]:
+    """Compatibility transport alias for the canonical runtime kernel.
+
+    This router is retained for research/standalone users. Docker never mounts
+    it; deployed aliases are statically composed in ``vulcan.runtime.app``.
+    """
+    from vulcan.runtime.app import _runtime
+    from vulcan.runtime.case import CognitiveCase
+    from vulcan.runtime.kernel import KernelRequest
+
+    runtime = _runtime(request)
+    case = CognitiveCase.create(
+        request_id=getattr(request.state, "request_id", str(uuid.uuid4())),
+        conversation_id=body.conversation_id,
+        message=body.message,
+    )
+    result = await runtime.kernel.handle(
+        KernelRequest(message=body.message, conversation_id=body.conversation_id, payload=request), case
+    )
+    result.payload.setdefault("metadata", {}).update({
+        "case_id": case.case_id,
+        "runtime_id": runtime.runtime_id,
+        "state_snapshot_id": case.state_snapshot_id,
+    })
+    return result.payload
+
+
+# Retained solely as a research-only callable for existing experiments.  It is
+# deliberately not decorated as a production route; both supported route shapes
+# above enter the canonical kernel instead.
 async def orchestrated_chat(request: Request, body: UnifiedChatRequest) -> Dict[str, Any]:
     """
     World Model Orchestrated Chat Endpoint.

--- a/src/vulcan/runtime/__init__.py
+++ b/src/vulcan/runtime/__init__.py
@@ -1,0 +1,21 @@
+"""The canonical production runtime for VULCAN.
+
+Only this package is allowed to assemble the production cognitive graph.
+"""
+
+from .case import CognitiveCase, CognitiveCaseStatus
+from .container import RuntimeContainer
+from .kernel import CognitiveKernel, KernelRequest, KernelResult
+
+__all__ = [
+    "CognitiveCase", "CognitiveCaseStatus",
+    "RuntimeContainer", "CognitiveKernel", "KernelRequest", "KernelResult",
+]
+
+
+def __getattr__(name: str):
+    """Keep domain runtime imports independent of the ASGI optional dependency."""
+    if name in {"app", "create_app"}:
+        from .app import app, create_app
+        return {"app": app, "create_app": create_app}[name]
+    raise AttributeError(name)

--- a/src/vulcan/runtime/app.py
+++ b/src/vulcan/runtime/app.py
@@ -1,0 +1,76 @@
+"""Canonical statically-composed ASGI application selected by Docker."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from uuid import uuid4
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from vulcan.api.models import UnifiedChatRequest
+
+from .case import CognitiveCase
+from .composition import compose_runtime
+from .kernel import KernelRequest
+
+
+def _runtime(request: Request):
+    runtime = getattr(request.app.state, "runtime", None)
+    if runtime is None or runtime.closed:
+        raise HTTPException(status_code=503, detail="Cognitive runtime is not ready")
+    return runtime
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Routes are registered below, before this point.  Readiness is not set
+    # until all required services form one RuntimeContainer.
+    app.state.ready = False
+    app.state.runtime = None
+    try:
+        runtime = await asyncio.to_thread(compose_runtime)
+        app.state.runtime = runtime
+        app.state.ready = True
+        yield
+    finally:
+        app.state.ready = False
+        runtime = getattr(app.state, "runtime", None)
+        if runtime is not None:
+            await runtime.close()
+        app.state.runtime = None
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="VULCAN canonical runtime", version="3.0", lifespan=lifespan)
+
+    @app.get("/health/live")
+    async def live() -> dict[str, str]:
+        return {"status": "alive"}
+
+    @app.get("/health/ready")
+    async def ready(request: Request):
+        runtime = getattr(request.app.state, "runtime", None)
+        if not getattr(request.app.state, "ready", False) or runtime is None:
+            return JSONResponse(status_code=503, content={"status": "not_ready"})
+        return {"status": "ready", "runtime_id": runtime.runtime_id}
+
+    async def chat_handler(request: Request, body: UnifiedChatRequest):
+        runtime = _runtime(request)
+        case = CognitiveCase.create(request_id=request.headers.get("X-Request-ID", str(uuid4())),
+                                    conversation_id=body.conversation_id, message=body.message)
+        command = KernelRequest(message=body.message, conversation_id=body.conversation_id, payload=request)
+        result = await runtime.kernel.handle(command, case)
+        result.payload.setdefault("metadata", {}).update({"case_id": case.case_id,
+                                                             "runtime_id": runtime.runtime_id,
+                                                             "state_snapshot_id": case.state_snapshot_id})
+        return result.payload
+
+    # Compatibility aliases deliberately reference the same callable.
+    app.post("/v1/chat", response_model=None)(chat_handler)
+    app.post("/v1/chat/orchestrated", response_model=None)(chat_handler)
+    app.post("/vulcan/v1/chat", response_model=None)(chat_handler)
+    return app
+
+
+app = create_app()

--- a/src/vulcan/runtime/case.py
+++ b/src/vulcan/runtime/case.py
@@ -1,0 +1,63 @@
+"""Request-scoped, privacy-preserving cognitive unit of work."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from hashlib import sha256
+from typing import Any
+from uuid import uuid4
+
+
+class CognitiveCaseStatus(str, Enum):
+    OPEN = "open"
+    SUCCESS = "success"
+    ABSTAINED = "abstained"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass(frozen=True)
+class CaseEvent:
+    stage: str
+    at: datetime
+    detail: str | None = None
+
+
+@dataclass
+class CognitiveCase:
+    """The sole mutable request record; it never retains the raw prompt."""
+
+    request_id: str
+    conversation_id: str | None
+    input_hash: str
+    case_id: str = field(default_factory=lambda: str(uuid4()))
+    schema_version: str = "1"
+    privacy_classification: str = "request-confidential"
+    state_snapshot_id: str | None = None
+    routing_proposal: Any | None = None
+    routing_decision: str | None = None
+    selected_components: tuple[str, ...] = ()
+    terminal_status: CognitiveCaseStatus = CognitiveCaseStatus.OPEN
+    failure_kind: str | None = None
+    events: list[CaseEvent] = field(default_factory=list)
+
+    @classmethod
+    def create(cls, *, request_id: str, conversation_id: str | None, message: str) -> "CognitiveCase":
+        case = cls(request_id=request_id, conversation_id=conversation_id,
+                   input_hash=sha256(message.encode("utf-8")).hexdigest())
+        case.record("created")
+        return case
+
+    def record(self, stage: str, detail: str | None = None) -> None:
+        if self.terminal_status is not CognitiveCaseStatus.OPEN:
+            raise RuntimeError("cannot append an event after a cognitive case is closed")
+        self.events.append(CaseEvent(stage, datetime.now(timezone.utc), detail))
+
+    def close(self, status: CognitiveCaseStatus, failure_kind: str | None = None) -> None:
+        if self.terminal_status is not CognitiveCaseStatus.OPEN:
+            raise RuntimeError("cognitive case closed more than once")
+        self.failure_kind = failure_kind
+        self.record("terminal", status.value)
+        self.terminal_status = status

--- a/src/vulcan/runtime/composition.py
+++ b/src/vulcan/runtime/composition.py
@@ -1,0 +1,23 @@
+"""Single composition function for the production runtime."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .container import RuntimeContainer
+from .kernel import KernelRequest
+
+
+async def legacy_chat_adapter(command: KernelRequest, _case: Any) -> dict[str, Any]:
+    """Compatibility adapter; transport is kept out of the kernel contract."""
+    from vulcan.endpoints.unified_chat import legacy_unified_chat
+    return await legacy_unified_chat(command.payload, command.payload.body)
+
+
+def compose_runtime() -> RuntimeContainer:
+    """Construct the only permitted production deployment and World State."""
+    from vulcan.config import get_config
+    from vulcan.orchestrator.deployment import ProductionDeployment
+
+    deployment = ProductionDeployment(get_config())
+    return RuntimeContainer.new(deployment=deployment, executor=legacy_chat_adapter)

--- a/src/vulcan/runtime/container.py
+++ b/src/vulcan/runtime/container.py
@@ -1,0 +1,45 @@
+"""Typed owner for the one production cognitive object graph."""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from typing import Any
+from uuid import uuid4
+
+from .kernel import CognitiveKernel
+
+
+@dataclass
+class RuntimeContainer:
+    runtime_id: str
+    deployment: Any
+    world_state: Any
+    kernel: CognitiveKernel
+    safety: Any
+    memory: Any | None
+    closed: bool = False
+
+    async def close(self) -> None:
+        """Release owned resources once, in reverse construction order."""
+        if self.closed:
+            return
+        self.closed = True
+        shutdown = getattr(self.deployment, "shutdown", None)
+        if shutdown is not None:
+            result = shutdown()
+            if inspect.isawaitable(result):
+                await result
+
+    @classmethod
+    def new(cls, *, deployment: Any, executor: Any) -> "RuntimeContainer":
+        deps = getattr(getattr(deployment, "collective", None), "deps", None)
+        world_state = getattr(deps, "world_model", None)
+        if world_state is None:
+            raise RuntimeError("required canonical World State is unavailable")
+        safety = getattr(deps, "safety_validator", None)
+        if safety is None:
+            raise RuntimeError("required safety finalization service is unavailable")
+        kernel = CognitiveKernel(state_authority=world_state, executor=executor)
+        return cls(runtime_id=str(uuid4()), deployment=deployment, world_state=world_state,
+                   kernel=kernel, safety=safety, memory=getattr(deps, "memory", None))

--- a/src/vulcan/runtime/kernel.py
+++ b/src/vulcan/runtime/kernel.py
@@ -1,0 +1,64 @@
+"""Framework-independent cognitive orchestration boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+
+from .case import CognitiveCase, CognitiveCaseStatus
+
+
+@dataclass(frozen=True)
+class KernelRequest:
+    message: str
+    conversation_id: str | None
+    payload: Any
+
+
+@dataclass(frozen=True)
+class KernelResult:
+    payload: dict[str, Any]
+    status: CognitiveCaseStatus
+
+
+LegacyExecutor = Callable[[KernelRequest, CognitiveCase], Awaitable[dict[str, Any]]]
+
+
+class CognitiveKernel:
+    """The only production authority which invokes cognitive orchestration.
+
+    The legacy executor is deliberately an injected adapter.  This lets the
+    strangler migration preserve response compatibility without allowing an
+    endpoint, provider, or bridge to become another coordinator.
+    """
+
+    def __init__(self, *, state_authority: Any, executor: LegacyExecutor) -> None:
+        self._state_authority = state_authority
+        self._executor = executor
+        self.calls = 0
+
+    async def handle(self, request: KernelRequest, case: CognitiveCase) -> KernelResult:
+        if case.terminal_status is not CognitiveCaseStatus.OPEN:
+            raise RuntimeError("kernel received a closed cognitive case")
+        self.calls += 1
+        case.state_snapshot_id = self._snapshot_id()
+        case.record("kernel_entered")
+        try:
+            # Item 2's router remains the source of an untrusted proposal;
+            # this kernel never treats proposal confidence as authority.
+            result = await self._executor(request, case)
+            status = (CognitiveCaseStatus.ABSTAINED if
+                      result.get("metadata", {}).get("source", "").startswith("deterministic_")
+                      else CognitiveCaseStatus.SUCCESS)
+            case.close(status)
+            return KernelResult(payload=result, status=status)
+        except BaseException as exc:
+            status = CognitiveCaseStatus.CANCELLED if type(exc).__name__ == "CancelledError" else CognitiveCaseStatus.FAILED
+            case.close(status, type(exc).__name__)
+            raise
+
+    def _snapshot_id(self) -> str:
+        candidate = getattr(self._state_authority, "version", None)
+        if candidate is None:
+            candidate = getattr(self._state_authority, "snapshot_id", None)
+        return f"world-state:{candidate if candidate is not None else id(self._state_authority)}"

--- a/tests/security/test_runtime_convergence.py
+++ b/tests/security/test_runtime_convergence.py
@@ -1,0 +1,81 @@
+"""Hard gates for remediation sequence item 3's single-authority runtime."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from vulcan.runtime.case import CognitiveCase, CognitiveCaseStatus
+from vulcan.runtime.container import RuntimeContainer
+from vulcan.runtime.kernel import KernelRequest
+
+
+class _Safety:
+    def validate_action(self, _payload):
+        return True
+
+
+_DEFAULT_WORLD = object()
+
+
+def _deployment(world=_DEFAULT_WORLD):
+    if world is _DEFAULT_WORLD:
+        world = SimpleNamespace(version="7")
+    return SimpleNamespace(collective=SimpleNamespace(deps=SimpleNamespace(
+        world_model=world, safety_validator=_Safety(), memory=None
+    )))
+
+
+@pytest.mark.asyncio
+async def test_one_container_injects_one_world_state_and_kernel_closes_case():
+    calls = 0
+
+    async def executor(_request, _case):
+        nonlocal calls
+        calls += 1
+        return {"response": "bounded", "metadata": {}}
+
+    deployment = _deployment()
+    runtime = RuntimeContainer.new(deployment=deployment, executor=executor)
+    case = CognitiveCase.create(request_id="request", conversation_id="conversation", message="secret prompt")
+    result = await runtime.kernel.handle(KernelRequest("secret prompt", "conversation", object()), case)
+
+    assert runtime.world_state is deployment.collective.deps.world_model
+    assert runtime.kernel._state_authority is runtime.world_state
+    assert calls == runtime.kernel.calls == 1
+    assert case.terminal_status is result.status is CognitiveCaseStatus.SUCCESS
+    assert "secret prompt" not in repr(case)
+
+
+@pytest.mark.asyncio
+async def test_cases_are_isolated_under_concurrency():
+    async def executor(_request, _case):
+        await asyncio.sleep(0)
+        return {"response": "ok", "metadata": {}}
+
+    runtime = RuntimeContainer.new(deployment=_deployment(), executor=executor)
+    cases = [CognitiveCase.create(request_id=str(index), conversation_id=None, message=f"prompt-{index}") for index in range(20)]
+    await asyncio.gather(*(runtime.kernel.handle(KernelRequest("x", None, object()), case) for case in cases))
+    assert len({case.case_id for case in cases}) == 20
+    assert all(case.terminal_status is CognitiveCaseStatus.SUCCESS for case in cases)
+    assert runtime.kernel.calls == 20
+
+
+def test_container_fails_closed_without_canonical_world_state():
+    with pytest.raises(RuntimeError, match="World State"):
+        RuntimeContainer.new(deployment=_deployment(world=None), executor=lambda *_: None)
+
+
+def test_production_docker_uses_canonical_package_identity():
+    dockerfile = open("Dockerfile", encoding="utf-8").read()
+    assert "uvicorn vulcan.runtime.app:app" in dockerfile
+    assert "ENV PYTHONPATH=/app/src" in dockerfile
+    assert "uvicorn src.full_platform:app" not in dockerfile
+
+
+def test_chat_aliases_are_one_handler_and_legacy_routes_are_not_deployed():
+    from vulcan.runtime.app import create_app
+
+    app = create_app()
+    routes = {route.path: route.endpoint for route in app.routes if hasattr(route, "endpoint")}
+    assert routes["/v1/chat"] is routes["/v1/chat/orchestrated"] is routes["/vulcan/v1/chat"]


### PR DESCRIPTION
### Motivation

- Replace overlapping production composition roots and multiple mini-minds with one authoritative runtime, kernel, and state owner to satisfy the remediation requirements.
- Ensure the production container selects a single statically composed ASGI app and that lifecycle/startup owns a single `RuntimeContainer` and canonical World State.
- Provide a bounded compatibility adapter so existing response behavior is preserved while preventing endpoints/bridges from creating competing authorities.

### Description

- Add a canonical runtime package at `src/vulcan/runtime` including `app.py` (ASGI app and lifespan), `container.py` (`RuntimeContainer`), `kernel.py` (`CognitiveKernel`, `KernelRequest`, `KernelResult`), `case.py` (`CognitiveCase`), and `composition.py` (`compose_runtime`) plus `__init__.py` exports and a brief ADR `docs/architecture/adr-003-canonical-runtime.md` documenting the decision.
- Make Docker use the canonical package identity by setting `ENV PYTHONPATH=/app/src` and change the container entrypoint to run `uvicorn vulcan.runtime.app:app` (single statically composed runtime).
- Wire existing endpoints into the kernel: retain the legacy endpoint as `legacy_unified_chat` and change the served `/v1/chat`, `/v1/chat/orchestrated`, and `/vulcan/v1/chat` aliases to call the same kernel-backed handler which creates one `CognitiveCase` and performs one kernel invocation per request.
- Add guarded composition that fails closed if the canonical World State or mandatory safety validator are missing, and provide a typed runtime owner that closes resources in reverse order; update `pyproject.toml` test `pythonpath` entries to retain local import compatibility.

### Testing

- Ran `PYTHONPATH=src python -m compileall -q src/vulcan/runtime src/vulcan/endpoints/unified_chat.py` which completed successfully.
- Executed a runtime smoke script that constructed `RuntimeContainer.new(...)` and called `runtime.kernel.handle(...)`, which printed `runtime-smoke: PASS` and verified `world-state:1` snapshot semantics and case terminalization.
- Ran `git diff --check` which reported no whitespace/diff errors for the applied changes.
- Attempted `pytest -q tests/security/test_runtime_convergence.py tests/security/test_transformer_authority_boundary.py tests/security/test_chat_safety_finalization.py` but test collection failed due to missing environment dependency `numpy` (`ModuleNotFoundError`), so the full gating suite could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a59347f223c832f8bbc79d728d7cc78)