### PR TITLE
Harden canonical runtime lifecycle checks

### DIFF
--- a/src/vulcan/runtime/app.py
+++ b/src/vulcan/runtime/app.py
@@ -36,16 +36,28 @@ async def lifespan(app: FastAPI):
     # until all required services form one RuntimeContainer.
     app.state.ready = False
     app.state.runtime = None
+    runtime = None
     try:
         runtime = await asyncio.to_thread(compose_runtime)
+        await runtime.readiness()
         app.state.runtime = runtime
         app.state.ready = True
         yield
+    except BaseException:
+        # Composition can succeed while a subsequent graph health check fails.
+        # Do not leak that partially composed owner graph or publish readiness.
+        if runtime is not None:
+            try:
+                await runtime.close()
+            except BaseException:
+                pass
+        app.state.runtime = None
+        raise
     finally:
         app.state.ready = False
-        runtime = getattr(app.state, "runtime", None)
-        if runtime is not None:
-            await runtime.close()
+        active_runtime = getattr(app.state, "runtime", None)
+        if active_runtime is not None:
+            await active_runtime.close()
         app.state.runtime = None
 
 
@@ -115,7 +127,14 @@ def create_app() -> FastAPI:
         runtime = getattr(request.app.state, "runtime", None)
         if not getattr(request.app.state, "ready", False) or runtime is None:
             return JSONResponse(status_code=503, content={"status": "not_ready"})
-        return {"status": "ready", "runtime_id": runtime.runtime_id, "capabilities": ["bounded-arithmetic"]}
+        try:
+            await runtime.readiness()
+            capabilities = runtime.capabilities()
+        except Exception:
+            app = request.app
+            app.state.ready = False
+            return JSONResponse(status_code=503, content={"status": "not_ready"})
+        return {"status": "ready", "runtime_id": runtime.runtime_id, "capabilities": list(capabilities)}
 
     async def chat_handler(request: Request, body: UnifiedChatRequest):
         runtime = _runtime(request)

--- a/src/vulcan/runtime/container.py
+++ b/src/vulcan/runtime/container.py
@@ -41,16 +41,75 @@ class RuntimeContainer:
     closed: bool = False
 
     async def close(self) -> None:
-        """Release each owned resource once, in reverse construction order."""
+        """Release every owned resource once, preserving the first failure.
+
+        Shutdown is deliberately best-effort across the complete composed graph:
+        one broken legacy dependency must not leak the remaining owned handles.
+        The first error is re-raised *after* every close hook has been offered a
+        chance to run.
+        """
         if self.closed:
             return
         self.closed = True
-        for resource in (self.language_output, self.language_input, self.memory, self.deployment):
+        first_error: BaseException | None = None
+        seen: set[int] = set()
+        for resource in (
+            self.language_output,
+            self.language_input,
+            self.memory,
+            self.kernel,
+            self.safety,
+            self.world_state,
+            self.deployment,
+        ):
+            if id(resource) in seen:
+                continue
+            seen.add(id(resource))
             shutdown = getattr(resource, "close", None) or getattr(resource, "shutdown", None)
             if shutdown is not None:
-                result = shutdown()
+                try:
+                    result = shutdown()
+                    if inspect.isawaitable(result):
+                        await result
+                except BaseException as exc:  # continue closing all remaining owners
+                    if first_error is None:
+                        first_error = exc
+        if first_error is not None:
+            raise first_error
+
+    async def readiness(self) -> None:
+        """Verify the actual object graph rather than a route-local flag."""
+        if self.closed:
+            raise RuntimeError("canonical runtime is closed")
+        required = {
+            "deployment": self.deployment,
+            "world_state": self.world_state,
+            "kernel": self.kernel,
+            "safety": self.safety,
+            "memory": self.memory,
+            "language_input": self.language_input,
+            "language_output": self.language_output,
+        }
+        for name, owner in required.items():
+            if owner is None:
+                raise RuntimeError(f"required canonical {name} is unavailable")
+            check = getattr(owner, "readiness", None) or getattr(owner, "healthcheck", None)
+            if check is not None:
+                result = check()
                 if inspect.isawaitable(result):
-                    await result
+                    result = await result
+                if result is False:
+                    raise RuntimeError(f"required canonical {name} is unhealthy")
+
+    def capabilities(self) -> tuple[str, ...]:
+        """Return only capabilities supplied by the composed kernel object."""
+        advertised = getattr(self.kernel, "capabilities", None)
+        if not callable(advertised):
+            raise RuntimeError("canonical kernel does not expose its capabilities")
+        result = advertised()
+        if not isinstance(result, tuple) or not all(isinstance(value, str) for value in result):
+            raise RuntimeError("canonical kernel returned an invalid capability list")
+        return result
 
     @classmethod
     def new(cls, *, deployment: Any, language_config: LanguageRuntimeConfig | None = None) -> "RuntimeContainer":

--- a/src/vulcan/runtime/kernel.py
+++ b/src/vulcan/runtime/kernel.py
@@ -25,6 +25,9 @@ class CognitiveKernel:
         # The kernel owns the only memory port exposed to the production path.
         # It deliberately does not turn retrieved text into executable semantics.
         self._state_authority=state_authority; self._finalizer=finalizer; self._language_input=language_input or DeterministicLanguageInput(); self._language_output=language_output or DeterministicLanguageOutput(); self._memory=memory; self.calls=0
+    def capabilities(self) -> tuple[str, ...]:
+        """Capabilities implemented by this composed kernel, not marketing text."""
+        return ("bounded-arithmetic",)
     async def handle(self, request: KernelRequest, case: CognitiveCase) -> KernelResult:
         if case.terminal_status is not CognitiveCaseStatus.OPEN: raise RuntimeError("kernel received a closed cognitive case")
         if request.utterance.digest != case.input_hash or request.conversation_id != case.conversation_id: raise ValueError("request/case correlation mismatch")

--- a/tests/security/test_runtime_convergence.py
+++ b/tests/security/test_runtime_convergence.py
@@ -58,6 +58,39 @@ def test_container_fails_closed_without_canonical_world_state():
         RuntimeContainer.new(deployment=_deployment(world=None))
 
 
+@pytest.mark.asyncio
+async def test_readiness_fails_when_an_owned_port_reports_unhealthy():
+    runtime = RuntimeContainer.new(deployment=_deployment())
+    runtime.memory.readiness = lambda: False
+    with pytest.raises(RuntimeError, match="memory is unhealthy"):
+        await runtime.readiness()
+
+
+@pytest.mark.asyncio
+async def test_close_attempts_every_owner_after_a_close_failure():
+    closed: list[str] = []
+
+    class _Resource:
+        def __init__(self, name: str, broken: bool = False):
+            self.name, self.broken = name, broken
+        def close(self):
+            closed.append(self.name)
+            if self.broken:
+                raise RuntimeError(self.name)
+
+    runtime = RuntimeContainer.new(deployment=_deployment())
+    runtime.language_output = _Resource("output", broken=True)
+    runtime.language_input = _Resource("input")
+    runtime.memory = _Resource("memory")
+    runtime.kernel = _Resource("kernel")
+    runtime.safety = _Resource("safety")
+    runtime.world_state = _Resource("world")
+    runtime.deployment = _Resource("deployment")
+    with pytest.raises(RuntimeError, match="output"):
+        await runtime.close()
+    assert closed == ["output", "input", "memory", "kernel", "safety", "world", "deployment"]
+
+
 def test_production_docker_uses_canonical_package_identity():
     dockerfile = open("Dockerfile", encoding="utf-8").read()
     assert "uvicorn vulcan.runtime.app:app" in dockerfile


### PR DESCRIPTION
### Motivation
- The canonical runtime exposed readiness via a route-local flag and advertised a static capability list, which could make a partially-composed graph appear ready. 
- Shutdown stopped on the first owner failure, risking leaked handles and inconsistent cleanup when composition succeeded but a subsequent health check failed.

### Description
- Make `RuntimeContainer.close` best-effort: attempt to close every owned resource, deduplicate shared owners, and re-raise only the first observed error after all close hooks run (`src/vulcan/runtime/container.py`).
- Add `RuntimeContainer.readiness` to verify the composed object graph and run per-owner `readiness`/`healthcheck` hooks, failing if any required owner is missing or unhealthy (`src/vulcan/runtime/container.py`).
- Replace the static capability list with kernel-provided capabilities via a new `CognitiveKernel.capabilities` method and use that in readiness responses (`src/vulcan/runtime/kernel.py`, `src/vulcan/runtime/app.py`).
- Harden ASGI lifespan: verify graph readiness before setting `app.state.ready`, clean up partially-composed runtimes on failure, and recheck readiness in `/health/ready` (also updated to call `runtime.readiness()` and report kernel-derived capabilities) (`src/vulcan/runtime/app.py`).
- Add adversarial regression tests for unhealthy owned ports and for ensuring `close` continues after a first failure (`tests/security/test_runtime_convergence.py`).

### Testing
- Ran static compilation in both normal and optimized modes: `PYTHONPATH=src python -m compileall -q src/vulcan/runtime tests/security/test_runtime_convergence.py` and `PYTHONPATH=src python -O -m compileall -q src/vulcan/runtime tests/security/test_runtime_convergence.py` — both passed.
- Executed a dependency-light runtime lifecycle diagnostic (composition, `readiness()`, capability derivation, shutdown continuation, and first-error propagation) — passed.
- Ran `git diff --check` and local diff validation — passed.
- Attempted full pytest selection including security/semantic/memory/language tests but test collection failed due to missing runtime dependencies (`numpy` and `fastapi`) in the environment; those suites were not executed and are recorded as unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a8159c6bc832fa90380995b06aaee)