### PR TITLE
Introduce governed durable memory backed by single-writer SQLite and integrate into runtime

### DIFF
--- a/docs/adr/0005-governed-durable-memory.md
+++ b/docs/adr/0005-governed-durable-memory.md
@@ -1,0 +1,30 @@
+# ADR 0005: Governed durable memory
+
+## Decision
+
+The canonical runtime owns exactly one `GovernedMemoryService`.  When disabled
+(the default), it rejects mutation rather than falling back to process memory.
+When enabled, the only supported backend is a one-replica SQLite database at an
+explicit configured path.  Historical graph, vector, pickle, hierarchical, and
+unlearning packages are research or migration-only code and are not composed by
+`vulcan.runtime`.
+
+The supported record is a minimized explicit user preference.  It is tenant,
+subject, actor, purpose, policy-version, retention, revision, lifecycle, and
+digest bound.  Raw transcripts, answers, hidden reasoning, arbitrary metadata,
+callables, embeddings, and procedures are not accepted.
+
+## Lifecycle and recovery
+
+Writes are idempotent SQLite transactions with journal and outbox rows.
+Corrections append immutable revisions; reads choose the latest active revision.
+Forget appends a tombstone revision before returning, so restarts cannot serve
+the preceding revision.  The tombstone and journal are logical denial controls,
+not a claim of physical media sanitization or model-weight unlearning.
+
+## Residual limitations
+
+This decision establishes neither HA/multi-writer support, backup media purge,
+key management, semantic/vector retrieval, legacy-data migration, nor legal or
+privacy compliance.  Enabling durable memory requires a maintenance-owned path
+and a single runtime replica; other topology values fail composition.

--- a/src/vulcan/memory/__init__.py
+++ b/src/vulcan/memory/__init__.py
@@ -1,112 +1,50 @@
-"""
-VULCAN-AGI Memory Module
-Hierarchical, distributed memory with multiple specialized types
+"""Canonical governed memory exports.
+
+Historical memory implementations remain importable by their explicit module
+paths for research and migration tooling, but are intentionally not initialized
+when the package is imported by the serving runtime.
 """
 
-from .base import (
-    Memory,
-    MemoryConfig,
-    MemoryException,
-    MemoryQuery,
-    MemoryStats,
-    MemoryType,
-    MemoryUsageMonitor,
+from .governed import (
+    DisabledMemoryService,
+    DefaultMemoryPolicy,
+    DeletionReceipt,
+    DeletionState,
+    GovernedMemoryService,
+    MemoryActor,
+    MemoryCommitResult,
+    MemoryKind,
+    MemoryReadRequest,
+    MemoryPolicyPort,
+    MemoryReason,
+    MemoryWriteProposal,
+    SQLiteMemoryRepository,
+    compose_governed_memory,
 )
-from .consolidation import (
-    ConsolidationStrategy,
-    GPUAcceleratedClustering,
-    MemoryConsolidator,
-    MemoryOptimizer,
-)
-from .distributed import (
-    ConnectionPool,
-    ConsistencyLevel,
-    DistributedCheckpoint,
-    DistributedMemory,
-    MemoryFederation,
-    MemoryNode,
-)
-from .hierarchical import EmbeddingMigration, HierarchicalMemory, MemoryLevel
-from .learning_persistence import LearningStatePersistence
-from .persistence import (
-    CompressionStats,
-    CompressionType,
-    MemoryPersistence,
-    MemoryVersionControl,
-)
-from .retrieval import (
-    AttentionMechanism,
-    MemoryIndex,
-    MemoryPrefetcher,
-    MemorySearch,
-    QueryPlanner,
-    RetrievalResult,
-    ShardedMemoryIndex,
-)
-from .specialized import (
-    Concept,
-    Episode,
-    EpisodicMemory,
-    ProceduralMemory,
-    SemanticMemory,
-    Skill,
-    WorkingMemory,
-    WorkingMemoryBuffer,
-)
-
-# Alias for API Gateway compatibility
-VectorMemoryStore = MemoryIndex
 
 __all__ = [
-    # Base
-    "MemoryType",
-    "Memory",
-    "MemoryQuery",
-    "MemoryConfig",
-    "MemoryStats",
-    "MemoryException",
-    "MemoryUsageMonitor",
-    # Hierarchical
-    "HierarchicalMemory",
-    "MemoryLevel",
-    "EmbeddingMigration",
-    # Distributed
-    "DistributedMemory",
-    "MemoryFederation",
-    "MemoryNode",
-    "ConsistencyLevel",
-    "ConnectionPool",
-    "DistributedCheckpoint",
-    # Persistence
-    "MemoryPersistence",
-    "MemoryVersionControl",
-    "CompressionType",
-    "CompressionStats",
-    "LearningStatePersistence",
-    # Retrieval
-    "MemoryIndex",
-    "MemorySearch",
-    "AttentionMechanism",
-    "RetrievalResult",
-    "VectorMemoryStore",  # Added - Alias for MemoryIndex
-    "ShardedMemoryIndex",
-    "MemoryPrefetcher",
-    "QueryPlanner",
-    # Consolidation
-    "MemoryConsolidator",
-    "ConsolidationStrategy",
-    "MemoryOptimizer",
-    "GPUAcceleratedClustering",
-    # Specialized
-    "EpisodicMemory",
-    "SemanticMemory",
-    "ProceduralMemory",
-    "WorkingMemory",
-    "Episode",
-    "Concept",
-    "Skill",
-    "WorkingMemoryBuffer",
+    "DisabledMemoryService", "DefaultMemoryPolicy", "DeletionReceipt", "DeletionState", "GovernedMemoryService", "MemoryActor",
+    "MemoryCommitResult", "MemoryKind", "MemoryPolicyPort", "MemoryReadRequest", "MemoryReason",
+    "MemoryWriteProposal", "SQLiteMemoryRepository", "compose_governed_memory",
 ]
 
-# Version info
-__version__ = "1.0.0"
+# Compatibility is deliberately lazy: importing the canonical authority must
+# not construct or import any legacy store, while explicit research callers
+# keep their historical symbols when optional dependencies are installed.
+_LEGACY_MODULES = {
+    "Memory": ".base", "MemoryConfig": ".base", "MemoryException": ".base",
+    "MemoryQuery": ".base", "MemoryStats": ".base", "MemoryType": ".base",
+    "MemoryUsageMonitor": ".base", "HierarchicalMemory": ".hierarchical",
+    "MemoryLevel": ".hierarchical", "MemoryPersistence": ".persistence",
+    "MemoryIndex": ".retrieval", "EpisodicMemory": ".specialized",
+    "SemanticMemory": ".specialized", "ProceduralMemory": ".specialized",
+    "WorkingMemory": ".specialized", "LearningStatePersistence": ".learning_persistence",
+}
+
+
+def __getattr__(name: str):
+    module_name = _LEGACY_MODULES.get(name)
+    if module_name is None:
+        raise AttributeError(name)
+    from importlib import import_module
+    return getattr(import_module(module_name, __name__), name)

--- a/src/vulcan/memory/governed.py
+++ b/src/vulcan/memory/governed.py
@@ -1,0 +1,350 @@
+"""The canonical, deliberately small durable-memory authority.
+
+This module is intentionally independent of the historical memory packages.  It
+stores only bounded, typed user preferences in the supported runtime surface;
+the old graph/vector stores are not a fallback or a peer authority.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import threading
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Callable, Protocol
+from uuid import uuid4
+
+
+SCHEMA_VERSION = "governed-memory/1"
+POLICY_VERSION = "memory-policy/1"
+MAX_VALUE_CHARS = 512
+MAX_KEY_CHARS = 64
+MAX_RESULTS = 20
+
+
+class MemoryKind(str, Enum):
+    EXPLICIT_PREFERENCE = "explicit_preference"
+
+
+class MemoryLifecycle(str, Enum):
+    ACTIVE = "active"
+    SUPERSEDED = "superseded"
+    TOMBSTONED = "tombstoned"
+    PURGED = "purged"
+    QUARANTINED = "quarantined"
+
+
+class MemoryReason(str, Enum):
+    COMMITTED = "committed"
+    CONFLICT = "conflict"
+    NOT_FOUND = "not_found"
+    UNAUTHORIZED = "unauthorized"
+    MEMORY_DISABLED = "memory_disabled"
+    POLICY_REJECTED = "policy_rejected"
+    EMPTY = "empty"
+
+
+class PolicyDecision(str, Enum):
+    ALLOW = "allow"
+    REJECT = "reject"
+
+
+class DeletionState(str, Enum):
+    COMPLETED = "completed"
+    PENDING = "pending"
+    REJECTED = "rejected"
+
+
+@dataclass(frozen=True)
+class MemoryActor:
+    tenant_id: str
+    subject_id: str
+    actor_id: str
+    purpose: str = "personalization"
+
+    def __post_init__(self) -> None:
+        for value in (self.tenant_id, self.subject_id, self.actor_id, self.purpose):
+            if not _identifier(value):
+                raise ValueError("memory actor contains an invalid identifier")
+
+
+@dataclass(frozen=True)
+class MemoryWriteProposal:
+    """Untrusted intent.  It cannot choose IDs, retention, or lifecycle."""
+    kind: MemoryKind
+    namespace: str
+    key: str
+    value: str
+    idempotency_key: str
+    case_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind is not MemoryKind.EXPLICIT_PREFERENCE:
+            raise ValueError("unsupported memory kind")
+        if not _identifier(self.namespace) or not _plain(self.key, MAX_KEY_CHARS) or not _plain(self.value, MAX_VALUE_CHARS):
+            raise ValueError("invalid bounded memory proposal")
+        if not _identifier(self.idempotency_key):
+            raise ValueError("invalid idempotency key")
+        if self.case_id is not None and not _identifier(self.case_id):
+            raise ValueError("invalid case reference")
+
+
+@dataclass(frozen=True)
+class MemoryRecord:
+    record_id: str
+    revision: int
+    tenant_id: str
+    subject_id: str
+    actor_id: str
+    purpose: str
+    namespace: str
+    key: str
+    value: str
+    kind: MemoryKind
+    lifecycle: MemoryLifecycle
+    policy_version: str
+    created_at: str
+    expires_at: str
+    deletion_epoch: int
+    digest: str
+    supersedes: str | None = None
+
+
+@dataclass(frozen=True)
+class MemoryCommitResult:
+    reason: MemoryReason
+    record: MemoryRecord | None = None
+    reconciliation_pending: bool = False
+
+
+@dataclass(frozen=True)
+class DeletionReceipt:
+    operation_id: str
+    state: DeletionState
+    record_id: str
+    revision: int
+    deletion_epoch: int
+    policy_version: str
+    required_locations: tuple[str, ...]
+    completed_locations: tuple[str, ...]
+    remaining_obligations: tuple[str, ...] = ()
+
+
+class MemoryPolicyPort(Protocol):
+    """Server-owned policy; callers cannot set a retention or lifecycle value."""
+    version: str
+    def allow_write(self, actor: "MemoryActor", proposal: "MemoryWriteProposal") -> PolicyDecision: ...
+    def retention(self, actor: "MemoryActor", proposal: "MemoryWriteProposal") -> timedelta: ...
+
+
+class DefaultMemoryPolicy:
+    """Conservative product policy: only minimized explicit preferences."""
+    version = POLICY_VERSION
+    def allow_write(self, actor: "MemoryActor", proposal: "MemoryWriteProposal") -> PolicyDecision:
+        if actor.purpose != "personalization" or proposal.kind is not MemoryKind.EXPLICIT_PREFERENCE:
+            return PolicyDecision.REJECT
+        forbidden = ("password", "secret", "token", "authorization", "credential")
+        return PolicyDecision.REJECT if any(word in proposal.key.lower() for word in forbidden) else PolicyDecision.ALLOW
+    def retention(self, actor: "MemoryActor", proposal: "MemoryWriteProposal") -> timedelta:
+        return timedelta(days=365)
+
+
+@dataclass(frozen=True)
+class MemoryReadRequest:
+    actor: MemoryActor
+    namespace: str
+    query: str
+    maximum_results: int = 5
+
+    def __post_init__(self) -> None:
+        if not _identifier(self.namespace) or not _plain(self.query, MAX_VALUE_CHARS):
+            raise ValueError("invalid memory read request")
+        if not 1 <= self.maximum_results <= MAX_RESULTS:
+            raise ValueError("memory result limit out of bounds")
+
+
+class MemoryRepositoryPort(Protocol):
+    def commit(self, actor: MemoryActor, proposal: MemoryWriteProposal) -> MemoryCommitResult: ...
+    def read(self, request: MemoryReadRequest) -> tuple[MemoryRecord, ...]: ...
+    def tombstone(self, actor: MemoryActor, record_id: str, revision: int) -> MemoryCommitResult: ...
+    def correct(self, actor: MemoryActor, record_id: str, base_revision: int, proposal: MemoryWriteProposal) -> MemoryCommitResult: ...
+    def readiness(self) -> None: ...
+    def close(self) -> None: ...
+
+
+def _identifier(value: object) -> bool:
+    return isinstance(value, str) and 1 <= len(value) <= 128 and value.replace("-", "").replace("_", "").isalnum()
+
+
+def _plain(value: object, limit: int) -> bool:
+    return isinstance(value, str) and bool(value) and len(value) <= limit and "\x00" not in value
+
+
+def _canonical_digest(values: dict[str, object]) -> str:
+    return hashlib.sha256(json.dumps(values, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")).hexdigest()
+
+
+class SQLiteMemoryRepository:
+    """Single-writer SQLite source of truth with journal and transactional outbox."""
+    def __init__(self, path: str, *, policy: MemoryPolicyPort | None = None,
+                 clock: Callable[[], datetime] | None = None) -> None:
+        if not path or path == ":memory:":
+            raise ValueError("durable memory requires an explicit filesystem path")
+        self._path = Path(path).resolve()
+        self._path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+        self._lock = threading.RLock()
+        self._closed = False
+        self._policy = policy or DefaultMemoryPolicy()
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._db = sqlite3.connect(str(self._path), check_same_thread=False, isolation_level=None)
+        self._db.execute("PRAGMA foreign_keys = ON")
+        self._db.execute("PRAGMA journal_mode = WAL")
+        self._migrate()
+        self.readiness()
+
+    def _migrate(self) -> None:
+        self._db.executescript("""
+        CREATE TABLE IF NOT EXISTS memory_records (
+          record_id TEXT NOT NULL, revision INTEGER NOT NULL, tenant_id TEXT NOT NULL,
+          subject_id TEXT NOT NULL, actor_id TEXT NOT NULL, purpose TEXT NOT NULL,
+          namespace TEXT NOT NULL, key_name TEXT NOT NULL, value TEXT NOT NULL,
+          kind TEXT NOT NULL, lifecycle TEXT NOT NULL, policy_version TEXT NOT NULL,
+          created_at TEXT NOT NULL, expires_at TEXT NOT NULL, deletion_epoch INTEGER NOT NULL,
+          digest TEXT NOT NULL, supersedes TEXT, PRIMARY KEY(record_id, revision),
+          CHECK(revision > 0), CHECK(deletion_epoch >= 0)
+        );
+        CREATE INDEX IF NOT EXISTS active_scope ON memory_records(tenant_id, subject_id, namespace, lifecycle, expires_at);
+        CREATE TABLE IF NOT EXISTS memory_idempotency (tenant_id TEXT NOT NULL, subject_id TEXT NOT NULL, idempotency_key TEXT NOT NULL, record_id TEXT NOT NULL, revision INTEGER NOT NULL, PRIMARY KEY(tenant_id, subject_id, idempotency_key));
+        CREATE TABLE IF NOT EXISTS memory_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, operation TEXT NOT NULL, record_id TEXT NOT NULL, revision INTEGER NOT NULL, digest TEXT NOT NULL, committed_at TEXT NOT NULL);
+        CREATE TABLE IF NOT EXISTS memory_outbox (sequence INTEGER PRIMARY KEY AUTOINCREMENT, record_id TEXT NOT NULL, revision INTEGER NOT NULL, deletion_epoch INTEGER NOT NULL, operation TEXT NOT NULL, delivered INTEGER NOT NULL DEFAULT 0);
+        """)
+
+    def readiness(self) -> None:
+        if self._closed:
+            raise RuntimeError("memory repository is closed")
+        integrity = self._db.execute("PRAGMA integrity_check").fetchone()
+        if integrity != ("ok",):
+            raise RuntimeError("memory repository integrity check failed")
+
+    def _row(self, row: tuple[object, ...]) -> MemoryRecord:
+        normalized = list(row)
+        normalized[9] = MemoryKind(normalized[9])
+        normalized[10] = MemoryLifecycle(normalized[10])
+        record = MemoryRecord(*normalized)
+        expected = _canonical_digest({k: v.value if isinstance(v, Enum) else v for k, v in asdict(record).items() if k != "digest"})
+        if record.digest != expected:
+            raise RuntimeError("memory record digest mismatch")
+        return record
+
+    def commit(self, actor: MemoryActor, proposal: MemoryWriteProposal) -> MemoryCommitResult:
+        with self._lock:
+            if self._closed: raise RuntimeError("memory repository is closed")
+            if self._policy.allow_write(actor, proposal) is not PolicyDecision.ALLOW:
+                return MemoryCommitResult(MemoryReason.POLICY_REJECTED)
+            self._db.execute("BEGIN IMMEDIATE")
+            try:
+                prior = self._db.execute("SELECT record_id, revision FROM memory_idempotency WHERE tenant_id=? AND subject_id=? AND idempotency_key=?", (actor.tenant_id, actor.subject_id, proposal.idempotency_key)).fetchone()
+                if prior:
+                    row = self._db.execute("SELECT record_id,revision,tenant_id,subject_id,actor_id,purpose,namespace,key_name,value,kind,lifecycle,policy_version,created_at,expires_at,deletion_epoch,digest,supersedes FROM memory_records WHERE record_id=? AND revision=?", prior).fetchone()
+                    self._db.execute("COMMIT"); return MemoryCommitResult(MemoryReason.COMMITTED, self._row(row), True)
+                now = self._clock(); record_id = f"mem-{uuid4().hex}"; created = now.isoformat().replace("+00:00", "Z"); expires = (now + self._policy.retention(actor, proposal)).isoformat().replace("+00:00", "Z")
+                values: dict[str, object] = {"record_id":record_id,"revision":1,"tenant_id":actor.tenant_id,"subject_id":actor.subject_id,"actor_id":actor.actor_id,"purpose":actor.purpose,"namespace":proposal.namespace,"key":proposal.key,"value":proposal.value,"kind":proposal.kind.value,"lifecycle":MemoryLifecycle.ACTIVE.value,"policy_version":self._policy.version,"created_at":created,"expires_at":expires,"deletion_epoch":0,"supersedes":None}
+                digest = _canonical_digest(values); values["digest"] = digest
+                self._db.execute("INSERT INTO memory_records VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", (values["record_id"],values["revision"],values["tenant_id"],values["subject_id"],values["actor_id"],values["purpose"],values["namespace"],values["key"],values["value"],values["kind"],values["lifecycle"],values["policy_version"],values["created_at"],values["expires_at"],values["deletion_epoch"],values["digest"],None))
+                self._db.execute("INSERT INTO memory_idempotency VALUES (?,?,?,?,?)", (actor.tenant_id,actor.subject_id,proposal.idempotency_key,record_id,1))
+                self._event("create", record_id, 1, digest, 0); self._db.execute("COMMIT")
+                return MemoryCommitResult(MemoryReason.COMMITTED, self._row(tuple(values[k] for k in ("record_id","revision","tenant_id","subject_id","actor_id","purpose","namespace","key","value","kind","lifecycle","policy_version","created_at","expires_at","deletion_epoch","digest","supersedes"))), True)
+            except Exception:
+                self._db.execute("ROLLBACK"); raise
+
+    def _event(self, operation: str, record_id: str, revision: int, digest: str, epoch: int) -> None:
+        now = self._clock().isoformat().replace("+00:00", "Z")
+        self._db.execute("INSERT INTO memory_journal(operation,record_id,revision,digest,committed_at) VALUES (?,?,?,?,?)", (operation,record_id,revision,digest,now))
+        self._db.execute("INSERT INTO memory_outbox(record_id,revision,deletion_epoch,operation) VALUES (?,?,?,?)", (record_id,revision,epoch,operation))
+
+    def read(self, request: MemoryReadRequest) -> tuple[MemoryRecord, ...]:
+        if self._closed: raise RuntimeError("memory repository is closed")
+        now = self._clock().isoformat().replace("+00:00", "Z")
+        # Exact, scoped lexical candidate generation; canonical rows are rehydrated.
+        rows = self._db.execute("SELECT r.record_id,r.revision,r.tenant_id,r.subject_id,r.actor_id,r.purpose,r.namespace,r.key_name,r.value,r.kind,r.lifecycle,r.policy_version,r.created_at,r.expires_at,r.deletion_epoch,r.digest,r.supersedes FROM memory_records r WHERE r.tenant_id=? AND r.subject_id=? AND r.purpose=? AND r.namespace=? AND r.lifecycle=? AND r.expires_at>? AND r.revision=(SELECT MAX(newer.revision) FROM memory_records newer WHERE newer.record_id=r.record_id) AND (r.key_name LIKE ? OR r.value LIKE ?) ORDER BY r.created_at DESC LIMIT ?", (request.actor.tenant_id,request.actor.subject_id,request.actor.purpose,request.namespace,MemoryLifecycle.ACTIVE.value,now,f"%{request.query}%",f"%{request.query}%",request.maximum_results)).fetchall()
+        return tuple(self._row(row) for row in rows)
+
+    def correct(self, actor: MemoryActor, record_id: str, base_revision: int,
+                proposal: MemoryWriteProposal) -> MemoryCommitResult:
+        """Append an immutable successor; stale revisions never overwrite data."""
+        if not _identifier(record_id) or base_revision < 1:
+            raise ValueError("invalid correction reference")
+        if self._policy.allow_write(actor, proposal) is not PolicyDecision.ALLOW:
+            return MemoryCommitResult(MemoryReason.POLICY_REJECTED)
+        with self._lock:
+            self._db.execute("BEGIN IMMEDIATE")
+            try:
+                row = self._db.execute("SELECT record_id,revision,tenant_id,subject_id,actor_id,purpose,namespace,key_name,value,kind,lifecycle,policy_version,created_at,expires_at,deletion_epoch,digest,supersedes FROM memory_records WHERE record_id=? AND revision=? AND tenant_id=? AND subject_id=?", (record_id,base_revision,actor.tenant_id,actor.subject_id)).fetchone()
+                if row is None:
+                    self._db.execute("COMMIT"); return MemoryCommitResult(MemoryReason.NOT_FOUND)
+                old = self._row(row)
+                latest = self._db.execute("SELECT MAX(revision) FROM memory_records WHERE record_id=?", (record_id,)).fetchone()[0]
+                if latest != base_revision or old.lifecycle is not MemoryLifecycle.ACTIVE:
+                    self._db.execute("COMMIT"); return MemoryCommitResult(MemoryReason.CONFLICT)
+                now = self._clock(); created = now.isoformat().replace("+00:00", "Z")
+                data: dict[str, object] = {"record_id":record_id,"revision":base_revision + 1,"tenant_id":actor.tenant_id,"subject_id":actor.subject_id,"actor_id":actor.actor_id,"purpose":actor.purpose,"namespace":proposal.namespace,"key":proposal.key,"value":proposal.value,"kind":proposal.kind.value,"lifecycle":MemoryLifecycle.ACTIVE.value,"policy_version":self._policy.version,"created_at":created,"expires_at":(now + self._policy.retention(actor, proposal)).isoformat().replace("+00:00", "Z"),"deletion_epoch":old.deletion_epoch,"supersedes":f"{record_id}:{base_revision}"}
+                data["digest"] = _canonical_digest(data)
+                self._db.execute("INSERT INTO memory_records VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", tuple(data[k] for k in ("record_id","revision","tenant_id","subject_id","actor_id","purpose","namespace","key","value","kind","lifecycle","policy_version","created_at","expires_at","deletion_epoch","digest","supersedes")))
+                self._event("correct", record_id, base_revision + 1, data["digest"], old.deletion_epoch)
+                self._db.execute("COMMIT")
+                return MemoryCommitResult(MemoryReason.COMMITTED, self._row(tuple(data[k] for k in ("record_id","revision","tenant_id","subject_id","actor_id","purpose","namespace","key","value","kind","lifecycle","policy_version","created_at","expires_at","deletion_epoch","digest","supersedes"))), True)
+            except Exception:
+                self._db.execute("ROLLBACK"); raise
+
+    def tombstone(self, actor: MemoryActor, record_id: str, revision: int) -> MemoryCommitResult:
+        if not _identifier(record_id) or revision < 1: raise ValueError("invalid memory revision")
+        with self._lock:
+            self._db.execute("BEGIN IMMEDIATE")
+            try:
+                row = self._db.execute("SELECT record_id,revision,tenant_id,subject_id,actor_id,purpose,namespace,key_name,value,kind,lifecycle,policy_version,created_at,expires_at,deletion_epoch,digest,supersedes FROM memory_records WHERE record_id=? AND revision=? AND tenant_id=? AND subject_id=?", (record_id,revision,actor.tenant_id,actor.subject_id)).fetchone()
+                if row is None: self._db.execute("COMMIT"); return MemoryCommitResult(MemoryReason.NOT_FOUND)
+                old = self._row(row)
+                latest = self._db.execute("SELECT MAX(revision) FROM memory_records WHERE record_id=?", (record_id,)).fetchone()[0]
+                if latest != revision or old.lifecycle is not MemoryLifecycle.ACTIVE: self._db.execute("COMMIT"); return MemoryCommitResult(MemoryReason.CONFLICT)
+                data = asdict(old); data.update(revision=revision + 1, lifecycle=MemoryLifecycle.TOMBSTONED, deletion_epoch=old.deletion_epoch+1, supersedes=f"{record_id}:{revision}", created_at=self._clock().isoformat().replace("+00:00", "Z")); data["digest"] = _canonical_digest({k:v.value if isinstance(v,Enum) else v for k,v in data.items() if k != "digest"})
+                self._db.execute("INSERT INTO memory_records VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", tuple(data[k].value if isinstance(data[k], Enum) else data[k] for k in ("record_id","revision","tenant_id","subject_id","actor_id","purpose","namespace","key","value","kind","lifecycle","policy_version","created_at","expires_at","deletion_epoch","digest","supersedes"))); self._event("tombstone",record_id,revision + 1,data["digest"],data["deletion_epoch"]); self._db.execute("COMMIT")
+                return MemoryCommitResult(MemoryReason.COMMITTED, self._row(tuple(data[k] for k in ("record_id","revision","tenant_id","subject_id","actor_id","purpose","namespace","key","value","kind","lifecycle","policy_version","created_at","expires_at","deletion_epoch","digest","supersedes"))), True)
+            except Exception: self._db.execute("ROLLBACK"); raise
+
+    def close(self) -> None:
+        with self._lock:
+            if not self._closed: self._db.close(); self._closed = True
+
+
+class DisabledMemoryService:
+    def commit(self, actor: MemoryActor, proposal: MemoryWriteProposal) -> MemoryCommitResult: return MemoryCommitResult(MemoryReason.MEMORY_DISABLED)
+    def read(self, request: MemoryReadRequest) -> tuple[MemoryRecord, ...]: return ()
+    def tombstone(self, actor: MemoryActor, record_id: str, revision: int) -> MemoryCommitResult: return MemoryCommitResult(MemoryReason.MEMORY_DISABLED)
+    def correct(self, actor: MemoryActor, record_id: str, base_revision: int, proposal: MemoryWriteProposal) -> MemoryCommitResult: return MemoryCommitResult(MemoryReason.MEMORY_DISABLED)
+    def readiness(self) -> None: return None
+    def close(self) -> None: return None
+
+
+class GovernedMemoryService:
+    """Policy boundary: only explicit, authenticated preferences are supported."""
+    def __init__(self, repository: MemoryRepositoryPort) -> None: self._repository = repository
+    def remember(self, actor: MemoryActor, proposal: MemoryWriteProposal) -> MemoryCommitResult: return self._repository.commit(actor, proposal)
+    def retrieve(self, request: MemoryReadRequest) -> tuple[MemoryRecord, ...]: return self._repository.read(request)
+    def forget(self, actor: MemoryActor, record_id: str, revision: int) -> MemoryCommitResult: return self._repository.tombstone(actor, record_id, revision)
+    def correct(self, actor: MemoryActor, record_id: str, base_revision: int, proposal: MemoryWriteProposal) -> MemoryCommitResult: return self._repository.correct(actor, record_id, base_revision, proposal)
+    def readiness(self) -> None: self._repository.readiness()
+    def close(self) -> None: self._repository.close()
+
+
+def compose_governed_memory() -> GovernedMemoryService | DisabledMemoryService:
+    if os.getenv("VULCAN_MEMORY_ENABLED", "0") != "1": return DisabledMemoryService()
+    path = os.getenv("VULCAN_MEMORY_SQLITE_PATH")
+    if not path: raise RuntimeError("VULCAN_MEMORY_SQLITE_PATH is required when durable memory is enabled")
+    # SQLite local storage has one writer process. Replica counts must be made
+    # explicit rather than hoping WAL makes an unsupported topology safe.
+    if os.getenv("VULCAN_RUNTIME_REPLICAS", "1") != "1": raise RuntimeError("SQLite governed memory supports exactly one runtime replica")
+    return GovernedMemoryService(SQLiteMemoryRepository(path))

--- a/src/vulcan/runtime/container.py
+++ b/src/vulcan/runtime/container.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import inspect
 from dataclasses import dataclass
 from typing import Any
+from vulcan.memory.governed import DisabledMemoryService, GovernedMemoryService, compose_governed_memory
 from uuid import uuid4
 
 from .kernel import CognitiveKernel
@@ -18,7 +19,7 @@ class RuntimeContainer:
     world_state: Any
     kernel: CognitiveKernel
     safety: Any
-    memory: Any | None
+    memory: GovernedMemoryService | DisabledMemoryService
     closed: bool = False
 
     async def close(self) -> None:
@@ -26,6 +27,7 @@ class RuntimeContainer:
         if self.closed:
             return
         self.closed = True
+        self.memory.close()
         shutdown = getattr(self.deployment, "shutdown", None)
         if shutdown is not None:
             result = shutdown()
@@ -41,6 +43,8 @@ class RuntimeContainer:
         safety = getattr(deps, "safety_validator", None)
         if safety is None:
             raise RuntimeError("required safety finalization service is unavailable")
-        kernel = CognitiveKernel(state_authority=world_state, finalizer=SafetyResponseFinalizer(safety))
+        memory = compose_governed_memory()
+        memory.readiness()
+        kernel = CognitiveKernel(state_authority=world_state, finalizer=SafetyResponseFinalizer(safety), memory=memory)
         return cls(runtime_id=str(uuid4()), deployment=deployment, world_state=world_state,
-                   kernel=kernel, safety=safety, memory=getattr(deps, "memory", None))
+                   kernel=kernel, safety=safety, memory=memory)

--- a/src/vulcan/runtime/kernel.py
+++ b/src/vulcan/runtime/kernel.py
@@ -19,8 +19,10 @@ class KernelResult:
     def transport(self, *, case_id: str, runtime_id: str, snapshot_id: str | None) -> dict[str, object]:
         return {"response": self.response, "metadata": {"case_id":case_id,"runtime_id":runtime_id,"state_snapshot_id":snapshot_id,"semantic_schema_version":self.response_ir.schema_version,"finalized":True,"finalization_safety_decision":self.finalization}}
 class CognitiveKernel:
-    def __init__(self, *, state_authority: Any, finalizer: ResponseFinalizerPort, language_input: LanguageInputPort | None = None) -> None:
-        self._state_authority=state_authority; self._finalizer=finalizer; self._language_input=language_input or DeterministicLanguageInput(); self.calls=0
+    def __init__(self, *, state_authority: Any, finalizer: ResponseFinalizerPort, language_input: LanguageInputPort | None = None, memory: Any | None = None) -> None:
+        # The kernel owns the only memory port exposed to the production path.
+        # It deliberately does not turn retrieved text into executable semantics.
+        self._state_authority=state_authority; self._finalizer=finalizer; self._language_input=language_input or DeterministicLanguageInput(); self._memory=memory; self.calls=0
     async def handle(self, request: KernelRequest, case: CognitiveCase) -> KernelResult:
         if case.terminal_status is not CognitiveCaseStatus.OPEN: raise RuntimeError("kernel received a closed cognitive case")
         if request.utterance.digest != case.input_hash or request.conversation_id != case.conversation_id: raise ValueError("request/case correlation mismatch")

--- a/tests/security/test_governed_memory.py
+++ b/tests/security/test_governed_memory.py
@@ -1,0 +1,48 @@
+"""Hard invariants for the small supported governed-memory surface."""
+from datetime import datetime, timedelta, timezone
+
+from vulcan.memory.governed import (
+    MemoryActor, MemoryKind, MemoryReadRequest, MemoryReason,
+    MemoryWriteProposal, SQLiteMemoryRepository,
+)
+
+
+def _proposal(value: str, key: str = "idem") -> MemoryWriteProposal:
+    return MemoryWriteProposal(MemoryKind.EXPLICIT_PREFERENCE, "profile", "color", value, key)
+
+
+def test_correction_is_immutable_and_stale_revision_conflicts(tmp_path):
+    repo = SQLiteMemoryRepository(str(tmp_path / "memory.sqlite"))
+    actor = MemoryActor("tenant", "subject", "actor")
+    first = repo.commit(actor, _proposal("blue")).record
+    assert first is not None
+    corrected = repo.correct(actor, first.record_id, first.revision, _proposal("red", "correct"))
+    assert corrected.record is not None and corrected.record.revision == 2
+    assert repo.correct(actor, first.record_id, 1, _proposal("green", "stale")).reason is MemoryReason.CONFLICT
+    assert [record.value for record in repo.read(MemoryReadRequest(actor, "profile", "color"))] == ["red"]
+    repo.close()
+
+
+def test_tombstone_is_a_new_revision_and_denies_reads(tmp_path):
+    repo = SQLiteMemoryRepository(str(tmp_path / "memory.sqlite"))
+    actor = MemoryActor("tenant", "subject", "actor")
+    first = repo.commit(actor, _proposal("blue")).record
+    assert first is not None
+    deleted = repo.tombstone(actor, first.record_id, first.revision)
+    assert deleted.record is not None and deleted.record.revision == 2
+    assert repo.read(MemoryReadRequest(actor, "profile", "color")) == ()
+    assert repo.tombstone(actor, first.record_id, first.revision).reason is MemoryReason.CONFLICT
+    repo.close()
+
+
+def test_scope_and_expiry_are_enforced(tmp_path):
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    clock = lambda: now
+    repo = SQLiteMemoryRepository(str(tmp_path / "memory.sqlite"), clock=clock)
+    owner = MemoryActor("tenant", "subject", "actor")
+    other = MemoryActor("tenant", "other", "actor")
+    assert repo.commit(owner, _proposal("blue")).reason is MemoryReason.COMMITTED
+    assert repo.read(MemoryReadRequest(other, "profile", "color")) == ()
+    repo._clock = lambda: now + timedelta(days=366)  # controlled clock boundary
+    assert repo.read(MemoryReadRequest(owner, "profile", "color")) == ()
+    repo.close()


### PR DESCRIPTION
### Motivation

- Provide a small, canonical governed durable-memory authority that only accepts minimized explicit user preferences and enforces policy and lifecycle rules. 
- Make durable memory opt-in and disallow falling back to legacy graph/vector stores from the serving runtime. 
- Require a single runtime replica and an explicit filesystem SQLite path for durability to avoid unsupported topologies.

### Description

- Add ADR `docs/adr/0005-governed-durable-memory.md` documenting the governed durable-memory decision, lifecycle, and limitations. 
- Introduce `src/vulcan/memory/governed.py` implementing the governed surface including `MemoryActor`, `MemoryWriteProposal`, `MemoryRecord`, `MemoryPolicyPort`/`DefaultMemoryPolicy`, `SQLiteMemoryRepository`, `DisabledMemoryService`, `GovernedMemoryService`, and `compose_governed_memory`. 
- Change memory package exports in `src/vulcan/memory/__init__.py` to expose the governed API and lazily import legacy research/migration modules via `__getattr__` so importing the canonical authority does not initialize legacy stores. 
- Integrate governed memory into the runtime by composing memory in `src/vulcan/runtime/container.py`, enforcing `readiness()` at startup, passing the memory port into `CognitiveKernel`, and ensuring `memory.close()` is called during shutdown. 
- Update `CognitiveKernel` constructor in `src/vulcan/runtime/kernel.py` to accept and hold the memory port without turning retrieved text into executable semantics. 
- Add unit/integration tests at `tests/security/test_governed_memory.py` exercising commit/correct/tombstone/read semantics, scoping, and expiry behavior.

### Testing

- Ran the new governed-memory tests with `pytest tests/security/test_governed_memory.py`, and the three tests passed. 
- The repository-level SQLite integrity checks are exercised by the tests and succeeded under the controlled clock and lifecycle scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5984583550832fb6287f74e7a5e0b4)