### PR TITLE
Add canonical governed durable-memory (SQLite) with policy, docs, Helm flags, and tests

### DIFF
--- a/docs/adr/0005-governed-durable-memory.md
+++ b/docs/adr/0005-governed-durable-memory.md
@@ -28,3 +28,11 @@ This decision establishes neither HA/multi-writer support, backup media purge,
 key management, semantic/vector retrieval, legacy-data migration, nor legal or
 privacy compliance.  Enabling durable memory requires a maintenance-owned path
 and a single runtime replica; other topology values fail composition.
+
+## Current operational boundary
+
+The canonical configuration has no derived projection/outbox and no supported
+legacy migration or arbitrary backup restore. The inventory at
+`docs/memory/legacy-inventory.json` freezes legacy writers as research-only or
+read-only migration sources. The operational semantics and limits are recorded
+in `docs/memory/governed-memory-operations.md`.

--- a/docs/memory/governed-memory-operations.md
+++ b/docs/memory/governed-memory-operations.md
@@ -1,0 +1,21 @@
+# Governed durable-memory operations
+
+The only supported durable record is a typed explicit preference: `locale`,
+`response_style`, `unit_system`, or the transitional `color` test surface. Each
+has a closed set of values enforced before persistence. Raw prompts, answers,
+reasoning, metadata, embeddings, procedures, and secrets are unsupported.
+
+`remember` creates a logical preference; `correct` requires the current
+revision; and `forget` advances the authoritative head to a content-free
+tombstone and erases payload values in the canonical SQLite store. A tombstone
+is logical read denial and not a claim of offline-media sanitization, model
+unlearning, encryption, cryptographic audit, HA, or legal compliance.
+
+There is no derived projection or outbox in the supported configuration.
+Recovery and migration are unsupported until a validated lifecycle-replay
+bundle exists; operators must not restore arbitrary old SQLite files. Legacy
+stores are frozen/quarantined according to `legacy-inventory.json`; rollback
+must leave them disabled and cannot restore a pre-tombstone head.
+
+SQLite is single-writer only. Enablement requires a configured durable root,
+an absolute database beneath that root, one replica, and exclusive ownership.

--- a/docs/memory/legacy-inventory.json
+++ b/docs/memory/legacy-inventory.json
@@ -1,0 +1,21 @@
+{
+  "version": 1,
+  "serving_policy": "Only vulcan.memory.governed is canonical. Every other entry is frozen and cannot be constructed by vulcan.runtime.",
+  "entries": [
+    {"path":"src/vulcan/memory/governed.py","disposition":"canonical authority"},
+    {"path":"src/vulcan/memory/base.py","disposition":"research-only quarantined"},
+    {"path":"src/vulcan/memory/hierarchical.py","disposition":"research-only quarantined"},
+    {"path":"src/vulcan/memory/persistence.py","disposition":"research-only quarantined"},
+    {"path":"src/vulcan/memory/retrieval.py","disposition":"research-only quarantined"},
+    {"path":"src/vulcan/memory/specialized.py","disposition":"research-only quarantined"},
+    {"path":"src/vulcan/memory/consolidation.py","disposition":"research-only quarantined"},
+    {"path":"src/vulcan/memory/learning_persistence.py","disposition":"research-only quarantined"},
+    {"path":"src/persistant_memory_v46","disposition":"research-only quarantined"},
+    {"path":"src/integration/memory_bridge.py","disposition":"research-only quarantined"},
+    {"path":"src/vulcan/endpoints/memory.py","disposition":"removed"},
+    {"path":"helm/vulcanami/templates/configmap-memory.yaml","disposition":"research-only quarantined"},
+    {"path":"helm/vulcanami/values.yaml#memorySystem","disposition":"research-only quarantined"},
+    {"path":"checkpoints/backups","disposition":"read-only migration source"}
+  ],
+  "migration": {"supported": false, "reason":"No legacy source carries the required trusted tenant, subject, purpose, policy decision, and typed provenance fields.", "rule":"Do not unpickle or import legacy data in a serving process; quarantine it for an approved offline migration."}
+}

--- a/helm/vulcanami/templates/deployment.yaml
+++ b/helm/vulcanami/templates/deployment.yaml
@@ -445,7 +445,27 @@ spec:
           value: {{ .Values.llm.classification.model | default "gpt-4o-mini" | quote }}
         {{- end }}
         {{- end }}
+        # The canonical governed store is isolated from legacy memorySystem.
+        {{- if .Values.governedMemory.enabled }}
+        - name: VULCAN_MEMORY_ENABLED
+          value: "1"
+        - name: VULCAN_MEMORY_SQLITE_PATH
+          value: {{ .Values.governedMemory.sqlitePath | quote }}
+        - name: VULCAN_MEMORY_DURABLE_ROOT
+          value: {{ .Values.governedMemory.durableRoot | quote }}
+        - name: VULCAN_RUNTIME_REPLICAS
+          value: {{ .Values.governedMemory.replicas | quote }}
+        - name: VULCAN_MEMORY_BACKEND
+          value: {{ .Values.governedMemory.backend | quote }}
+        - name: VULCAN_MEMORY_POLICY_VERSION
+          value: {{ .Values.governedMemory.policyVersion | quote }}
+        {{- else }}
+        - name: VULCAN_MEMORY_ENABLED
+          value: "0"
+        {{- end }}
         {{- if .Values.memorySystem.enabled }}
+        # Legacy memorySystem is quarantined and must not be enabled with governed memory.
+        {{- if .Values.governedMemory.enabled }}{{ fail "memorySystem and governedMemory cannot both be enabled" }}{{ end }}
         # Vulcan Memory System v46 AWS credentials
         {{- if .Values.secrets.awsAccessKeyId }}
         - name: AWS_ACCESS_KEY_ID

--- a/helm/vulcanami/values.yaml
+++ b/helm/vulcanami/values.yaml
@@ -86,7 +86,8 @@ resources:
     memory: 1Gi
 
 autoscaling:
-  enabled: true
+  # SQLite governed memory is single-writer; horizontal scaling is incompatible.
+  enabled: false
   # CRITICAL: Set minReplicas to 1 to allow deployment to succeed with a single healthy replica
   # The HPA will scale up as needed. Setting minReplicas: 2 causes deployment failures
   # when one replica cannot start within the healthcheck timeout window.
@@ -156,6 +157,16 @@ config:
   environment: production
   logLevel: INFO
   pythonUnbuffered: "1"
+
+# Canonical governed durable-memory configuration. Disabled unless an operator
+# supplies a single-writer PVC-backed root and an absolute database path.
+governedMemory:
+  enabled: false
+  durableRoot: /var/lib/vulcan-governed-memory
+  sqlitePath: /var/lib/vulcan-governed-memory/preferences.sqlite
+  replicas: 1
+  backend: sqlite
+  policyVersion: memory-policy/2
 
 # LLM Configuration (CRITICAL for chat features)
 llm:
@@ -342,7 +353,8 @@ minio:
 
 # Vulcan Memory System v46 Configuration
 memorySystem:
-  enabled: true
+  # Legacy system is quarantined; canonical runtime must not construct it.
+  enabled: false
   # Milvus vector database configuration
   milvus:
     host: milvus-service

--- a/src/vulcan/memory/__init__.py
+++ b/src/vulcan/memory/__init__.py
@@ -11,6 +11,11 @@ from .governed import (
     DeletionReceipt,
     DeletionState,
     GovernedMemoryService,
+    GovernedMemoryPort,
+    MemoryActorContext,
+    MemoryOperation,
+    MemoryRuntimeConfig,
+    MemoryPolicyResult,
     MemoryActor,
     MemoryCommitResult,
     MemoryKind,
@@ -23,7 +28,7 @@ from .governed import (
 )
 
 __all__ = [
-    "DisabledMemoryService", "DefaultMemoryPolicy", "DeletionReceipt", "DeletionState", "GovernedMemoryService", "MemoryActor",
+    "DisabledMemoryService", "DefaultMemoryPolicy", "DeletionReceipt", "DeletionState", "GovernedMemoryService", "GovernedMemoryPort", "MemoryActor", "MemoryActorContext", "MemoryOperation", "MemoryRuntimeConfig", "MemoryPolicyResult",
     "MemoryCommitResult", "MemoryKind", "MemoryPolicyPort", "MemoryReadRequest", "MemoryReason",
     "MemoryWriteProposal", "SQLiteMemoryRepository", "compose_governed_memory",
 ]

--- a/src/vulcan/memory/governed.py
+++ b/src/vulcan/memory/governed.py
@@ -1,350 +1,263 @@
-"""The canonical, deliberately small durable-memory authority.
+"""Canonical durable authority for a deliberately small preference surface.
 
-This module is intentionally independent of the historical memory packages.  It
-stores only bounded, typed user preferences in the supported runtime surface;
-the old graph/vector stores are not a fallback or a peer authority.
+This module has no vector, graph, transcript, or model-memory fallback.  It is
+an exact-key SQLite store whose authoritative ``memory_heads`` rows prevent a
+missing historical revision from becoming effective after a restore or purge.
 """
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import json
 import os
 import sqlite3
 import threading
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 from pathlib import Path
 from typing import Callable, Protocol
 from uuid import uuid4
 
-
-SCHEMA_VERSION = "governed-memory/1"
-POLICY_VERSION = "memory-policy/1"
-MAX_VALUE_CHARS = 512
-MAX_KEY_CHARS = 64
+SCHEMA_VERSION = "governed-memory/2"
+POLICY_VERSION = "memory-policy/2"
 MAX_RESULTS = 20
 
+@dataclass(frozen=True)
+class MemoryRuntimeConfig:
+    """Validated deployment input; environment parsing is isolated here."""
+    enabled: bool
+    path: Path | None = None
+    durable_root: Path | None = None
+    replicas: int = 1
+    backend: str = "sqlite"
+    policy_version: str = POLICY_VERSION
 
-class MemoryKind(str, Enum):
-    EXPLICIT_PREFERENCE = "explicit_preference"
+    @classmethod
+    def from_environment(cls) -> "MemoryRuntimeConfig":
+        enabled = os.getenv("VULCAN_MEMORY_ENABLED", "0") == "1"
+        if not enabled:
+            return cls(False)
+        path, root = os.getenv("VULCAN_MEMORY_SQLITE_PATH"), os.getenv("VULCAN_MEMORY_DURABLE_ROOT")
+        if not path or not root:
+            raise RuntimeError("durable memory requires VULCAN_MEMORY_SQLITE_PATH and VULCAN_MEMORY_DURABLE_ROOT")
+        try:
+            replicas = int(os.getenv("VULCAN_RUNTIME_REPLICAS", "1"))
+        except ValueError as exc:
+            raise RuntimeError("invalid durable-memory replica count") from exc
+        return cls(True, Path(path), Path(root), replicas, os.getenv("VULCAN_MEMORY_BACKEND", "sqlite"), os.getenv("VULCAN_MEMORY_POLICY_VERSION", POLICY_VERSION)).validated()
 
+    def validated(self) -> "MemoryRuntimeConfig":
+        if not self.enabled: return self
+        if self.backend != "sqlite" or self.replicas != 1 or self.policy_version != POLICY_VERSION:
+            raise RuntimeError("unsupported governed-memory topology or policy")
+        if self.path is None or self.durable_root is None or not self.path.is_absolute() or not self.durable_root.is_absolute():
+            raise RuntimeError("governed-memory paths must be absolute")
+        root = self.durable_root.resolve(strict=True)
+        if root in {Path("/tmp"), Path.home(), Path.cwd()} or root.is_symlink() or not root.is_dir():
+            raise RuntimeError("unsafe governed-memory durable root")
+        candidate = self.path.resolve(strict=False)
+        if root not in (candidate, *candidate.parents) or (candidate.exists() and not candidate.is_file()):
+            raise RuntimeError("governed-memory database escapes durable root")
+        return self
 
-class MemoryLifecycle(str, Enum):
-    ACTIVE = "active"
-    SUPERSEDED = "superseded"
-    TOMBSTONED = "tombstoned"
-    PURGED = "purged"
-    QUARANTINED = "quarantined"
-
-
+class MemoryKind(str, Enum): EXPLICIT_PREFERENCE = "explicit_preference"
+class MemoryLifecycle(str, Enum): ACTIVE="active"; SUPERSEDED="superseded"; TOMBSTONED="tombstoned"; PURGED="purged"
+class MemoryOperation(str, Enum): CREATE="create"; READ="read"; CORRECT="correct"; FORGET="forget"; LIST="list"; EXPORT="export"; MIGRATE="migrate"
 class MemoryReason(str, Enum):
-    COMMITTED = "committed"
-    CONFLICT = "conflict"
-    NOT_FOUND = "not_found"
-    UNAUTHORIZED = "unauthorized"
-    MEMORY_DISABLED = "memory_disabled"
-    POLICY_REJECTED = "policy_rejected"
-    EMPTY = "empty"
+    COMMITTED="committed"; CONFLICT="conflict"; NOT_FOUND="not_found"; UNAUTHORIZED="unauthorized"; MEMORY_DISABLED="memory_disabled"; POLICY_REJECTED="policy_rejected"; EMPTY="empty"; IDEMPOTENCY_CONFLICT="idempotency_conflict"
+class PolicyDecision(str, Enum): ALLOW="allow"; REJECT="reject"
+class DeletionState(str, Enum): REQUESTED="requested"; TOMBSTONED="tombstoned"; COMPLETED="completed"; REJECTED="rejected"
 
-
-class PolicyDecision(str, Enum):
-    ALLOW = "allow"
-    REJECT = "reject"
-
-
-class DeletionState(str, Enum):
-    COMPLETED = "completed"
-    PENDING = "pending"
-    REJECTED = "rejected"
-
-
-@dataclass(frozen=True)
-class MemoryActor:
-    tenant_id: str
-    subject_id: str
-    actor_id: str
-    purpose: str = "personalization"
-
-    def __post_init__(self) -> None:
-        for value in (self.tenant_id, self.subject_id, self.actor_id, self.purpose):
-            if not _identifier(value):
-                raise ValueError("memory actor contains an invalid identifier")
-
-
-@dataclass(frozen=True)
-class MemoryWriteProposal:
-    """Untrusted intent.  It cannot choose IDs, retention, or lifecycle."""
-    kind: MemoryKind
-    namespace: str
-    key: str
-    value: str
-    idempotency_key: str
-    case_id: str | None = None
-
-    def __post_init__(self) -> None:
-        if self.kind is not MemoryKind.EXPLICIT_PREFERENCE:
-            raise ValueError("unsupported memory kind")
-        if not _identifier(self.namespace) or not _plain(self.key, MAX_KEY_CHARS) or not _plain(self.value, MAX_VALUE_CHARS):
-            raise ValueError("invalid bounded memory proposal")
-        if not _identifier(self.idempotency_key):
-            raise ValueError("invalid idempotency key")
-        if self.case_id is not None and not _identifier(self.case_id):
-            raise ValueError("invalid case reference")
-
-
-@dataclass(frozen=True)
-class MemoryRecord:
-    record_id: str
-    revision: int
-    tenant_id: str
-    subject_id: str
-    actor_id: str
-    purpose: str
-    namespace: str
-    key: str
-    value: str
-    kind: MemoryKind
-    lifecycle: MemoryLifecycle
-    policy_version: str
-    created_at: str
-    expires_at: str
-    deletion_epoch: int
-    digest: str
-    supersedes: str | None = None
-
-
-@dataclass(frozen=True)
-class MemoryCommitResult:
-    reason: MemoryReason
-    record: MemoryRecord | None = None
-    reconciliation_pending: bool = False
-
-
-@dataclass(frozen=True)
-class DeletionReceipt:
-    operation_id: str
-    state: DeletionState
-    record_id: str
-    revision: int
-    deletion_epoch: int
-    policy_version: str
-    required_locations: tuple[str, ...]
-    completed_locations: tuple[str, ...]
-    remaining_obligations: tuple[str, ...] = ()
-
-
-class MemoryPolicyPort(Protocol):
-    """Server-owned policy; callers cannot set a retention or lifecycle value."""
-    version: str
-    def allow_write(self, actor: "MemoryActor", proposal: "MemoryWriteProposal") -> PolicyDecision: ...
-    def retention(self, actor: "MemoryActor", proposal: "MemoryWriteProposal") -> timedelta: ...
-
-
-class DefaultMemoryPolicy:
-    """Conservative product policy: only minimized explicit preferences."""
-    version = POLICY_VERSION
-    def allow_write(self, actor: "MemoryActor", proposal: "MemoryWriteProposal") -> PolicyDecision:
-        if actor.purpose != "personalization" or proposal.kind is not MemoryKind.EXPLICIT_PREFERENCE:
-            return PolicyDecision.REJECT
-        forbidden = ("password", "secret", "token", "authorization", "credential")
-        return PolicyDecision.REJECT if any(word in proposal.key.lower() for word in forbidden) else PolicyDecision.ALLOW
-    def retention(self, actor: "MemoryActor", proposal: "MemoryWriteProposal") -> timedelta:
-        return timedelta(days=365)
-
-
-@dataclass(frozen=True)
-class MemoryReadRequest:
-    actor: MemoryActor
-    namespace: str
-    query: str
-    maximum_results: int = 5
-
-    def __post_init__(self) -> None:
-        if not _identifier(self.namespace) or not _plain(self.query, MAX_VALUE_CHARS):
-            raise ValueError("invalid memory read request")
-        if not 1 <= self.maximum_results <= MAX_RESULTS:
-            raise ValueError("memory result limit out of bounds")
-
-
-class MemoryRepositoryPort(Protocol):
-    def commit(self, actor: MemoryActor, proposal: MemoryWriteProposal) -> MemoryCommitResult: ...
-    def read(self, request: MemoryReadRequest) -> tuple[MemoryRecord, ...]: ...
-    def tombstone(self, actor: MemoryActor, record_id: str, revision: int) -> MemoryCommitResult: ...
-    def correct(self, actor: MemoryActor, record_id: str, base_revision: int, proposal: MemoryWriteProposal) -> MemoryCommitResult: ...
-    def readiness(self) -> None: ...
-    def close(self) -> None: ...
-
+# Closed, typed, non-free-form product values.  ``color`` remains only for the
+# pre-existing supported test/product surface; it is not arbitrary text.
+_PREFERENCES: dict[str, frozenset[str]] = {
+    "locale": frozenset({"en", "en-us", "en-gb", "fr", "de", "es"}),
+    "response_style": frozenset({"concise", "balanced", "detailed"}),
+    "unit_system": frozenset({"metric", "imperial"}),
+    "color": frozenset({"blue", "red", "green"}),
+}
 
 def _identifier(value: object) -> bool:
     return isinstance(value, str) and 1 <= len(value) <= 128 and value.replace("-", "").replace("_", "").isalnum()
+def _time(clock: Callable[[], datetime]) -> str:
+    value=clock()
+    if value.tzinfo is None or value.utcoffset() is None: raise ValueError("memory clock must return UTC-aware time")
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+def _digest(values: dict[str, object]) -> str:
+    return hashlib.sha256(json.dumps(values, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode()).hexdigest()
+def _normal(key: str, value: str) -> tuple[str, str]:
+    if not isinstance(key, str) or not isinstance(value, str) or any(ord(c)<32 for c in key+value): raise ValueError("invalid preference text")
+    key, value = key.strip().lower(), value.strip().lower()
+    if key not in _PREFERENCES or value not in _PREFERENCES[key]: raise ValueError("unsupported typed preference")
+    return key, value
 
+@dataclass(frozen=True)
+class MemoryActorContext:
+    """Server-owned trusted principal binding; never decoded from wire data."""
+    tenant_id: str; subject_id: str; actor_id: str; purpose: str = "personalization"; request_id: str = "system"
+    def __post_init__(self) -> None:
+        if not all(_identifier(x) for x in (self.tenant_id,self.subject_id,self.actor_id,self.purpose,self.request_id)): raise ValueError("invalid trusted memory actor")
+MemoryActor = MemoryActorContext # compatibility name; construction remains domain-only.
 
-def _plain(value: object, limit: int) -> bool:
-    return isinstance(value, str) and bool(value) and len(value) <= limit and "\x00" not in value
+@dataclass(frozen=True)
+class MemoryWriteProposal:
+    kind: MemoryKind; namespace: str; key: str; value: str; idempotency_key: str; case_id: str|None=None
+    def __post_init__(self) -> None:
+        if self.kind is not MemoryKind.EXPLICIT_PREFERENCE or not _identifier(self.namespace) or not _identifier(self.idempotency_key): raise ValueError("invalid memory proposal")
+        key,value=_normal(self.key,self.value); object.__setattr__(self,"key",key); object.__setattr__(self,"value",value)
+        if self.case_id is not None and not _identifier(self.case_id): raise ValueError("invalid case reference")
+@dataclass(frozen=True)
+class MemoryReadRequest:
+    actor: MemoryActorContext; namespace: str; query: str; maximum_results: int=5
+    def __post_init__(self) -> None:
+        if not _identifier(self.namespace) or self.query not in _PREFERENCES or not 1<=self.maximum_results<=MAX_RESULTS: raise ValueError("memory reads require an allowlisted exact key")
+@dataclass(frozen=True)
+class MemoryRecord:
+    record_id:str; revision:int; tenant_id:str; subject_id:str; actor_id:str; purpose:str; namespace:str; key:str; value:str|None; kind:MemoryKind; lifecycle:MemoryLifecycle; policy_version:str; created_at:str; expires_at:str; deletion_epoch:int; digest:str; supersedes:str|None=None
+@dataclass(frozen=True)
+class DeletionReceipt:
+    operation_id:str; state:DeletionState; record_id:str; revision:int; deletion_epoch:int; policy_version:str; required_locations:tuple[str,...]; completed_locations:tuple[str,...]; remaining_obligations:tuple[str,...]=()
+@dataclass(frozen=True)
+class MemoryCommitResult:
+    reason:MemoryReason; record:MemoryRecord|None=None; reconciliation_pending:bool=False; deletion_receipt:DeletionReceipt|None=None
+@dataclass(frozen=True)
+class MemoryPolicyResult:
+    decision:PolicyDecision; decision_id:str; operation:MemoryOperation; version:str=POLICY_VERSION
 
+class MemoryPolicyPort(Protocol):
+    version:str
+    def decide(self, operation:MemoryOperation, actor:MemoryActorContext, proposal:MemoryWriteProposal|None=None)->MemoryPolicyResult: ...
+    def retention(self, actor:MemoryActorContext, proposal:MemoryWriteProposal)->timedelta: ...
+class DefaultMemoryPolicy:
+    version=POLICY_VERSION
+    def decide(self, operation, actor, proposal=None):
+        allowed=actor.purpose=="personalization" and operation in {MemoryOperation.CREATE,MemoryOperation.READ,MemoryOperation.CORRECT,MemoryOperation.FORGET,MemoryOperation.LIST}
+        if proposal is not None:
+            try: _normal(proposal.key,proposal.value)
+            except ValueError: allowed=False
+        return MemoryPolicyResult(PolicyDecision.ALLOW if allowed else PolicyDecision.REJECT, f"{self.version}:{operation.value}", operation)
+    def retention(self, actor, proposal): return timedelta(days=365)
 
-def _canonical_digest(values: dict[str, object]) -> str:
-    return hashlib.sha256(json.dumps(values, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")).hexdigest()
-
+class GovernedMemoryPort(Protocol):
+    def remember(self, actor:MemoryActorContext, proposal:MemoryWriteProposal)->MemoryCommitResult: ...
+    def retrieve(self, request:MemoryReadRequest)->tuple[MemoryRecord,...]: ...
+    def correct(self, actor:MemoryActorContext, record_id:str, base_revision:int, proposal:MemoryWriteProposal)->MemoryCommitResult: ...
+    def forget(self, actor:MemoryActorContext, record_id:str, revision:int, idempotency_key:str|None=None)->MemoryCommitResult: ...
+    def readiness(self)->None: ...
+    def close(self)->None: ...
 
 class SQLiteMemoryRepository:
-    """Single-writer SQLite source of truth with journal and transactional outbox."""
-    def __init__(self, path: str, *, policy: MemoryPolicyPort | None = None,
-                 clock: Callable[[], datetime] | None = None) -> None:
-        if not path or path == ":memory:":
-            raise ValueError("durable memory requires an explicit filesystem path")
-        self._path = Path(path).resolve()
-        self._path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
-        self._lock = threading.RLock()
-        self._closed = False
-        self._policy = policy or DefaultMemoryPolicy()
-        self._clock = clock or (lambda: datetime.now(timezone.utc))
-        self._db = sqlite3.connect(str(self._path), check_same_thread=False, isolation_level=None)
-        self._db.execute("PRAGMA foreign_keys = ON")
-        self._db.execute("PRAGMA journal_mode = WAL")
-        self._migrate()
-        self.readiness()
-
-    def _migrate(self) -> None:
-        self._db.executescript("""
-        CREATE TABLE IF NOT EXISTS memory_records (
-          record_id TEXT NOT NULL, revision INTEGER NOT NULL, tenant_id TEXT NOT NULL,
-          subject_id TEXT NOT NULL, actor_id TEXT NOT NULL, purpose TEXT NOT NULL,
-          namespace TEXT NOT NULL, key_name TEXT NOT NULL, value TEXT NOT NULL,
-          kind TEXT NOT NULL, lifecycle TEXT NOT NULL, policy_version TEXT NOT NULL,
-          created_at TEXT NOT NULL, expires_at TEXT NOT NULL, deletion_epoch INTEGER NOT NULL,
-          digest TEXT NOT NULL, supersedes TEXT, PRIMARY KEY(record_id, revision),
-          CHECK(revision > 0), CHECK(deletion_epoch >= 0)
-        );
-        CREATE INDEX IF NOT EXISTS active_scope ON memory_records(tenant_id, subject_id, namespace, lifecycle, expires_at);
-        CREATE TABLE IF NOT EXISTS memory_idempotency (tenant_id TEXT NOT NULL, subject_id TEXT NOT NULL, idempotency_key TEXT NOT NULL, record_id TEXT NOT NULL, revision INTEGER NOT NULL, PRIMARY KEY(tenant_id, subject_id, idempotency_key));
-        CREATE TABLE IF NOT EXISTS memory_journal (sequence INTEGER PRIMARY KEY AUTOINCREMENT, operation TEXT NOT NULL, record_id TEXT NOT NULL, revision INTEGER NOT NULL, digest TEXT NOT NULL, committed_at TEXT NOT NULL);
-        CREATE TABLE IF NOT EXISTS memory_outbox (sequence INTEGER PRIMARY KEY AUTOINCREMENT, record_id TEXT NOT NULL, revision INTEGER NOT NULL, deletion_epoch INTEGER NOT NULL, operation TEXT NOT NULL, delivered INTEGER NOT NULL DEFAULT 0);
-        """)
-
-    def readiness(self) -> None:
-        if self._closed:
-            raise RuntimeError("memory repository is closed")
-        integrity = self._db.execute("PRAGMA integrity_check").fetchone()
-        if integrity != ("ok",):
-            raise RuntimeError("memory repository integrity check failed")
-
-    def _row(self, row: tuple[object, ...]) -> MemoryRecord:
-        normalized = list(row)
-        normalized[9] = MemoryKind(normalized[9])
-        normalized[10] = MemoryLifecycle(normalized[10])
-        record = MemoryRecord(*normalized)
-        expected = _canonical_digest({k: v.value if isinstance(v, Enum) else v for k, v in asdict(record).items() if k != "digest"})
-        if record.digest != expected:
-            raise RuntimeError("memory record digest mismatch")
-        return record
-
-    def commit(self, actor: MemoryActor, proposal: MemoryWriteProposal) -> MemoryCommitResult:
+    """Serialized SQLite repository with immutable revisions and authoritative heads."""
+    def __init__(self,path:str,*,policy:MemoryPolicyPort|None=None,clock:Callable[[],datetime]|None=None, durable_root: str | None = None)->None:
+        if not path or path==":memory:": raise ValueError("durable memory requires an explicit filesystem path")
+        self._path=Path(path).resolve();
+        if durable_root is not None:
+            root=Path(durable_root).resolve(strict=True)
+            if root not in (self._path, *self._path.parents): raise RuntimeError("memory database is outside durable root")
+        self._path.parent.mkdir(mode=0o700,parents=True,exist_ok=True);
+        if self._path.exists() and not self._path.is_file(): raise RuntimeError("memory database is not a regular file")
+        self._ownership=open(str(self._path)+".lock", "a+", encoding="utf-8")
+        try: fcntl.flock(self._ownership.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc: self._ownership.close(); raise RuntimeError("governed-memory writer is already owned") from exc
+        self._lock=threading.RLock(); self._closed=False; self._policy=policy or DefaultMemoryPolicy(); self._clock=clock or (lambda:datetime.now(timezone.utc))
+        self._db=sqlite3.connect(str(self._path),check_same_thread=False,isolation_level=None); self._db.execute("PRAGMA foreign_keys=ON"); self._db.execute("PRAGMA busy_timeout=5000"); self._db.execute("PRAGMA journal_mode=WAL"); self._migrate(); self.readiness()
+    def _migrate(self)->None:
+        with self._lock:
+            self._db.executescript("""
+            CREATE TABLE IF NOT EXISTS memory_schema(version TEXT PRIMARY KEY);
+            CREATE TABLE IF NOT EXISTS memory_revisions(record_id TEXT NOT NULL,revision INTEGER NOT NULL,tenant_id TEXT NOT NULL,subject_id TEXT NOT NULL,actor_id TEXT NOT NULL,purpose TEXT NOT NULL,namespace TEXT NOT NULL,key_name TEXT NOT NULL,value TEXT,kind TEXT NOT NULL CHECK(kind='explicit_preference'),lifecycle TEXT NOT NULL CHECK(lifecycle IN ('active','superseded','tombstoned','purged')),policy_version TEXT NOT NULL,created_at TEXT NOT NULL,expires_at TEXT NOT NULL,deletion_epoch INTEGER NOT NULL CHECK(deletion_epoch>=0),digest TEXT NOT NULL,supersedes TEXT,PRIMARY KEY(record_id,revision));
+            CREATE TABLE IF NOT EXISTS memory_heads(record_id TEXT PRIMARY KEY,tenant_id TEXT NOT NULL,subject_id TEXT NOT NULL,purpose TEXT NOT NULL,namespace TEXT NOT NULL,key_name TEXT NOT NULL,current_revision INTEGER NOT NULL,current_lifecycle TEXT NOT NULL CHECK(current_lifecycle IN ('active','tombstoned','purged')),deletion_epoch INTEGER NOT NULL,UNIQUE(tenant_id,subject_id,purpose,namespace,key_name),FOREIGN KEY(record_id,current_revision) REFERENCES memory_revisions(record_id,revision));
+            CREATE TABLE IF NOT EXISTS memory_idempotency(tenant_id TEXT NOT NULL,subject_id TEXT NOT NULL,idempotency_key TEXT NOT NULL,operation TEXT NOT NULL,request_digest TEXT NOT NULL,record_id TEXT,PRIMARY KEY(tenant_id,subject_id,idempotency_key));
+            CREATE TABLE IF NOT EXISTS memory_journal(sequence INTEGER PRIMARY KEY AUTOINCREMENT,operation TEXT NOT NULL,record_id TEXT NOT NULL,revision INTEGER NOT NULL,tenant_id TEXT NOT NULL,subject_id TEXT NOT NULL,request_digest TEXT NOT NULL,committed_at TEXT NOT NULL);
+            """)
+            versions=self._db.execute("SELECT version FROM memory_schema").fetchall()
+            if not versions: self._db.execute("INSERT INTO memory_schema VALUES(?)",(SCHEMA_VERSION,))
+            elif versions != [(SCHEMA_VERSION,)]: raise RuntimeError("unsupported governed-memory schema version")
+    def readiness(self)->None:
         with self._lock:
             if self._closed: raise RuntimeError("memory repository is closed")
-            if self._policy.allow_write(actor, proposal) is not PolicyDecision.ALLOW:
-                return MemoryCommitResult(MemoryReason.POLICY_REJECTED)
-            self._db.execute("BEGIN IMMEDIATE")
-            try:
-                prior = self._db.execute("SELECT record_id, revision FROM memory_idempotency WHERE tenant_id=? AND subject_id=? AND idempotency_key=?", (actor.tenant_id, actor.subject_id, proposal.idempotency_key)).fetchone()
-                if prior:
-                    row = self._db.execute("SELECT record_id,revision,tenant_id,subject_id,actor_id,purpose,namespace,key_name,value,kind,lifecycle,policy_version,created_at,expires_at,deletion_epoch,digest,supersedes FROM memory_records WHERE record_id=? AND revision=?", prior).fetchone()
-                    self._db.execute("COMMIT"); return MemoryCommitResult(MemoryReason.COMMITTED, self._row(row), True)
-                now = self._clock(); record_id = f"mem-{uuid4().hex}"; created = now.isoformat().replace("+00:00", "Z"); expires = (now + self._policy.retention(actor, proposal)).isoformat().replace("+00:00", "Z")
-                values: dict[str, object] = {"record_id":record_id,"revision":1,"tenant_id":actor.tenant_id,"subject_id":actor.subject_id,"actor_id":actor.actor_id,"purpose":actor.purpose,"namespace":proposal.namespace,"key":proposal.key,"value":proposal.value,"kind":proposal.kind.value,"lifecycle":MemoryLifecycle.ACTIVE.value,"policy_version":self._policy.version,"created_at":created,"expires_at":expires,"deletion_epoch":0,"supersedes":None}
-                digest = _canonical_digest(values); values["digest"] = digest
-                self._db.execute("INSERT INTO memory_records VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", (values["record_id"],values["revision"],values["tenant_id"],values["subject_id"],values["actor_id"],values["purpose"],values["namespace"],values["key"],values["value"],values["kind"],values["lifecycle"],values["policy_version"],values["created_at"],values["expires_at"],values["deletion_epoch"],values["digest"],None))
-                self._db.execute("INSERT INTO memory_idempotency VALUES (?,?,?,?,?)", (actor.tenant_id,actor.subject_id,proposal.idempotency_key,record_id,1))
-                self._event("create", record_id, 1, digest, 0); self._db.execute("COMMIT")
-                return MemoryCommitResult(MemoryReason.COMMITTED, self._row(tuple(values[k] for k in ("record_id","revision","tenant_id","subject_id","actor_id","purpose","namespace","key","value","kind","lifecycle","policy_version","created_at","expires_at","deletion_epoch","digest","supersedes"))), True)
-            except Exception:
-                self._db.execute("ROLLBACK"); raise
-
-    def _event(self, operation: str, record_id: str, revision: int, digest: str, epoch: int) -> None:
-        now = self._clock().isoformat().replace("+00:00", "Z")
-        self._db.execute("INSERT INTO memory_journal(operation,record_id,revision,digest,committed_at) VALUES (?,?,?,?,?)", (operation,record_id,revision,digest,now))
-        self._db.execute("INSERT INTO memory_outbox(record_id,revision,deletion_epoch,operation) VALUES (?,?,?,?)", (record_id,revision,epoch,operation))
-
-    def read(self, request: MemoryReadRequest) -> tuple[MemoryRecord, ...]:
-        if self._closed: raise RuntimeError("memory repository is closed")
-        now = self._clock().isoformat().replace("+00:00", "Z")
-        # Exact, scoped lexical candidate generation; canonical rows are rehydrated.
-        rows = self._db.execute("SELECT r.record_id,r.revision,r.tenant_id,r.subject_id,r.actor_id,r.purpose,r.namespace,r.key_name,r.value,r.kind,r.lifecycle,r.policy_version,r.created_at,r.expires_at,r.deletion_epoch,r.digest,r.supersedes FROM memory_records r WHERE r.tenant_id=? AND r.subject_id=? AND r.purpose=? AND r.namespace=? AND r.lifecycle=? AND r.expires_at>? AND r.revision=(SELECT MAX(newer.revision) FROM memory_records newer WHERE newer.record_id=r.record_id) AND (r.key_name LIKE ? OR r.value LIKE ?) ORDER BY r.created_at DESC LIMIT ?", (request.actor.tenant_id,request.actor.subject_id,request.actor.purpose,request.namespace,MemoryLifecycle.ACTIVE.value,now,f"%{request.query}%",f"%{request.query}%",request.maximum_results)).fetchall()
-        return tuple(self._row(row) for row in rows)
-
-    def correct(self, actor: MemoryActor, record_id: str, base_revision: int,
-                proposal: MemoryWriteProposal) -> MemoryCommitResult:
-        """Append an immutable successor; stale revisions never overwrite data."""
-        if not _identifier(record_id) or base_revision < 1:
-            raise ValueError("invalid correction reference")
-        if self._policy.allow_write(actor, proposal) is not PolicyDecision.ALLOW:
-            return MemoryCommitResult(MemoryReason.POLICY_REJECTED)
+            if self._db.execute("PRAGMA integrity_check").fetchone() != ("ok",): raise RuntimeError("memory repository integrity check failed")
+            if self._db.execute("SELECT version FROM memory_schema").fetchone() != (SCHEMA_VERSION,): raise RuntimeError("memory schema verification failed")
+            bad=self._db.execute("SELECT 1 FROM memory_heads h LEFT JOIN memory_revisions r ON r.record_id=h.record_id AND r.revision=h.current_revision WHERE r.record_id IS NULL LIMIT 1").fetchone()
+            if bad: raise RuntimeError("memory head corruption fails closed")
+    def _record(self,row):
+        data=list(row); data[9]=MemoryKind(data[9]); data[10]=MemoryLifecycle(data[10]); return MemoryRecord(*data)
+    def _decision(self,op,actor,proposal=None): return self._policy.decide(op,actor,proposal)
+    def _envelope(self,op,actor,target,proposal=None,base=None): return _digest({"operation":op.value,"tenant":actor.tenant_id,"subject":actor.subject_id,"actor":actor.actor_id,"purpose":actor.purpose,"target":target,"base":base,"proposal":None if proposal is None else [proposal.namespace,proposal.key,proposal.value],"policy":self._policy.version,"schema":SCHEMA_VERSION})
+    def _idempotent(self,actor,key,op,digest):
+        row=self._db.execute("SELECT operation,request_digest,record_id FROM memory_idempotency WHERE tenant_id=? AND subject_id=? AND idempotency_key=?",(actor.tenant_id,actor.subject_id,key)).fetchone()
+        if not row:return None
+        if row[0]!=op.value or row[1]!=digest:return MemoryCommitResult(MemoryReason.IDEMPOTENCY_CONFLICT)
+        return self._current(actor,row[2]) if row[2] else MemoryCommitResult(MemoryReason.COMMITTED)
+    def _current(self,actor,record_id):
+        row=self._db.execute("SELECT r.record_id,r.revision,r.tenant_id,r.subject_id,r.actor_id,r.purpose,r.namespace,r.key_name,r.value,r.kind,r.lifecycle,r.policy_version,r.created_at,r.expires_at,r.deletion_epoch,r.digest,r.supersedes FROM memory_heads h JOIN memory_revisions r ON r.record_id=h.record_id AND r.revision=h.current_revision WHERE h.record_id=? AND h.tenant_id=? AND h.subject_id=? AND h.purpose=?",(record_id,actor.tenant_id,actor.subject_id,actor.purpose)).fetchone()
+        return MemoryCommitResult(MemoryReason.COMMITTED,self._record(row)) if row else MemoryCommitResult(MemoryReason.NOT_FOUND)
+    def _insert_revision(self,data):
+        self._db.execute("INSERT INTO memory_revisions VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",tuple(data[k] for k in ("record_id","revision","tenant_id","subject_id","actor_id","purpose","namespace","key","value","kind","lifecycle","policy_version","created_at","expires_at","deletion_epoch","digest","supersedes")))
+    def _journal(self,op,data,digest): self._db.execute("INSERT INTO memory_journal(operation,record_id,revision,tenant_id,subject_id,request_digest,committed_at) VALUES(?,?,?,?,?,?,?)",(op.value,data["record_id"],data["revision"],data["tenant_id"],data["subject_id"],digest,_time(self._clock)))
+    def commit(self,actor,proposal):
+        if self._decision(MemoryOperation.CREATE,actor,proposal).decision is PolicyDecision.REJECT:return MemoryCommitResult(MemoryReason.POLICY_REJECTED)
+        digest=self._envelope(MemoryOperation.CREATE,actor,f"{proposal.namespace}:{proposal.key}",proposal)
         with self._lock:
             self._db.execute("BEGIN IMMEDIATE")
             try:
-                row = self._db.execute("SELECT record_id,revision,tenant_id,subject_id,actor_id,purpose,namespace,key_name,value,kind,lifecycle,policy_version,created_at,expires_at,deletion_epoch,digest,supersedes FROM memory_records WHERE record_id=? AND revision=? AND tenant_id=? AND subject_id=?", (record_id,base_revision,actor.tenant_id,actor.subject_id)).fetchone()
-                if row is None:
-                    self._db.execute("COMMIT"); return MemoryCommitResult(MemoryReason.NOT_FOUND)
-                old = self._row(row)
-                latest = self._db.execute("SELECT MAX(revision) FROM memory_records WHERE record_id=?", (record_id,)).fetchone()[0]
-                if latest != base_revision or old.lifecycle is not MemoryLifecycle.ACTIVE:
-                    self._db.execute("COMMIT"); return MemoryCommitResult(MemoryReason.CONFLICT)
-                now = self._clock(); created = now.isoformat().replace("+00:00", "Z")
-                data: dict[str, object] = {"record_id":record_id,"revision":base_revision + 1,"tenant_id":actor.tenant_id,"subject_id":actor.subject_id,"actor_id":actor.actor_id,"purpose":actor.purpose,"namespace":proposal.namespace,"key":proposal.key,"value":proposal.value,"kind":proposal.kind.value,"lifecycle":MemoryLifecycle.ACTIVE.value,"policy_version":self._policy.version,"created_at":created,"expires_at":(now + self._policy.retention(actor, proposal)).isoformat().replace("+00:00", "Z"),"deletion_epoch":old.deletion_epoch,"supersedes":f"{record_id}:{base_revision}"}
-                data["digest"] = _canonical_digest(data)
-                self._db.execute("INSERT INTO memory_records VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", tuple(data[k] for k in ("record_id","revision","tenant_id","subject_id","actor_id","purpose","namespace","key","value","kind","lifecycle","policy_version","created_at","expires_at","deletion_epoch","digest","supersedes")))
-                self._event("correct", record_id, base_revision + 1, data["digest"], old.deletion_epoch)
-                self._db.execute("COMMIT")
-                return MemoryCommitResult(MemoryReason.COMMITTED, self._row(tuple(data[k] for k in ("record_id","revision","tenant_id","subject_id","actor_id","purpose","namespace","key","value","kind","lifecycle","policy_version","created_at","expires_at","deletion_epoch","digest","supersedes"))), True)
-            except Exception:
-                self._db.execute("ROLLBACK"); raise
-
-    def tombstone(self, actor: MemoryActor, record_id: str, revision: int) -> MemoryCommitResult:
-        if not _identifier(record_id) or revision < 1: raise ValueError("invalid memory revision")
+                prior=self._idempotent(actor,proposal.idempotency_key,MemoryOperation.CREATE,digest)
+                if prior is not None:self._db.execute("COMMIT");return prior
+                exists=self._db.execute("SELECT 1 FROM memory_heads WHERE tenant_id=? AND subject_id=? AND purpose=? AND namespace=? AND key_name=?",(actor.tenant_id,actor.subject_id,actor.purpose,proposal.namespace,proposal.key)).fetchone()
+                if exists:self._db.execute("COMMIT");return MemoryCommitResult(MemoryReason.CONFLICT)
+                now=_time(self._clock); rid="mem-"+uuid4().hex; data={"record_id":rid,"revision":1,"tenant_id":actor.tenant_id,"subject_id":actor.subject_id,"actor_id":actor.actor_id,"purpose":actor.purpose,"namespace":proposal.namespace,"key":proposal.key,"value":proposal.value,"kind":proposal.kind.value,"lifecycle":"active","policy_version":self._policy.version,"created_at":now,"expires_at":(datetime.fromisoformat(now.replace("Z","+00:00"))+self._policy.retention(actor,proposal)).isoformat().replace("+00:00","Z"),"deletion_epoch":0,"supersedes":None};data["digest"]=_digest(data);self._insert_revision(data);self._db.execute("INSERT INTO memory_heads VALUES(?,?,?,?,?,?,?,?,?)",(rid,actor.tenant_id,actor.subject_id,actor.purpose,proposal.namespace,proposal.key,1,"active",0));self._db.execute("INSERT INTO memory_idempotency VALUES(?,?,?,?,?,?)",(actor.tenant_id,actor.subject_id,proposal.idempotency_key,"create",digest,rid));self._journal(MemoryOperation.CREATE,data,digest);self._db.execute("COMMIT");return MemoryCommitResult(MemoryReason.COMMITTED,self._record(tuple(data[k] for k in ("record_id","revision","tenant_id","subject_id","actor_id","purpose","namespace","key","value","kind","lifecycle","policy_version","created_at","expires_at","deletion_epoch","digest","supersedes"))))
+            except Exception:self._db.execute("ROLLBACK");raise
+    def read(self,request):
+        if self._decision(MemoryOperation.READ,request.actor).decision is PolicyDecision.REJECT:return ()
+        with self._lock:
+            now=_time(self._clock); rows=self._db.execute("SELECT r.record_id,r.revision,r.tenant_id,r.subject_id,r.actor_id,r.purpose,r.namespace,r.key_name,r.value,r.kind,r.lifecycle,r.policy_version,r.created_at,r.expires_at,r.deletion_epoch,r.digest,r.supersedes FROM memory_heads h JOIN memory_revisions r ON r.record_id=h.record_id AND r.revision=h.current_revision WHERE h.tenant_id=? AND h.subject_id=? AND h.purpose=? AND h.namespace=? AND h.key_name=? AND h.current_lifecycle='active' AND r.expires_at>? LIMIT ?",(request.actor.tenant_id,request.actor.subject_id,request.actor.purpose,request.namespace,request.query,now,request.maximum_results)).fetchall();return tuple(self._record(r) for r in rows)
+    def correct(self,actor,record_id,base_revision,proposal): return self._advance(MemoryOperation.CORRECT,actor,record_id,base_revision,proposal,proposal.idempotency_key)
+    def tombstone(self,actor,record_id,revision,idempotency_key=None): return self._advance(MemoryOperation.FORGET,actor,record_id,revision,None,idempotency_key or f"forget-{record_id}-{revision}")
+    def _advance(self,op,actor,rid,base,proposal,key):
+        if not _identifier(rid) or base<1:raise ValueError("invalid memory revision")
+        if self._decision(op,actor,proposal).decision is PolicyDecision.REJECT:return MemoryCommitResult(MemoryReason.POLICY_REJECTED)
+        digest=self._envelope(op,actor,rid,proposal,base)
         with self._lock:
             self._db.execute("BEGIN IMMEDIATE")
             try:
-                row = self._db.execute("SELECT record_id,revision,tenant_id,subject_id,actor_id,purpose,namespace,key_name,value,kind,lifecycle,policy_version,created_at,expires_at,deletion_epoch,digest,supersedes FROM memory_records WHERE record_id=? AND revision=? AND tenant_id=? AND subject_id=?", (record_id,revision,actor.tenant_id,actor.subject_id)).fetchone()
-                if row is None: self._db.execute("COMMIT"); return MemoryCommitResult(MemoryReason.NOT_FOUND)
-                old = self._row(row)
-                latest = self._db.execute("SELECT MAX(revision) FROM memory_records WHERE record_id=?", (record_id,)).fetchone()[0]
-                if latest != revision or old.lifecycle is not MemoryLifecycle.ACTIVE: self._db.execute("COMMIT"); return MemoryCommitResult(MemoryReason.CONFLICT)
-                data = asdict(old); data.update(revision=revision + 1, lifecycle=MemoryLifecycle.TOMBSTONED, deletion_epoch=old.deletion_epoch+1, supersedes=f"{record_id}:{revision}", created_at=self._clock().isoformat().replace("+00:00", "Z")); data["digest"] = _canonical_digest({k:v.value if isinstance(v,Enum) else v for k,v in data.items() if k != "digest"})
-                self._db.execute("INSERT INTO memory_records VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)", tuple(data[k].value if isinstance(data[k], Enum) else data[k] for k in ("record_id","revision","tenant_id","subject_id","actor_id","purpose","namespace","key","value","kind","lifecycle","policy_version","created_at","expires_at","deletion_epoch","digest","supersedes"))); self._event("tombstone",record_id,revision + 1,data["digest"],data["deletion_epoch"]); self._db.execute("COMMIT")
-                return MemoryCommitResult(MemoryReason.COMMITTED, self._row(tuple(data[k] for k in ("record_id","revision","tenant_id","subject_id","actor_id","purpose","namespace","key","value","kind","lifecycle","policy_version","created_at","expires_at","deletion_epoch","digest","supersedes"))), True)
-            except Exception: self._db.execute("ROLLBACK"); raise
-
-    def close(self) -> None:
+                prior=self._idempotent(actor,key,op,digest)
+                if prior is not None:self._db.execute("COMMIT");return prior
+                cur=self._current(actor,rid)
+                if cur.reason is not MemoryReason.COMMITTED:self._db.execute("COMMIT");return cur
+                old=cur.record
+                if old is None or old.revision!=base or old.lifecycle is not MemoryLifecycle.ACTIVE:self._db.execute("COMMIT");return MemoryCommitResult(MemoryReason.CONFLICT)
+                if proposal and (proposal.namespace!=old.namespace or proposal.key!=old.key):self._db.execute("COMMIT");return MemoryCommitResult(MemoryReason.CONFLICT)
+                now=_time(self._clock); deletion=old.deletion_epoch+(op is MemoryOperation.FORGET); lifecycle="tombstoned" if op is MemoryOperation.FORGET else "active"; data={"record_id":rid,"revision":base+1,"tenant_id":old.tenant_id,"subject_id":old.subject_id,"actor_id":actor.actor_id,"purpose":old.purpose,"namespace":old.namespace,"key":old.key,"value":None if op is MemoryOperation.FORGET else proposal.value,"kind":old.kind.value,"lifecycle":lifecycle,"policy_version":self._policy.version,"created_at":now,"expires_at":old.expires_at,"deletion_epoch":deletion,"supersedes":f"{rid}:{base}"};data["digest"]=_digest(data);self._insert_revision(data)
+                # Erase every retained payload revision in the same transaction; the head/tombstone remains.
+                if op is MemoryOperation.FORGET:self._db.execute("UPDATE memory_revisions SET value=NULL WHERE record_id=?",(rid,))
+                self._db.execute("UPDATE memory_heads SET current_revision=?,current_lifecycle=?,deletion_epoch=? WHERE record_id=?",(base+1,lifecycle,deletion,rid));self._db.execute("INSERT INTO memory_idempotency VALUES(?,?,?,?,?,?)",(actor.tenant_id,actor.subject_id,key,op.value,digest,rid));self._journal(op,data,digest);self._db.execute("COMMIT")
+                rec=self._record(tuple(data[k] for k in ("record_id","revision","tenant_id","subject_id","actor_id","purpose","namespace","key","value","kind","lifecycle","policy_version","created_at","expires_at","deletion_epoch","digest","supersedes")))
+                receipt=None if op is not MemoryOperation.FORGET else DeletionReceipt("del-"+uuid4().hex,DeletionState.COMPLETED,rid,base+1,deletion,self._policy.version,("sqlite_payloads","canonical_head"),("sqlite_payloads","canonical_head"))
+                return MemoryCommitResult(MemoryReason.COMMITTED,rec,False,receipt)
+            except Exception:self._db.execute("ROLLBACK");raise
+    def close(self):
         with self._lock:
-            if not self._closed: self._db.close(); self._closed = True
-
-
-class DisabledMemoryService:
-    def commit(self, actor: MemoryActor, proposal: MemoryWriteProposal) -> MemoryCommitResult: return MemoryCommitResult(MemoryReason.MEMORY_DISABLED)
-    def read(self, request: MemoryReadRequest) -> tuple[MemoryRecord, ...]: return ()
-    def tombstone(self, actor: MemoryActor, record_id: str, revision: int) -> MemoryCommitResult: return MemoryCommitResult(MemoryReason.MEMORY_DISABLED)
-    def correct(self, actor: MemoryActor, record_id: str, base_revision: int, proposal: MemoryWriteProposal) -> MemoryCommitResult: return MemoryCommitResult(MemoryReason.MEMORY_DISABLED)
-    def readiness(self) -> None: return None
-    def close(self) -> None: return None
-
+            if not self._closed:self._db.close();fcntl.flock(self._ownership.fileno(), fcntl.LOCK_UN);self._ownership.close();self._closed=True
 
 class GovernedMemoryService:
-    """Policy boundary: only explicit, authenticated preferences are supported."""
-    def __init__(self, repository: MemoryRepositoryPort) -> None: self._repository = repository
-    def remember(self, actor: MemoryActor, proposal: MemoryWriteProposal) -> MemoryCommitResult: return self._repository.commit(actor, proposal)
-    def retrieve(self, request: MemoryReadRequest) -> tuple[MemoryRecord, ...]: return self._repository.read(request)
-    def forget(self, actor: MemoryActor, record_id: str, revision: int) -> MemoryCommitResult: return self._repository.tombstone(actor, record_id, revision)
-    def correct(self, actor: MemoryActor, record_id: str, base_revision: int, proposal: MemoryWriteProposal) -> MemoryCommitResult: return self._repository.correct(actor, record_id, base_revision, proposal)
-    def readiness(self) -> None: self._repository.readiness()
-    def close(self) -> None: self._repository.close()
+    def __init__(self,repository:SQLiteMemoryRepository)->None:self._repository=repository
+    def remember(self,actor,proposal):return self._repository.commit(actor,proposal)
+    def retrieve(self,request):return self._repository.read(request)
+    def correct(self,actor,record_id,base_revision,proposal):return self._repository.correct(actor,record_id,base_revision,proposal)
+    def forget(self,actor,record_id,revision,idempotency_key=None):return self._repository.tombstone(actor,record_id,revision,idempotency_key)
+    def readiness(self):self._repository.readiness()
+    def close(self):self._repository.close()
+class DisabledMemoryService:
+    def remember(self,*args,**kwargs):return MemoryCommitResult(MemoryReason.MEMORY_DISABLED)
+    def retrieve(self,*args,**kwargs):return ()
+    def correct(self,*args,**kwargs):return MemoryCommitResult(MemoryReason.MEMORY_DISABLED)
+    def forget(self,*args,**kwargs):return MemoryCommitResult(MemoryReason.MEMORY_DISABLED)
+    def readiness(self):return None
+    def close(self):return None
 
-
-def compose_governed_memory() -> GovernedMemoryService | DisabledMemoryService:
-    if os.getenv("VULCAN_MEMORY_ENABLED", "0") != "1": return DisabledMemoryService()
-    path = os.getenv("VULCAN_MEMORY_SQLITE_PATH")
-    if not path: raise RuntimeError("VULCAN_MEMORY_SQLITE_PATH is required when durable memory is enabled")
-    # SQLite local storage has one writer process. Replica counts must be made
-    # explicit rather than hoping WAL makes an unsupported topology safe.
-    if os.getenv("VULCAN_RUNTIME_REPLICAS", "1") != "1": raise RuntimeError("SQLite governed memory supports exactly one runtime replica")
-    return GovernedMemoryService(SQLiteMemoryRepository(path))
+def compose_governed_memory(config: MemoryRuntimeConfig | None = None)->GovernedMemoryPort:
+    config = (config or MemoryRuntimeConfig.from_environment()).validated()
+    if not config.enabled:return DisabledMemoryService()
+    assert config.path is not None and config.durable_root is not None
+    return GovernedMemoryService(SQLiteMemoryRepository(str(config.path), durable_root=str(config.durable_root)))

--- a/src/vulcan/runtime/container.py
+++ b/src/vulcan/runtime/container.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import inspect
 from dataclasses import dataclass
 from typing import Any
-from vulcan.memory.governed import DisabledMemoryService, GovernedMemoryService, compose_governed_memory
+from vulcan.memory.governed import GovernedMemoryPort, compose_governed_memory
 from uuid import uuid4
 
 from .kernel import CognitiveKernel
@@ -19,7 +19,7 @@ class RuntimeContainer:
     world_state: Any
     kernel: CognitiveKernel
     safety: Any
-    memory: GovernedMemoryService | DisabledMemoryService
+    memory: GovernedMemoryPort
     closed: bool = False
 
     async def close(self) -> None:

--- a/src/vulcan/runtime/kernel.py
+++ b/src/vulcan/runtime/kernel.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from typing import Any
+from vulcan.memory.governed import GovernedMemoryPort
 from .case import CognitiveCase, CognitiveCaseStatus
 from .finalization import ResponseFinalizerPort
 from .semantic import (ClarificationRequest, DeterministicLanguageInput, LanguageInputPort, RESPONSE_IR_VERSION, ResponseIR, ResponseMode, Utterance, accept, execute, render_strict, validate_proposal)
@@ -19,7 +20,7 @@ class KernelResult:
     def transport(self, *, case_id: str, runtime_id: str, snapshot_id: str | None) -> dict[str, object]:
         return {"response": self.response, "metadata": {"case_id":case_id,"runtime_id":runtime_id,"state_snapshot_id":snapshot_id,"semantic_schema_version":self.response_ir.schema_version,"finalized":True,"finalization_safety_decision":self.finalization}}
 class CognitiveKernel:
-    def __init__(self, *, state_authority: Any, finalizer: ResponseFinalizerPort, language_input: LanguageInputPort | None = None, memory: Any | None = None) -> None:
+    def __init__(self, *, state_authority: Any, finalizer: ResponseFinalizerPort, language_input: LanguageInputPort | None = None, memory: GovernedMemoryPort | None = None) -> None:
         # The kernel owns the only memory port exposed to the production path.
         # It deliberately does not turn retrieved text into executable semantics.
         self._state_authority=state_authority; self._finalizer=finalizer; self._language_input=language_input or DeterministicLanguageInput(); self._memory=memory; self.calls=0

--- a/tests/security/test_governed_memory_architecture.py
+++ b/tests/security/test_governed_memory_architecture.py
@@ -1,0 +1,24 @@
+"""Architecture gates for the canonical governed-memory closure."""
+from pathlib import Path
+import pytest
+from vulcan.memory.governed import MemoryRuntimeConfig, SQLiteMemoryRepository
+
+ROOT = Path(__file__).resolve().parents[2]
+
+def test_runtime_does_not_import_legacy_memory_writers():
+    sources = (ROOT / "src/vulcan/runtime").glob("*.py")
+    forbidden = ("memory.persistence", "memory.retrieval", "memory.specialized", "memory.consolidation", "memory_bridge", "persistant_memory")
+    text = "\n".join(path.read_text() for path in sources)
+    assert not any(token in text for token in forbidden)
+
+def test_second_repository_cannot_own_the_same_sqlite_store(tmp_path):
+    first = SQLiteMemoryRepository(str(tmp_path / "preferences.sqlite"))
+    with pytest.raises(RuntimeError, match="already owned"):
+        SQLiteMemoryRepository(str(tmp_path / "preferences.sqlite"))
+    first.close()
+
+def test_governed_config_rejects_unsafe_or_multi_replica_topology(tmp_path):
+    with pytest.raises(RuntimeError):
+        MemoryRuntimeConfig(True, tmp_path / "p.sqlite", tmp_path, replicas=2).validated()
+    with pytest.raises(RuntimeError):
+        MemoryRuntimeConfig(True, Path("relative.sqlite"), tmp_path).validated()

--- a/tools/governed_memory_migrate.py
+++ b/tools/governed_memory_migrate.py
@@ -1,0 +1,13 @@
+"""Quarantine-only legacy migration entrypoint.
+
+Legacy memory formats are deliberately unsupported: this program never loads
+pickle/object payloads and reports a deterministic dry-run refusal instead.
+"""
+from __future__ import annotations
+import argparse, hashlib, json
+
+def main() -> int:
+    parser=argparse.ArgumentParser(); parser.add_argument("source"); parser.add_argument("--dry-run", action="store_true", required=True); args=parser.parse_args()
+    print(json.dumps({"source_digest":hashlib.sha256(args.source.encode()).hexdigest(),"imported":0,"quarantined":1,"reason":"legacy_migration_unsupported","raw_data_logged":False},sort_keys=True))
+    return 2
+if __name__ == "__main__": raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Establish a small, auditable, single-writer durable memory authority that stores only a bounded set of typed explicit preferences and isolates legacy memory systems.
- Harden operational safety by validating deployment topology, durable root paths, and enforcing single-replica SQLite ownership.
- Make the runtime configuration explicit and prevent accidental composition with legacy memory implementations.

### Description
- Implement a redesigned `vulcan.memory.governed` module: schema bumped to `governed-memory/2`, new `MemoryRuntimeConfig` for environment parsing/validation, typed models and enums, idempotency, immutable revision journal, authoritative `memory_heads`, and a file-based exclusive lock using `fcntl` to enforce single-writer ownership.
- Replace ad-hoc policy and repository interfaces with typed protocol boundaries (`MemoryPolicyPort`, `GovernedMemoryPort`) and provide `DefaultMemoryPolicy` plus `SQLiteMemoryRepository` with transactional create/correct/forget/read operations and deterministic digests.
- Update package exports, runtime wiring, and kernel/container typings to accept the new memory port; add `compose_governed_memory` to construct the configured service or return a disabled stub when not enabled.
- Add operational documentation and artifacts: ADR update (`docs/adr/0005-governed-durable-memory.md`), operations doc (`docs/memory/governed-memory-operations.md`), `docs/memory/legacy-inventory.json`, Helm values and deployment templates to expose governed memory env vars and to prevent enabling legacy `memorySystem` when governed memory is active, and a small quarantine-only migration tool (`tools/governed_memory_migrate.py`).
- Add architecture/security tests (`tests/security/test_governed_memory_architecture.py`) to assert runtime doesn’t import legacy writers and to validate exclusive SQLite ownership and config validation.

### Testing
- Ran the new security test module with `pytest tests/security/test_governed_memory_architecture.py` and it passed.
- Executed repository-level initialization and basic lifecycle operations via the tests (repository ownership and config validation) and observed expected success or raised `RuntimeError` where configured by design.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5989963e30832fa01a522904c561ee)