### PR TITLE
Canonical runtime: bounded-arithmetic semantic runtime, mandatory safety finalization, and serving boundary middleware

### DIFF
--- a/src/vulcan/api/models.py
+++ b/src/vulcan/api/models.py
@@ -346,98 +346,24 @@ class ThumbsFeedbackRequest(BaseModel):
 
 
 class UnifiedChatRequest(BaseModel):
-    """
-    Standard request model for all chat endpoints.
-    
-    This is the canonical request model that supports all features.
-    Legacy ChatRequest is deprecated and redirects here.
-    
-    This endpoint orchestrates the entire VulcanAMI platform, providing access to:
-    - Multi-modal processing and understanding
-    - Long-term and episodic memory systems
-    - Safety validation and governance
-    - Multiple reasoning engines (symbolic, probabilistic, causal, analogical)
-    - Planning and goal management systems
-    - World model predictions and simulations
-    
-    Attributes:
-        message: The user's message/prompt (required)
-        max_tokens: Maximum tokens in the response (default: 2000)
-        history: Conversation history as list of {"role": "...", "content": "..."} dicts
-        conversation_id: Optional conversation identifier for context continuity.
-            If None, a new conversation ID will be auto-generated.
-        enable_reasoning: Enable advanced reasoning engines (default: True)
-        enable_memory: Enable long-term memory search and retrieval (default: True)
-        enable_safety: Enable safety validation and compliance checking (default: True)
-        enable_planning: Enable hierarchical planning systems (default: True)
-        enable_causal: Enable causal reasoning and inference (default: True)
-        
-    Example:
-        >>> request = UnifiedChatRequest(
-        ...     message="Explain quantum entanglement",
-        ...     max_tokens=1500,
-        ...     history=[{"role": "user", "content": "Hi"}],
-        ...     conversation_id="conv_12345"
-        ... )
-        
-    Note:
-        Feature toggles (enable_*) allow fine-grained control over platform
-        capabilities for performance tuning or specialized use cases.
-    """
-    message: str = Field(
-        ...,
-        description="The user's message/prompt",
-        min_length=1,
-        max_length=10000
-    )
-    max_tokens: int = Field(
-        default=2000,
-        ge=1,
-        le=32000,
-        description="Maximum tokens in response (increased from 8000 to 32000 to support longer responses)"
-    )
-    history: List[ChatHistoryMessage] = Field(
-        default_factory=list,
-        description="Conversation history for context",
-        max_length=100
-    )
-    conversation_id: Optional[str] = Field(
-        default=None,
-        description="Optional conversation ID for tracking",
-        max_length=256
-    )
-    # Feature toggles for fine-grained control
-    enable_reasoning: bool = Field(
-        default=True,
-        description="Enable advanced reasoning engines"
-    )
-    enable_memory: bool = Field(
-        default=True,
-        description="Enable long-term memory search and retrieval"
-    )
-    enable_safety: bool = Field(
-        default=True,
-        description="Enable safety validation and compliance checking"
-    )
-    enable_planning: bool = Field(
-        default=True,
-        description="Enable hierarchical planning systems"
-    )
-    enable_causal: bool = Field(
-        default=True,
-        description="Enable causal reasoning and inference"
-    )
+    """Canonical runtime request: bounded arithmetic only.
 
-    model_config = ConfigDict(
-        json_schema_extra={
-            "example": {
-                "message": "Explain quantum entanglement",
-                "max_tokens": 2000,
-                "history": [],
-                "enable_reasoning": True
-            }
-        }
-    )
+    The Docker-selected runtime deliberately does not support history, memory,
+    planning, causal/general reasoning, or multimodal processing.  The legacy
+    fields remain parseable for an explicit 422 capability error rather than
+    being silently ignored.  ``enable_safety`` is compatibility metadata only:
+    mandatory finalization cannot be disabled.
+    """
+    message: str = Field(..., description="Bounded arithmetic source text", min_length=1, max_length=10000)
+    max_tokens: int = Field(default=2000, ge=1, le=32000, description="Compatibility output limit; strict renderer owns output bounds")
+    history: List[ChatHistoryMessage] = Field(default_factory=list, description="Unsupported by canonical runtime", max_length=100)
+    conversation_id: Optional[str] = Field(default=None, description="Request correlation identifier; no durable history", max_length=256)
+    enable_reasoning: bool = Field(default=False, description="Unsupported on canonical runtime")
+    enable_memory: bool = Field(default=False, description="Unsupported on canonical runtime")
+    enable_safety: bool = Field(default=True, description="Cannot disable mandatory finalization")
+    enable_planning: bool = Field(default=False, description="Unsupported on canonical runtime")
+    enable_causal: bool = Field(default=False, description="Unsupported on canonical runtime")
+    model_config = ConfigDict(json_schema_extra={"example": {"message": "2 + 2", "conversation_id": "request-123"}})
 
 
 # ============================================================

--- a/src/vulcan/endpoints/unified_chat.py
+++ b/src/vulcan/endpoints/unified_chat.py
@@ -2435,8 +2435,6 @@ async def legacy_unified_chat(request: Request, body: UnifiedChatRequest) -> Dic
         }, {"source": "deterministic_error", "authority_source": "error"})
 
 
-@router.post("/v1/chat", response_model=None)
-@router.post("/v1/chat/orchestrated", response_model=None)
 async def unified_chat(request: Request, body: UnifiedChatRequest) -> Dict[str, Any]:
     """Compatibility transport alias for the canonical runtime kernel.
 
@@ -2446,22 +2444,17 @@ async def unified_chat(request: Request, body: UnifiedChatRequest) -> Dict[str, 
     from vulcan.runtime.app import _runtime
     from vulcan.runtime.case import CognitiveCase
     from vulcan.runtime.kernel import KernelRequest
+    from vulcan.runtime.semantic import Utterance
 
     runtime = _runtime(request)
+    utterance = Utterance.from_text(body.message)
     case = CognitiveCase.create(
         request_id=getattr(request.state, "request_id", str(uuid.uuid4())),
         conversation_id=body.conversation_id,
-        message=body.message,
+        input_digest=utterance.digest,
     )
-    result = await runtime.kernel.handle(
-        KernelRequest(message=body.message, conversation_id=body.conversation_id, payload=request), case
-    )
-    result.payload.setdefault("metadata", {}).update({
-        "case_id": case.case_id,
-        "runtime_id": runtime.runtime_id,
-        "state_snapshot_id": case.state_snapshot_id,
-    })
-    return result.payload
+    result = await runtime.kernel.handle(KernelRequest(utterance, body.conversation_id), case)
+    return result.transport(case_id=case.case_id, runtime_id=runtime.runtime_id, snapshot_id=case.state_snapshot_id)
 
 
 # Retained solely as a research-only callable for existing experiments.  It is

--- a/src/vulcan/runtime/app.py
+++ b/src/vulcan/runtime/app.py
@@ -8,6 +8,13 @@ from uuid import uuid4
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+import os
+import base64
+import hashlib
+import hmac
+import json
+import time
 from vulcan.api.models import UnifiedChatRequest
 
 from .case import CognitiveCase
@@ -42,8 +49,62 @@ async def lifespan(app: FastAPI):
         app.state.runtime = None
 
 
+def _jwt_secret() -> str | None:
+    return os.getenv("GRAPHIX_JWT_SECRET") or os.getenv("JWT_SECRET_KEY") or os.getenv("JWT_SECRET")
+
+def _decode_segment(segment: str) -> dict[str, object]:
+    padding = "=" * (-len(segment) % 4)
+    decoded = base64.urlsafe_b64decode((segment + padding).encode("ascii"))
+    value = json.loads(decoded.decode("utf-8"))
+    if not isinstance(value, dict):
+        raise ValueError("JWT segment is not an object")
+    return value
+
+def _authenticate_bearer(value: str) -> bool:
+    """Verify only configured HS256 bearer tokens; never treat presence as auth."""
+    secret = _jwt_secret()
+    if not secret or not value.startswith("Bearer "):
+        return False
+    parts = value[7:].split(".")
+    if len(parts) != 3:
+        return False
+    try:
+        header, payload = _decode_segment(parts[0]), _decode_segment(parts[1])
+        if header.get("alg") != "HS256" or not isinstance(payload.get("sub"), str):
+            return False
+        expected = base64.urlsafe_b64encode(hmac.new(secret.encode("utf-8"), f"{parts[0]}.{parts[1]}".encode("ascii"), hashlib.sha256).digest()).rstrip(b"=").decode("ascii")
+        if not hmac.compare_digest(expected, parts[2]):
+            return False
+        expiry = payload.get("exp")
+        return isinstance(expiry, (int, float)) and not isinstance(expiry, bool) and expiry > time.time()
+    except (UnicodeError, ValueError, json.JSONDecodeError):
+        return False
+
+class ServingBoundaryMiddleware(BaseHTTPMiddleware):
+    """Canonical transport policy: health is public; chat is authenticated and bounded."""
+    max_body_bytes = 16_384
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path not in {"/health/live", "/health/ready"}:
+            length = request.headers.get("content-length")
+            # Chunked bodies are rejected here; deployments must enforce the same
+            # bound upstream before forwarding a request without Content-Length.
+            if length is None or not length.isdigit() or int(length) > self.max_body_bytes:
+                return JSONResponse(status_code=413, content={"detail": "request body exceeds canonical bound"})
+            if not _authenticate_bearer(request.headers.get("authorization", "")):
+                return JSONResponse(status_code=401, content={"detail": "authentication required"}, headers={"WWW-Authenticate": "Bearer"})
+        response = await call_next(request)
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("Cache-Control", "no-store")
+        return response
+
+def generate_route_manifest() -> tuple[dict[str, object], ...]:
+    return tuple({"path": path, "method": method, "classification": "public" if path.startswith("/health/") else "protected", "authentication_required": not path.startswith("/health/"), "authorization": "none" if path.startswith("/health/") else "authenticated"} for path, method in (("/health/live", "GET"), ("/health/ready", "GET"), ("/v1/chat", "POST"), ("/v1/chat/orchestrated", "POST"), ("/vulcan/v1/chat", "POST")))
+
 def create_app() -> FastAPI:
-    app = FastAPI(title="VULCAN canonical runtime", version="3.0", lifespan=lifespan)
+    app = FastAPI(title="VULCAN canonical runtime", version="4.0", lifespan=lifespan)
+    app.add_middleware(ServingBoundaryMiddleware)
+    app.state.route_manifest = generate_route_manifest()
 
     @app.get("/health/live")
     async def live() -> dict[str, str]:
@@ -54,31 +115,17 @@ def create_app() -> FastAPI:
         runtime = getattr(request.app.state, "runtime", None)
         if not getattr(request.app.state, "ready", False) or runtime is None:
             return JSONResponse(status_code=503, content={"status": "not_ready"})
-        return {"status": "ready", "runtime_id": runtime.runtime_id}
+        return {"status": "ready", "runtime_id": runtime.runtime_id, "capabilities": ["bounded-arithmetic"]}
 
     async def chat_handler(request: Request, body: UnifiedChatRequest):
         runtime = _runtime(request)
+        if body.history or body.enable_reasoning or body.enable_memory or body.enable_planning or body.enable_causal:
+            raise HTTPException(status_code=422, detail="history, memory, planning, causal, and general reasoning are unavailable on the canonical runtime")
         utterance = Utterance.from_text(body.message)
-        case = CognitiveCase.create(request_id=request.headers.get("X-Request-ID", str(uuid4())),
-                                    conversation_id=body.conversation_id, input_digest=utterance.digest)
+        case = CognitiveCase.create(request_id=request.headers.get("X-Request-ID", str(uuid4())), conversation_id=body.conversation_id, input_digest=utterance.digest)
         result = await runtime.kernel.handle(KernelRequest(utterance, body.conversation_id), case)
-        transport = result.transport(case_id=case.case_id, runtime_id=runtime.runtime_id,
-                                     snapshot_id=case.state_snapshot_id)
-        safety_payload = {"type": "response", "content": result.response}
-        try:
-            decision = await asyncio.to_thread(runtime.safety.validate_action, safety_payload)
-            allowed = decision[0] if isinstance(decision, tuple) else (decision if isinstance(decision, bool) else False)
-        except Exception:
-            allowed = False
-        transport["metadata"]["finalized"] = True
-        transport["metadata"]["finalization_safety_decision"] = "allow" if allowed else "block"
-        if not allowed:
-            transport["response"] = "I generated a response, but it could not be safely returned. Please rephrase your request."
-            transport["safety_status"] = "output_filtered"
-        case.record_finalization(transport["metadata"]["finalization_safety_decision"])
-        return transport
+        return result.transport(case_id=case.case_id, runtime_id=runtime.runtime_id, snapshot_id=case.state_snapshot_id)
 
-    # Compatibility aliases deliberately reference the same callable.
     app.post("/v1/chat", response_model=None)(chat_handler)
     app.post("/v1/chat/orchestrated", response_model=None)(chat_handler)
     app.post("/vulcan/v1/chat", response_model=None)(chat_handler)

--- a/src/vulcan/runtime/case.py
+++ b/src/vulcan/runtime/case.py
@@ -43,14 +43,15 @@ class CognitiveCase:
     interpretation: "InterpretationBundle | None" = None
     accepted_interpretation: "AcceptedInterpretation | None" = None
     clarification: "ClarificationRequest | None" = None
-    evidence: list["EvidenceArtifact"] = field(default_factory=list)
-    claims: list["Claim"] = field(default_factory=list)
-    derivations: list["Derivation"] = field(default_factory=list)
+    _evidence: list["EvidenceArtifact"] = field(default_factory=list, repr=False)
+    _claims: list["Claim"] = field(default_factory=list, repr=False)
+    _derivations: list["Derivation"] = field(default_factory=list, repr=False)
     response_ir: "ResponseIR | None" = None
     selected_components: tuple[str, ...] = ()
     terminal_status: CognitiveCaseStatus = CognitiveCaseStatus.OPEN
     failure_kind: str | None = None
     finalization_status: str | None = None
+    render_artifact: object | None = field(default=None, repr=False)
     events: list[CaseEvent] = field(default_factory=list)
 
     @classmethod
@@ -71,21 +72,38 @@ class CognitiveCase:
             raise RuntimeError("cannot append an event after a cognitive case is closed")
         self.events.append(CaseEvent(stage, datetime.now(timezone.utc), detail))
 
+    @property
+    def evidence(self) -> tuple["EvidenceArtifact", ...]:
+        return tuple(self._evidence)
+
+    @property
+    def claims(self) -> tuple["Claim", ...]:
+        return tuple(self._claims)
+
+    @property
+    def derivations(self) -> tuple["Derivation", ...]:
+        return tuple(self._derivations)
+
     def append_ledger(self, *, claim: "Claim", derivation: "Derivation", evidence: tuple["EvidenceArtifact", ...] = ()) -> None:
-        """The kernel is the sole writer of accepted request-local ledger records."""
+        """Atomically validate and commit one request-local ledger transaction."""
         if self.terminal_status is not CognitiveCaseStatus.OPEN:
             raise RuntimeError("cannot mutate a closed case ledger")
-        known = {item.claim_id for item in self.claims}
-        if claim.claim_id in known or derivation.derivation_id in {item.derivation_id for item in self.derivations}:
-            raise ValueError("duplicate ledger record")
-        self.evidence.extend(evidence)
-        self.derivations.append(derivation)
-        self.claims.append(claim)
+        from .semantic import validate_ledger
+        proposed_evidence = (*self._evidence, *evidence)
+        proposed_derivations = (*self._derivations, derivation)
+        proposed_claims = (*self._claims, claim)
+        validate_ledger(proposed_evidence, proposed_derivations, proposed_claims)
+        self._evidence.extend(evidence)
+        self._derivations.append(derivation)
+        self._claims.append(claim)
 
     def record_finalization(self, decision: str) -> None:
+        if self.terminal_status is not CognitiveCaseStatus.OPEN:
+            raise RuntimeError("cannot finalize a closed cognitive case")
         if self.finalization_status is not None:
             raise RuntimeError("response finalized more than once")
         self.finalization_status = decision
+        self.record("finalized", decision)
 
     def close(self, status: CognitiveCaseStatus, failure_kind: str | None = None) -> None:
         if self.terminal_status is not CognitiveCaseStatus.OPEN:

--- a/src/vulcan/runtime/container.py
+++ b/src/vulcan/runtime/container.py
@@ -8,6 +8,7 @@ from typing import Any
 from uuid import uuid4
 
 from .kernel import CognitiveKernel
+from .finalization import SafetyResponseFinalizer
 
 
 @dataclass
@@ -32,7 +33,7 @@ class RuntimeContainer:
                 await result
 
     @classmethod
-    def new(cls, *, deployment: Any, executor: Any | None = None) -> "RuntimeContainer":
+    def new(cls, *, deployment: Any) -> "RuntimeContainer":
         deps = getattr(getattr(deployment, "collective", None), "deps", None)
         world_state = getattr(deps, "world_model", None)
         if world_state is None:
@@ -40,6 +41,6 @@ class RuntimeContainer:
         safety = getattr(deps, "safety_validator", None)
         if safety is None:
             raise RuntimeError("required safety finalization service is unavailable")
-        kernel = CognitiveKernel(state_authority=world_state)
+        kernel = CognitiveKernel(state_authority=world_state, finalizer=SafetyResponseFinalizer(safety))
         return cls(runtime_id=str(uuid4()), deployment=deployment, world_state=world_state,
                    kernel=kernel, safety=safety, memory=getattr(deps, "memory", None))

--- a/src/vulcan/runtime/finalization.py
+++ b/src/vulcan/runtime/finalization.py
@@ -1,0 +1,25 @@
+"""Framework-independent mandatory response finalization."""
+from __future__ import annotations
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Protocol
+from .semantic import RenderArtifact
+class FinalizationDecision(str, Enum): ALLOW="allow"; BLOCK="block"; ERROR="error"; CANCELLED="cancelled"
+@dataclass(frozen=True)
+class FinalizationResult:
+    decision: FinalizationDecision
+    artifact: RenderArtifact
+    public_text: str
+class ResponseFinalizerPort(Protocol):
+    async def finalize(self, artifact: RenderArtifact) -> FinalizationResult: ...
+class SafetyResponseFinalizer:
+    def __init__(self, safety: Any) -> None: self._safety = safety
+    async def finalize(self, artifact: RenderArtifact) -> FinalizationResult:
+        try:
+            verdict = self._safety.validate_action({"type":"response", "content":artifact.text})
+            if hasattr(verdict, "__await__"): verdict = await verdict
+            allowed = verdict[0] if isinstance(verdict, tuple) else verdict is True
+        except Exception:
+            allowed = False
+        if allowed: return FinalizationResult(FinalizationDecision.ALLOW, artifact, artifact.text)
+        return FinalizationResult(FinalizationDecision.BLOCK, artifact, "I generated a response, but it could not be safely returned. Please rephrase your request.")

--- a/src/vulcan/runtime/kernel.py
+++ b/src/vulcan/runtime/kernel.py
@@ -1,72 +1,51 @@
 """Framework-independent typed semantic orchestration boundary."""
 from __future__ import annotations
-
+import asyncio
 from dataclasses import dataclass
 from typing import Any
-
 from .case import CognitiveCase, CognitiveCaseStatus
-from .semantic import (AcceptedInterpretation, ClarificationRequest, DeterministicLanguageInput,
-                       InterpretationBundle, LanguageInputPort, ResponseIR, ResponseMode, Utterance, accept,
-                       execute, render_strict, validate_ledger, validate_proposal)
-
+from .finalization import ResponseFinalizerPort
+from .semantic import (ClarificationRequest, DeterministicLanguageInput, LanguageInputPort, RESPONSE_IR_VERSION, ResponseIR, ResponseMode, Utterance, accept, execute, render_strict, validate_proposal)
 @dataclass(frozen=True)
 class KernelRequest:
     utterance: Utterance
     conversation_id: str | None
-
 @dataclass(frozen=True)
 class KernelResult:
     response: str
     response_ir: ResponseIR
     status: CognitiveCaseStatus
-
+    finalization: str
     def transport(self, *, case_id: str, runtime_id: str, snapshot_id: str | None) -> dict[str, object]:
-        return {"response": self.response, "metadata": {"case_id": case_id, "runtime_id": runtime_id,
-                "state_snapshot_id": snapshot_id, "semantic_schema_version": self.response_ir.schema_version}}
-
+        return {"response": self.response, "metadata": {"case_id":case_id,"runtime_id":runtime_id,"state_snapshot_id":snapshot_id,"semantic_schema_version":self.response_ir.schema_version,"finalized":True,"finalization_safety_decision":self.finalization}}
 class CognitiveKernel:
-    """Owns acceptance, computation, claims, response planning, and strict rendering."""
-    def __init__(self, *, state_authority: Any, language_input: LanguageInputPort | None = None) -> None:
-        self._state_authority = state_authority
-        self._language_input = language_input or DeterministicLanguageInput()
-        self.calls = 0
-
+    def __init__(self, *, state_authority: Any, finalizer: ResponseFinalizerPort, language_input: LanguageInputPort | None = None) -> None:
+        self._state_authority=state_authority; self._finalizer=finalizer; self._language_input=language_input or DeterministicLanguageInput(); self.calls=0
     async def handle(self, request: KernelRequest, case: CognitiveCase) -> KernelResult:
-        if case.terminal_status is not CognitiveCaseStatus.OPEN:
-            raise RuntimeError("kernel received a closed cognitive case")
-        self.calls += 1
-        case.state_snapshot_id = self._snapshot_id()
-        case.record("semantic_ingress")
+        if case.terminal_status is not CognitiveCaseStatus.OPEN: raise RuntimeError("kernel received a closed cognitive case")
+        if request.utterance.digest != case.input_hash or request.conversation_id != case.conversation_id: raise ValueError("request/case correlation mismatch")
+        self.calls += 1; case.state_snapshot_id=self._snapshot_id(); case.record("semantic_ingress")
         try:
-            proposal = await self._language_input.propose(request.utterance)
-            bundle = validate_proposal(request.utterance, proposal)
-            case.interpretation = bundle
-            selection = accept(bundle)
+            proposal=await self._language_input.propose(request.utterance); bundle=validate_proposal(request.utterance,proposal); case.interpretation=bundle; selection=accept(bundle)
             if isinstance(selection, ClarificationRequest):
-                case.clarification = selection
-                claim, derivation = execute(AcceptedInterpretation(0, "arithmetic", "invalid"))
-                case.append_ledger(claim=claim, derivation=derivation)
-                response_ir = ResponseIR("response-ir/2", "response-1", case.case_id, None, case.state_snapshot_id, ResponseMode.CLARIFICATION, (claim.claim_id,))
-                case.response_ir = response_ir
-                case.close(CognitiveCaseStatus.ABSTAINED)
-                return KernelResult(selection.question, response_ir, CognitiveCaseStatus.ABSTAINED)
-            case.accepted_interpretation = selection
-            claim, derivation = execute(selection)
-            case.append_ledger(claim=claim, derivation=derivation)
-            validate_ledger(tuple(case.evidence), tuple(case.derivations), tuple(case.claims))
-            mode = ResponseMode.STRICT if claim.status.value == "computed" else ResponseMode.UNKNOWN
-            response_ir = ResponseIR("response-ir/2", "response-1", case.case_id, "accepted-0", case.state_snapshot_id, mode, (claim.claim_id,))
-            case.response_ir = response_ir
-            status = CognitiveCaseStatus.SUCCESS if claim.status.value == "computed" else CognitiveCaseStatus.ABSTAINED
-            rendered = render_strict(response_ir, tuple(case.claims)).text
-            case.record("strict_rendered")
-            case.close(status)
-            return KernelResult(rendered, response_ir, status)
-        except BaseException as exc:
-            status = CognitiveCaseStatus.CANCELLED if type(exc).__name__ == "CancelledError" else CognitiveCaseStatus.FAILED
-            case.close(status, type(exc).__name__)
+                case.clarification=selection
+                # A clarification is an explicit unknown claim, not an evaluation side effect.
+                claim, derivation=execute(type("Unsupported", (), {"operation":"unsupported", "expression":"", "assumptions":()})())
+                case.append_ledger(claim=claim,derivation=derivation); mode=ResponseMode.CLARIFICATION; status=CognitiveCaseStatus.ABSTAINED; accepted_id=None
+            else:
+                case.accepted_interpretation=selection; claim,derivation=execute(selection,case_id=case.case_id); case.append_ledger(claim=claim,derivation=derivation)
+                mode=ResponseMode.STRICT if claim.status.value=="computed" else ResponseMode.UNKNOWN; status=CognitiveCaseStatus.SUCCESS if mode is ResponseMode.STRICT else CognitiveCaseStatus.ABSTAINED; accepted_id=selection.interpretation_id
+            response_ir=ResponseIR(RESPONSE_IR_VERSION,f"response-{case.case_id}",case.case_id,accepted_id,case.state_snapshot_id,mode,(claim.claim_id,))
+            case.response_ir=response_ir; artifact=render_strict(response_ir,case.claims,case.derivations,case.evidence); case.render_artifact=artifact; case.record("strict_rendered")
+            finalization=await self._finalizer.finalize(artifact); case.record_finalization(finalization.decision.value); case.close(status)
+            return KernelResult(finalization.public_text,response_ir,status,finalization.decision.value)
+        except asyncio.CancelledError:
+            if case.terminal_status is CognitiveCaseStatus.OPEN: case.close(CognitiveCaseStatus.CANCELLED,"cancelled")
             raise
-
-    def _snapshot_id(self) -> str:
-        candidate = getattr(self._state_authority, "version", None) or getattr(self._state_authority, "snapshot_id", None)
-        return f"world-state:{candidate if candidate is not None else id(self._state_authority)}"
+        except Exception as exc:
+            if case.terminal_status is CognitiveCaseStatus.OPEN: case.close(CognitiveCaseStatus.FAILED,type(exc).__name__)
+            raise
+    def _snapshot_id(self)->str:
+        candidate=getattr(self._state_authority,"version",None) or getattr(self._state_authority,"snapshot_id",None)
+        if candidate is None: return "world-state:unversioned"
+        return f"world-state:{candidate}"

--- a/src/vulcan/runtime/output.py
+++ b/src/vulcan/runtime/output.py
@@ -1,0 +1,69 @@
+"""Capability-minimized fluent rendering adapter and conservative firewall.
+
+Fluent rendering is disabled by default.  If enabled by a caller, this module
+accepts only structured references to already validated IR/ledger content;
+unreferenced prose is not an allowed wire feature.
+"""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Protocol
+from .semantic import Claim, EvidenceArtifact, ResponseIR
+
+@dataclass(frozen=True)
+class ProjectedClaim:
+    claim_id: str
+    text: str
+    status: str
+    caveat: str | None
+    citation_ids: tuple[str, ...]
+@dataclass(frozen=True)
+class ResponseIRProjection:
+    response_id: str
+    locale: str
+    max_chars: int
+    required_claim_ids: tuple[str, ...]
+    claims: tuple[ProjectedClaim, ...]
+    # No utterance, request, history, case, world-state, tool, memory, or finalizer capability is present.
+@dataclass(frozen=True)
+class DraftSegment:
+    kind: str  # only claim or citation
+    reference_id: str
+@dataclass(frozen=True)
+class UntrustedRenderDraft:
+    schema_version: str
+    segments: tuple[DraftSegment, ...]
+class LanguageOutputPort(Protocol):
+    async def render(self, projection: ResponseIRProjection) -> UntrustedRenderDraft: ...
+@dataclass(frozen=True)
+class FirewallResult:
+    accepted: bool
+    findings: tuple[str, ...]
+
+def project(ir: ResponseIR, claims: tuple[Claim, ...]) -> ResponseIRProjection:
+    indexed = {claim.claim_id: claim for claim in claims}
+    if not set(ir.required_claim_ids) <= set(indexed):
+        raise ValueError("projection references unknown claim")
+    selected = tuple(indexed[identifier] for identifier in ir.required_claim_ids)
+    return ResponseIRProjection(ir.response_id, ir.locale, ir.max_chars, ir.required_claim_ids, tuple(ProjectedClaim(c.claim_id, c.proposition.object, c.status.value, c.caveat, c.citation_ids) for c in selected))
+
+class SemanticFirewall:
+    """Accept only an exact, ordered structural realization of the projection."""
+    def validate(self, projection: ResponseIRProjection, draft: UntrustedRenderDraft) -> FirewallResult:
+        if draft.schema_version != "untrusted-render/1":
+            return FirewallResult(False, ("unsupported draft schema",))
+        findings: list[str] = []
+        claim_ids = tuple(segment.reference_id for segment in draft.segments if segment.kind == "claim")
+        if any(segment.kind not in {"claim", "citation"} for segment in draft.segments):
+            findings.append("unrecognized segment kind")
+        if claim_ids != projection.required_claim_ids:
+            findings.append("required claim coverage or order changed")
+        known_claims = {claim.claim_id for claim in projection.claims}
+        known_citations = {citation for claim in projection.claims for citation in claim.citation_ids}
+        for segment in draft.segments:
+            if segment.kind == "claim" and segment.reference_id not in known_claims:
+                findings.append("unknown claim reference")
+            if segment.kind == "citation" and segment.reference_id not in known_citations:
+                findings.append("unknown citation reference")
+        if len(draft.segments) > len(projection.required_claim_ids) + len(known_citations):
+            findings.append("draft exceeds structural bounds")
+        return FirewallResult(not findings, tuple(findings))

--- a/src/vulcan/runtime/semantic.py
+++ b/src/vulcan/runtime/semantic.py
@@ -1,111 +1,245 @@
-"""Framework-independent, closed semantic contracts for the canonical runtime."""
-from __future__ import annotations
-import ast, hashlib, html, json, math, operator, unicodedata
-from dataclasses import dataclass
-from datetime import datetime
-from enum import Enum
-from typing import Protocol
+"""Closed semantic contracts for the canonical runtime.
 
-SCHEMA_VERSION = "semantic-ingress/2"; LEDGER_VERSION = "semantic-ledger/1"; RESPONSE_IR_VERSION = "response-ir/2"
-MAX_UTTERANCE_CHARS = 10_000; MAX_CANDIDATES = 4; MAX_REFERENCE = 512; MAX_TRACE = 1024
+Language ports may suggest spans only.  The server reconstructs executable
+arithmetic from those spans before a request can reach the evaluator.
+"""
+from __future__ import annotations
+import ast
+import hashlib
+import html
+import json
+import math
+import operator
+import re
+import unicodedata
+from dataclasses import asdict, dataclass, is_dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from fractions import Fraction
+from typing import Any, Protocol
+from uuid import uuid4
+
+SCHEMA_VERSION = "semantic-ingress/2"
+LEDGER_VERSION = "semantic-ledger/2"
+RESPONSE_IR_VERSION = "response-ir/3"
+MAX_UTTERANCE_CHARS = 10_000
+MAX_CANDIDATES = 4
+MAX_REFERENCE = 512
+MAX_TRACE = 1024
+MAX_AST_NODES = 64
+MAX_AST_DEPTH = 16
+MAX_INTEGER_BITS = 256
+MAX_EXPONENT = 32
+
 class EpistemicStatus(str, Enum):
     PROVEN="proven"; COMPUTED="computed"; OBSERVED="observed"; RETRIEVED="retrieved"; ASSUMED="assumed"; HYPOTHESIS="hypothesis"; CONTESTED="contested"; UNKNOWN="unknown"; ERROR="error"
 class EvidenceKind(str, Enum):
     SOURCE_DOCUMENT="source_document"; SOURCE_EXCERPT="source_excerpt"; OBSERVATION="observation"; TOOL_OUTPUT="tool_output"; RETRIEVED_RECORD="retrieved_record"; FORMAL_PREMISE="formal_premise"; USER_ASSERTION="user_assertion"; POLICY_FACT="policy_fact"; STATE_SNAPSHOT="state_snapshot"
 class ExecutionStatus(str, Enum): SUCCESS="success"; PARTIAL="partial"; NOT_APPLICABLE="not_applicable"; UNKNOWN="unknown"; ERROR="error"; CANCELLED="cancelled"
-class ResponseMode(str, Enum): STRICT="strict"; CLARIFICATION="clarification"; PARTIAL="partial"; UNKNOWN="unknown"; ERROR="error"
+class ResponseMode(str, Enum): STRICT="strict"; CLARIFICATION="clarification"; PARTIAL="partial"; UNKNOWN="unknown"; ERROR="error"; ACTION_CONFIRMATION="action_confirmation"
+
 @dataclass(frozen=True)
 class Utterance:
-    text:str; digest:str; locale:str="und"; normalization:str="NFC"
+    text: str
+    digest: str
+    locale: str = "und"
+    normalization: str = "NFC"
     @classmethod
-    def from_text(cls,text:str,locale:str="und")->"Utterance":
-        if not isinstance(text,str) or not text or len(text)>MAX_UTTERANCE_CHARS: raise ValueError("utterance must be bounded")
-        text=unicodedata.normalize("NFC",text); return cls(text,hashlib.sha256(text.encode()).hexdigest(),locale)
+    def from_text(cls, text: str, locale: str = "und") -> "Utterance":
+        if not isinstance(text, str) or not text or len(text) > MAX_UTTERANCE_CHARS:
+            raise ValueError("utterance must be a non-empty bounded string")
+        normalized = unicodedata.normalize("NFC", text)
+        if not re.fullmatch(r"[A-Za-z0-9_-]{2,35}", locale):
+            raise ValueError("invalid locale")
+        return cls(normalized, hashlib.sha256(normalized.encode("utf-8")).hexdigest(), locale)
+
 @dataclass(frozen=True)
 class SourceSpan:
-    start:int; end:int; unit:str="unicode-codepoint"
-    def resolve(self,u:Utterance)->str:
-        if self.unit!="unicode-codepoint" or self.start<0 or self.end<=self.start or self.end>len(u.text): raise ValueError("invalid source span")
-        return u.text[self.start:self.end]
+    start: int
+    end: int
+    unit: str = "unicode-codepoint"
+    def resolve(self, utterance: Utterance) -> str:
+        if self.unit != "unicode-codepoint" or self.start < 0 or self.end <= self.start or self.end > len(utterance.text):
+            raise ValueError("invalid source span")
+        return utterance.text[self.start:self.end]
+
 @dataclass(frozen=True)
-class ProposedCandidate: operation:str; expression:str; span:SourceSpan; diagnostic_confidence:float|None=None
+class ProposedCandidate:
+    operation: str
+    expression: str
+    span: SourceSpan
+    diagnostic_confidence: float | None = None
+
 @dataclass(frozen=True)
-class InterpretationProposal: schema_version:str; candidates:tuple[ProposedCandidate,...]; parser_identity:str
+class InterpretationProposal:
+    schema_version: str
+    candidates: tuple[ProposedCandidate, ...]
+    parser_identity: str
+
 class LanguageInputPort(Protocol):
-    async def propose(self, utterance:Utterance)->InterpretationProposal: ...
+    async def propose(self, utterance: Utterance) -> InterpretationProposal: ...
+
 @dataclass(frozen=True)
-class InterpretationBundle: schema_version:str; ontology_version:str; input_digest:str; candidates:tuple[ProposedCandidate,...]; diagnostics:tuple[str,...]
+class InterpretationBundle:
+    schema_version: str
+    ontology_version: str
+    input_digest: str
+    candidates: tuple[ProposedCandidate, ...]
+    diagnostics: tuple[str, ...]
+    parser_identity: str = "unknown"
+
 @dataclass(frozen=True)
-class AcceptedInterpretation: candidate_index:int; operation:str; expression:str; assumptions:tuple[str,...]=()
+class AcceptedInterpretation:
+    candidate_index: int
+    operation: str
+    expression: str
+    interpretation_id: str = ""
+    assumptions: tuple[str, ...] = ()
+
 @dataclass(frozen=True)
-class ClarificationRequest: field:str; question:str
+class ClarificationRequest:
+    field: str
+    question: str
+    clarification_id: str = ""
+
 @dataclass(frozen=True)
 class EvidenceArtifact:
-    artifact_id:str; kind:EvidenceKind; content_digest:str; reference:str; origin:str; acquisition_method:str; case_id:str; schema_version:str=LEDGER_VERSION; state_snapshot_id:str|None=None; observed_at:datetime|None=None; valid_until:datetime|None=None; scope:str="request"; locale:str="und"; privacy_class:str="request-confidential"; source_integrity:str="not-applicable"; trust_policy:str="not-evaluated"; citation:str|None=None; supporting_span:SourceSpan|None=None; contradicts:tuple[str,...]=(); supersedes:tuple[str,...]=(); limitations:tuple[str,...]=(); adapter_identity:str="kernel"; adapter_version:str="1"
+    artifact_id: str; kind: EvidenceKind; content_digest: str; reference: str; origin: str; acquisition_method: str; case_id: str
+    schema_version: str = LEDGER_VERSION; state_snapshot_id: str | None = None; observed_at: datetime | None = None; valid_until: datetime | None = None
+    scope: str = "request"; locale: str = "und"; privacy_class: str = "request-confidential"; source_integrity: str = "not-applicable"; trust_policy: str = "not-evaluated"; citation: str | None = None; supporting_span: SourceSpan | None = None; contradicts: tuple[str, ...] = (); supersedes: tuple[str, ...] = (); limitations: tuple[str, ...] = (); adapter_identity: str = "kernel"; adapter_version: str = "1"
 @dataclass(frozen=True)
 class Derivation:
-    derivation_id:str; method:str; method_version:str; inputs:tuple[str,...]; output_claim_id:str; assumptions:tuple[str,...]; parameters:tuple[tuple[str,str],...]; deterministic:bool; status:ExecutionStatus; trace_digest:str; error_detail:str|None=None
+    derivation_id: str; method: str; method_version: str; inputs: tuple[str, ...]; output_claim_id: str; assumptions: tuple[str, ...]; parameters: tuple[tuple[str,str], ...]; deterministic: bool; status: ExecutionStatus; trace_digest: str; error_detail: str | None = None
 @dataclass(frozen=True)
-class Proposition: subject:str; predicate:str; object:str; expression:str|None=None; units:str|None=None; negated:bool=False; modality:str="assertive"; quantifier:str="specific"
+class Proposition:
+    subject: str; predicate: str; object: str; expression: str | None = None; units: str | None = None; negated: bool = False; modality: str = "assertive"; quantifier: str = "specific"
 @dataclass(frozen=True)
 class Claim:
-    claim_id:str; proposition:Proposition; status:EpistemicStatus; evidence_ids:tuple[str,...]=(); derivation_ids:tuple[str,...]=(); assumptions:tuple[str,...]=(); contradictions:tuple[str,...]=(); citation_ids:tuple[str,...]=(); scope:str="request"; temporal_validity:str|None=None; uncertainty:str|None=None; caveat:str|None=None
+    claim_id: str; proposition: Proposition; status: EpistemicStatus; evidence_ids: tuple[str, ...] = (); derivation_ids: tuple[str, ...] = (); assumptions: tuple[str, ...] = (); contradictions: tuple[str, ...] = (); citation_ids: tuple[str, ...] = (); scope: str = "request"; temporal_validity: str | None = None; uncertainty: str | None = None; caveat: str | None = None
+    @property
+    def derivation_id(self) -> str | None:  # temporary compatibility for callers that read singular result derivations
+        return self.derivation_ids[0] if len(self.derivation_ids) == 1 else None
 @dataclass(frozen=True)
 class ResponseIR:
-    schema_version:str; response_id:str; case_id:str; accepted_interpretation_id:str|None; state_snapshot_id:str|None; mode:ResponseMode; required_claim_ids:tuple[str,...]; optional_claim_ids:tuple[str,...]=(); locale:str="und"; style:str="strict"; max_chars:int=4000; literals:tuple[str,...]=()
+    schema_version: str; response_id: str; case_id: str; accepted_interpretation_id: str | None; state_snapshot_id: str | None; mode: ResponseMode; required_claim_ids: tuple[str, ...]; optional_claim_ids: tuple[str, ...] = (); locale: str = "und"; style: str = "strict"; max_chars: int = 4000; literals: tuple[str, ...] = ()
 @dataclass(frozen=True)
-class RenderArtifact: text:str; renderer:str; renderer_version:str; ir_digest:str; claim_ids:tuple[str,...]; citation_ids:tuple[str,...]; locale:str; diagnostics:tuple[str,...]=()
+class RenderArtifact:
+    text: str; renderer: str; renderer_version: str; ir_digest: str; claim_ids: tuple[str, ...]; citation_ids: tuple[str, ...]; locale: str; diagnostics: tuple[str, ...] = ()
 @dataclass(frozen=True)
-class UntrustedRenderDraft: text:str
+class UntrustedRenderDraft: text: str
 class LanguageOutputPort(Protocol):
-    async def render(self, response_ir:ResponseIR, style:str, locale:str, max_chars:int)->UntrustedRenderDraft: ...
+    async def render(self, response_ir: ResponseIR, style: str, locale: str, max_chars: int) -> UntrustedRenderDraft: ...
+
+_ARITHMETIC = re.compile(r"^[\s0-9+*/%().-]+$")
 class DeterministicLanguageInput:
-    async def propose(self,u:Utterance)->InterpretationProposal:
-        return InterpretationProposal(SCHEMA_VERSION,(ProposedCandidate("arithmetic",u.text.strip(),SourceSpan(0,len(u.text))),),"deterministic-arithmetic/1")
-def validate_proposal(u:Utterance,p:InterpretationProposal)->InterpretationBundle:
-    if p.schema_version!=SCHEMA_VERSION or not p.candidates or len(p.candidates)>MAX_CANDIDATES: raise ValueError("unsupported interpretation proposal")
-    for c in p.candidates:
-        if c.operation!="arithmetic" or c.span.resolve(u)!=u.text or (c.diagnostic_confidence is not None and not math.isfinite(c.diagnostic_confidence)): raise ValueError("invalid proposal")
-    return InterpretationBundle(SCHEMA_VERSION,"formal-arithmetic/1",u.digest,p.candidates,())
-def accept(b:InterpretationBundle)->AcceptedInterpretation|ClarificationRequest:
-    return AcceptedInterpretation(0,b.candidates[0].operation,b.candidates[0].expression) if len(b.candidates)==1 else ClarificationRequest("interpretation","Please choose one unambiguous supported request.")
-_BIN={ast.Add:operator.add,ast.Sub:operator.sub,ast.Mult:operator.mul,ast.Div:operator.truediv,ast.Pow:operator.pow,ast.Mod:operator.mod}; _UN={ast.UAdd:operator.pos,ast.USub:operator.neg}
-def _evaluate(n:ast.AST)->int|float:
-    if isinstance(n,ast.Constant) and type(n.value) in (int,float) and math.isfinite(n.value): return n.value
-    if isinstance(n,ast.UnaryOp) and type(n.op) in _UN:return _UN[type(n.op)](_evaluate(n.operand))
-    if isinstance(n,ast.BinOp) and type(n.op) in _BIN:
-        v=_BIN[type(n.op)](_evaluate(n.left),_evaluate(n.right))
-        if not math.isfinite(v) or abs(v)>10**100: raise ValueError("bounds")
-        return v
-    raise ValueError("unsupported")
-def execute(a:AcceptedInterpretation)->tuple[Claim,Derivation]:
+    async def propose(self, utterance: Utterance) -> InterpretationProposal:
+        text = utterance.text.strip()
+        offset = utterance.text.index(text)
+        operation = "arithmetic" if _ARITHMETIC.fullmatch(text) else "unsupported"
+        return InterpretationProposal(SCHEMA_VERSION, (ProposedCandidate(operation, text, SourceSpan(offset, offset + len(text))),), "deterministic-parser/2")
+
+def _valid_text(value: str, maximum: int = MAX_REFERENCE) -> bool:
+    return isinstance(value, str) and bool(value) and len(value) <= maximum
+
+def validate_proposal(utterance: Utterance, proposal: InterpretationProposal) -> InterpretationBundle:
+    if proposal.schema_version != SCHEMA_VERSION or not _valid_text(proposal.parser_identity) or not proposal.candidates or len(proposal.candidates) > MAX_CANDIDATES:
+        raise ValueError("unsupported interpretation proposal")
+    validated: list[ProposedCandidate] = []
+    for candidate in proposal.candidates:
+        if candidate.operation not in {"arithmetic", "unsupported"} or not _valid_text(candidate.expression):
+            raise ValueError("unsupported proposal operation")
+        if candidate.diagnostic_confidence is not None and (not isinstance(candidate.diagnostic_confidence, float) or not math.isfinite(candidate.diagnostic_confidence)):
+            raise ValueError("invalid proposal confidence")
+        source = candidate.span.resolve(utterance).strip()
+        # Crucially the expression is reconstructed from the span; a provider cannot substitute tokens.
+        if candidate.expression != source:
+            raise ValueError("proposal expression is not grounded to its source span")
+        if candidate.operation == "arithmetic" and not _ARITHMETIC.fullmatch(source):
+            raise ValueError("arithmetic proposal contains unsupported tokens")
+        validated.append(candidate)
+    return InterpretationBundle(SCHEMA_VERSION, "formal-arithmetic/2", utterance.digest, tuple(validated), (), proposal.parser_identity)
+
+def accept(bundle: InterpretationBundle) -> AcceptedInterpretation | ClarificationRequest:
+    if len(bundle.candidates) != 1:
+        return ClarificationRequest("interpretation", "Please provide one supported, unambiguous request.", f"clarification-{uuid4().hex}")
+    candidate = bundle.candidates[0]
+    return AcceptedInterpretation(0, candidate.operation, candidate.expression, f"accepted-{uuid4().hex}")
+
+_BIN = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul, ast.Div: operator.truediv, ast.Mod: operator.mod, ast.Pow: operator.pow}
+_UN = {ast.UAdd: operator.pos, ast.USub: operator.neg}
+def _budget(node: ast.AST, depth: int = 1) -> int:
+    if depth > MAX_AST_DEPTH: raise ValueError("expression nesting exceeds budget")
+    count = 1
+    for child in ast.iter_child_nodes(node): count += _budget(child, depth + 1)
+    if count > MAX_AST_NODES: raise ValueError("expression node budget exceeded")
+    return count
+def _evaluate(node: ast.AST) -> Fraction:
+    if isinstance(node, ast.Constant) and type(node.value) is int:
+        if node.value.bit_length() > MAX_INTEGER_BITS: raise ValueError("integer exceeds bit budget")
+        return Fraction(node.value)
+    if isinstance(node, ast.UnaryOp) and type(node.op) in _UN: return _UN[type(node.op)](_evaluate(node.operand))
+    if isinstance(node, ast.BinOp) and type(node.op) in _BIN:
+        left, right = _evaluate(node.left), _evaluate(node.right)
+        if isinstance(node.op, ast.Pow):
+            if right.denominator != 1 or abs(right.numerator) > MAX_EXPONENT: raise ValueError("exponent exceeds budget")
+        try: value = _BIN[type(node.op)](left, right)
+        except ZeroDivisionError: raise ValueError("division by zero") from None
+        if value.numerator.bit_length() > MAX_INTEGER_BITS or value.denominator.bit_length() > MAX_INTEGER_BITS: raise ValueError("result exceeds bit budget")
+        return value
+    raise ValueError("unsupported expression")
+def _format_fraction(value: Fraction) -> str: return str(value.numerator) if value.denominator == 1 else f"{value.numerator}/{value.denominator}"
+def execute(accepted: AcceptedInterpretation, *, case_id: str = "case") -> tuple[Claim, Derivation]:
+    cid, did = f"claim-{uuid4().hex}", f"derivation-{uuid4().hex}"
     try:
-        value=str(_evaluate(ast.parse(a.expression,mode="eval").body)); cid="claim-1"; d=Derivation("derivation-1","restricted-python-ast","1",(),cid,a.assumptions,(("precision","exact-integer-or-ieee-float"),),True,ExecutionStatus.SUCCESS,canonical_digest(a.expression))
-        return Claim(cid,Proposition(a.expression,"evaluates_to",value,expression=a.expression),EpistemicStatus.COMPUTED,derivation_ids=(d.derivation_id,),assumptions=a.assumptions),d
-    except (SyntaxError,ValueError,ZeroDivisionError,OverflowError):
-        return Claim("claim-1",Proposition("request","support","unsupported"),EpistemicStatus.UNKNOWN,caveat="No factual result was inferred."),Derivation("derivation-1","restricted-python-ast","1",(),"claim-1",(),(),True,ExecutionStatus.NOT_APPLICABLE,"", "unsupported syntax")
-def validate_ledger(evidence:tuple[EvidenceArtifact,...], derivations:tuple[Derivation,...], claims:tuple[Claim,...])->None:
-    eids={e.artifact_id for e in evidence}; dids={d.derivation_id for d in derivations}; cids={c.claim_id for c in claims}
-    if len(eids)!=len(evidence) or len(dids)!=len(derivations) or len(cids)!=len(claims): raise ValueError("duplicate ledger id")
-    for c in claims:
-        if not set(c.evidence_ids)<=eids or not set(c.derivation_ids)<=dids or not set(c.contradictions)<=cids: raise ValueError("dangling ledger reference")
-        if c.status is EpistemicStatus.COMPUTED and not any(d.status is ExecutionStatus.SUCCESS and d.output_claim_id==c.claim_id for d in derivations): raise ValueError("computed claim lacks successful derivation")
-        if c.status is EpistemicStatus.PROVEN and (not c.evidence_ids or not any(d.status is ExecutionStatus.SUCCESS and d.output_claim_id==c.claim_id for d in derivations)): raise ValueError("proven claim lacks proof inputs")
-        if c.status is EpistemicStatus.OBSERVED and not any(e.kind is EvidenceKind.OBSERVATION for e in evidence if e.artifact_id in c.evidence_ids): raise ValueError("observed claim lacks observation")
-        if c.status is EpistemicStatus.RETRIEVED and not c.evidence_ids: raise ValueError("retrieved claim lacks artifact")
-        if c.status is EpistemicStatus.ASSUMED and not c.assumptions: raise ValueError("assumption not visible")
-def render_strict(ir:ResponseIR, claims:tuple[Claim,...])->RenderArtifact:
-    byid={c.claim_id:c for c in claims}; validate_ledger((),(),tuple(c for c in claims if not c.derivation_ids)) if False else None
-    if not set(ir.required_claim_ids)<=set(byid): raise ValueError("IR references unknown claim")
-    parts=[]
-    for cid in ir.required_claim_ids:
-        c=byid[cid]; p=c.proposition
-        if c.status is EpistemicStatus.COMPUTED: text=f"The computed result is {p.object}."
-        elif c.status is EpistemicStatus.UNKNOWN: text="This request is not supported by the deterministic interpreter."
-        else: text=f"{c.status.value.capitalize()}: {p.subject} {p.predicate} {p.object}."
-        if c.caveat:text+=f" Caveat: {c.caveat}"
-        parts.append(html.escape(text,quote=False))
-    text="\n".join(parts)
-    if len(text)>ir.max_chars: raise ValueError("render bound")
-    return RenderArtifact(text,"strict-template","1",canonical_digest(ir),ir.required_claim_ids,(),ir.locale)
-def canonical_digest(value:object)->str:return hashlib.sha256(json.dumps(value,default=str,sort_keys=True,separators=(",",":"),allow_nan=False).encode()).hexdigest()
+        if accepted.operation != "arithmetic": raise ValueError("unsupported operation")
+        parsed = ast.parse(accepted.expression, mode="eval")
+        _budget(parsed)
+        value = _format_fraction(_evaluate(parsed.body))
+        derivation = Derivation(did, "bounded-arithmetic-ast", "2", (), cid, accepted.assumptions, (("precision", "exact-rational"),), True, ExecutionStatus.SUCCESS, canonical_digest(accepted.expression))
+        return Claim(cid, Proposition(accepted.expression, "evaluates_to", value, expression=accepted.expression), EpistemicStatus.COMPUTED, derivation_ids=(did,), assumptions=accepted.assumptions), derivation
+    except (SyntaxError, ValueError, OverflowError):
+        derivation = Derivation(did, "bounded-arithmetic-ast", "2", (), cid, (), (), True, ExecutionStatus.NOT_APPLICABLE, "", "unsupported or bounded expression")
+        return Claim(cid, Proposition("request", "support", "unsupported"), EpistemicStatus.UNKNOWN, caveat="No factual result was inferred."), derivation
+
+def validate_ledger(evidence: tuple[EvidenceArtifact, ...], derivations: tuple[Derivation, ...], claims: tuple[Claim, ...]) -> None:
+    eids, dids, cids = {e.artifact_id for e in evidence}, {d.derivation_id for d in derivations}, {c.claim_id for c in claims}
+    if len(eids) != len(evidence) or len(dids) != len(derivations) or len(cids) != len(claims): raise ValueError("duplicate ledger id")
+    for derivation in derivations:
+        if derivation.output_claim_id not in cids or len(derivation.trace_digest) > MAX_TRACE: raise ValueError("invalid derivation reference")
+    for claim in claims:
+        if not set(claim.evidence_ids) <= eids or not set(claim.derivation_ids) <= dids or not set(claim.contradictions) <= cids or not set(claim.citation_ids) <= eids: raise ValueError("dangling ledger reference")
+        output = [d for d in derivations if d.output_claim_id == claim.claim_id and d.status is ExecutionStatus.SUCCESS]
+        if claim.status is EpistemicStatus.COMPUTED and not output: raise ValueError("computed claim lacks successful derivation")
+        if claim.status is EpistemicStatus.PROVEN and (not output or not any(e.kind is EvidenceKind.FORMAL_PREMISE for e in evidence if e.artifact_id in claim.evidence_ids)): raise ValueError("proven claim lacks formal evidence")
+        if claim.status is EpistemicStatus.OBSERVED and not any(e.kind is EvidenceKind.OBSERVATION for e in evidence if e.artifact_id in claim.evidence_ids): raise ValueError("observed claim lacks observation")
+        if claim.status is EpistemicStatus.RETRIEVED and not any(e.kind is EvidenceKind.RETRIEVED_RECORD for e in evidence if e.artifact_id in claim.evidence_ids): raise ValueError("retrieved claim lacks retrieved evidence")
+        if claim.status is EpistemicStatus.ASSUMED and not claim.assumptions: raise ValueError("assumption not visible")
+
+def render_strict(ir: ResponseIR, claims: tuple[Claim, ...], derivations: tuple[Derivation, ...] = (), evidence: tuple[EvidenceArtifact, ...] = ()) -> RenderArtifact:
+    if ir.schema_version != RESPONSE_IR_VERSION or ir.literals or ir.max_chars <= 0: raise ValueError("invalid response IR")
+    validate_ledger(evidence, derivations, claims)
+    by_id = {claim.claim_id: claim for claim in claims}
+    if not set(ir.required_claim_ids) <= set(by_id) or set(ir.required_claim_ids) & set(ir.optional_claim_ids): raise ValueError("IR references unknown or duplicate claim")
+    parts: list[str] = []
+    for claim_id in ir.required_claim_ids:
+        claim = by_id[claim_id]; proposition = claim.proposition
+        if claim.status is EpistemicStatus.COMPUTED: text = f"The computed result is {proposition.object}."
+        elif claim.status is EpistemicStatus.UNKNOWN: text = "This request is not supported by the deterministic interpreter."
+        elif claim.status is EpistemicStatus.ERROR: text = "The deterministic interpreter could not complete this request."
+        else: text = f"{claim.status.value.capitalize()}: {proposition.subject} {proposition.predicate} {proposition.object}."
+        if claim.caveat: text += f" Caveat: {claim.caveat}"
+        parts.append(html.escape(text, quote=False))
+    text = "\n".join(parts)
+    if len(text) > ir.max_chars: raise ValueError("render bound")
+    return RenderArtifact(text, "strict-template", "2", canonical_digest(ir), ir.required_claim_ids, (), ir.locale)
+
+def _canonical(value: Any) -> Any:
+    if is_dataclass(value): return _canonical(asdict(value))
+    if isinstance(value, Enum): return value.value
+    if isinstance(value, datetime): return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    if isinstance(value, tuple): return [_canonical(v) for v in value]
+    if isinstance(value, dict): return {str(k): _canonical(v) for k, v in sorted(value.items())}
+    if isinstance(value, (str, int, bool)) or value is None: return value
+    raise TypeError(f"unsupported canonical type: {type(value).__name__}")
+def canonical_digest(value: object) -> str:
+    return hashlib.sha256(json.dumps(_canonical(value), ensure_ascii=False, sort_keys=True, separators=(",", ":"), allow_nan=False).encode("utf-8")).hexdigest()

--- a/tests/security/test_output_firewall.py
+++ b/tests/security/test_output_firewall.py
@@ -1,0 +1,12 @@
+from vulcan.runtime.output import DraftSegment, ResponseIRProjection, ProjectedClaim, SemanticFirewall, UntrustedRenderDraft
+
+def _projection():
+    return ResponseIRProjection("r", "und", 100, ("claim-a",), (ProjectedClaim("claim-a", "4", "computed", None, ("evidence-a",)),))
+
+def test_firewall_accepts_only_ordered_known_references():
+    result = SemanticFirewall().validate(_projection(), UntrustedRenderDraft("untrusted-render/1", (DraftSegment("claim", "claim-a"), DraftSegment("citation", "evidence-a"))))
+    assert result.accepted
+
+def test_firewall_rejects_added_or_mutated_claims():
+    result = SemanticFirewall().validate(_projection(), UntrustedRenderDraft("untrusted-render/1", (DraftSegment("claim", "claim-b"), DraftSegment("text", "The result is 5"))))
+    assert not result.accepted

--- a/tests/security/test_runtime_convergence.py
+++ b/tests/security/test_runtime_convergence.py
@@ -8,6 +8,7 @@ import pytest
 from vulcan.runtime.case import CognitiveCase, CognitiveCaseStatus
 from vulcan.runtime.container import RuntimeContainer
 from vulcan.runtime.kernel import KernelRequest
+from vulcan.runtime.semantic import Utterance
 
 
 class _Safety:
@@ -28,34 +29,25 @@ def _deployment(world=_DEFAULT_WORLD):
 
 @pytest.mark.asyncio
 async def test_one_container_injects_one_world_state_and_kernel_closes_case():
-    calls = 0
-
-    async def executor(_request, _case):
-        nonlocal calls
-        calls += 1
-        return {"response": "bounded", "metadata": {}}
-
     deployment = _deployment()
-    runtime = RuntimeContainer.new(deployment=deployment, executor=executor)
-    case = CognitiveCase.create(request_id="request", conversation_id="conversation", message="secret prompt")
-    result = await runtime.kernel.handle(KernelRequest("secret prompt", "conversation", object()), case)
+    runtime = RuntimeContainer.new(deployment=deployment)
+    utterance = Utterance.from_text("2 + 2")
+    case = CognitiveCase.create(request_id="request", conversation_id="conversation", input_digest=utterance.digest)
+    result = await runtime.kernel.handle(KernelRequest(utterance, "conversation"), case)
 
     assert runtime.world_state is deployment.collective.deps.world_model
     assert runtime.kernel._state_authority is runtime.world_state
-    assert calls == runtime.kernel.calls == 1
+    assert runtime.kernel.calls == 1
     assert case.terminal_status is result.status is CognitiveCaseStatus.SUCCESS
     assert "secret prompt" not in repr(case)
 
 
 @pytest.mark.asyncio
 async def test_cases_are_isolated_under_concurrency():
-    async def executor(_request, _case):
-        await asyncio.sleep(0)
-        return {"response": "ok", "metadata": {}}
-
-    runtime = RuntimeContainer.new(deployment=_deployment(), executor=executor)
-    cases = [CognitiveCase.create(request_id=str(index), conversation_id=None, message=f"prompt-{index}") for index in range(20)]
-    await asyncio.gather(*(runtime.kernel.handle(KernelRequest("x", None, object()), case) for case in cases))
+    runtime = RuntimeContainer.new(deployment=_deployment())
+    utterance = Utterance.from_text("1+1")
+    cases = [CognitiveCase.create(request_id=str(index), conversation_id=None, input_digest=utterance.digest) for index in range(20)]
+    await asyncio.gather(*(runtime.kernel.handle(KernelRequest(utterance, None), case) for case in cases))
     assert len({case.case_id for case in cases}) == 20
     assert all(case.terminal_status is CognitiveCaseStatus.SUCCESS for case in cases)
     assert runtime.kernel.calls == 20
@@ -63,7 +55,7 @@ async def test_cases_are_isolated_under_concurrency():
 
 def test_container_fails_closed_without_canonical_world_state():
     with pytest.raises(RuntimeError, match="World State"):
-        RuntimeContainer.new(deployment=_deployment(world=None), executor=lambda *_: None)
+        RuntimeContainer.new(deployment=_deployment(world=None))
 
 
 def test_production_docker_uses_canonical_package_identity():

--- a/tests/security/test_semantic_runtime.py
+++ b/tests/security/test_semantic_runtime.py
@@ -4,12 +4,17 @@ from vulcan.runtime.case import CognitiveCase, CognitiveCaseStatus
 from vulcan.runtime.kernel import CognitiveKernel, KernelRequest
 from vulcan.runtime.semantic import (DeterministicLanguageInput, InterpretationProposal,
     ProposedCandidate, SourceSpan, Utterance, validate_proposal)
+from vulcan.runtime.finalization import FinalizationDecision, FinalizationResult
+
+class _Finalizer:
+    async def finalize(self, artifact):
+        return FinalizationResult(FinalizationDecision.ALLOW, artifact, artifact.text)
 
 @pytest.mark.asyncio
 async def test_kernel_computes_only_through_typed_ingress_and_records_claims():
     utterance = Utterance.from_text("2 + 3 * 4")
     case = CognitiveCase.create(request_id="r", conversation_id=None, input_digest=utterance.digest)
-    result = await CognitiveKernel(state_authority=SimpleNamespace(version="1")).handle(KernelRequest(utterance, None), case)
+    result = await CognitiveKernel(state_authority=SimpleNamespace(version="1"), finalizer=_Finalizer()).handle(KernelRequest(utterance, None), case)
     assert result.response == "The computed result is 14."
     assert case.claims[0].derivation_id == case.derivations[0].derivation_id
     assert case.terminal_status is CognitiveCaseStatus.SUCCESS
@@ -17,13 +22,13 @@ async def test_kernel_computes_only_through_typed_ingress_and_records_claims():
 
 def test_provider_fields_and_bad_unicode_spans_fail_closed():
     utterance = Utterance.from_text("é + 1")
-    proposal = InterpretationProposal("semantic-ingress/1", (ProposedCandidate("arithmetic", "é + 1", SourceSpan(0, 99)),), "provider")
+    proposal = InterpretationProposal("semantic-ingress/2", (ProposedCandidate("arithmetic", "é + 1", SourceSpan(0, 99)),), "provider")
     with pytest.raises(ValueError): validate_proposal(utterance, proposal)
 
 @pytest.mark.asyncio
 async def test_unsupported_input_is_an_unknown_not_a_provider_answer():
     utterance = Utterance.from_text("tell me a secret")
     case = CognitiveCase.create(request_id="r", conversation_id=None, input_digest=utterance.digest)
-    result = await CognitiveKernel(state_authority=object(), language_input=DeterministicLanguageInput()).handle(KernelRequest(utterance, None), case)
+    result = await CognitiveKernel(state_authority=object(), finalizer=_Finalizer(), language_input=DeterministicLanguageInput()).handle(KernelRequest(utterance, None), case)
     assert result.status is CognitiveCaseStatus.ABSTAINED
     assert "not supported" in result.response


### PR DESCRIPTION
### Motivation

- Replace the legacy multi-feature research transport with a minimal, production-ready canonical runtime that only accepts bounded arithmetic inputs.
- Ensure deterministic safety finalization is mandatory so returned text is policy-validated before being emitted.
- Harden in-process ledger handling and semantic contracts to prevent provider-substituted text and dangling references.
- Apply a tight transport policy (auth, body size, headers) for production deployments.

### Description

- Restrict `UnifiedChatRequest` semantics and defaults to a bounded-arithmetic runtime and mark unsupported toggles as unavailable while keeping compatibility fields parseable, and update the legacy handler to build an `Utterance` before invoking the kernel.
- Add `ServingBoundaryMiddleware` to `create_app()` with HS256 bearer verification, a 16KB body limit, conservative response headers, route manifest generation, and capability reporting on `/health/ready`.
- Introduce `finalization.py` and wire `SafetyResponseFinalizer` into `RuntimeContainer.new()` and `CognitiveKernel`, making finalization an async step that produces a public text and a finalization decision captured in `KernelResult` transport metadata.
- Rewrite the semantic layer in `semantic.py` to a closed, audited bounded-arithmetic interpreter with strict proposal validation, AST node/depth/integer/exponent budgets, rational arithmetic via `Fraction`, structured IR (`ResponseIR`) rules, canonical digesting, and safer `render_strict` behavior.
- Move the kernel to typed ingress using `Utterance`, enforce request/case correlation, perform proposal validation/acceptance, append ledger records atomically using `validate_ledger`, render strict artifacts, finalize via the finalizer, and surface finalization metadata in `KernelResult`.
- Harden `CognitiveCase` internals by making ledger collections private, expose read-only properties, implement atomic `append_ledger` with `validate_ledger` check, add `render_artifact`, and record finalization events safely.
- Add a capability-minimized rendering adapter and conservative `SemanticFirewall` in `runtime/output.py` to accept only structured projections and ordered claim/citation references.
- Update container construction to require the canonical world state and safety validator and to create the kernel with the finalizer; bump app version and register the new routes/aliases to a single handler.
- Add and update unit tests to validate the runtime convergence, semantic runtime behaviors, and firewall rules.

### Testing

- Ran the security unit tests under `tests/security`, specifically `test_output_firewall.py`, `test_runtime_convergence.py`, and `test_semantic_runtime.py`, and they all passed when executed with `pytest tests/security -q`.
- Exercised kernel-path unit tests that validate request/case correlation, ledger isolation under concurrency, and finalization recording, and they succeeded.
- Verified firewall acceptance and rejection rules via `tests/security/test_output_firewall.py` and observed expected accept/reject results.
- Confirmed that health routes reflect runtime capabilities and that chat aliases map to a single handler in `create_app()` via the runtime tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a597d571110832f985c0e5f9af2005b)