### PR TITLE
Harden Graphix and semantic ledger invariants

### DIFF
--- a/src/platform/__init__.py
+++ b/src/platform/__init__.py
@@ -1,7 +1,38 @@
-"""Platform package for Vulcan AMI unified platform."""
-from src.platform.auth import AuthMethod, JWTAuth, AuthenticationError
-from src.platform.secrets import SecretsManager
-from src.platform.settings import UnifiedPlatformSettings
-from src.platform.session import FlashMessage, FlashMessageManager
-from src.platform.service_imports import ServiceImportResult, import_service_async, check_service_health_async
-from src.platform.service_lifecycle import stop_service, start_service
+"""Platform package for Vulcan AMI unified platform.
+
+This package name collides with Python's stdlib ``platform`` module when the
+repository ``src`` directory is on ``PYTHONPATH``.  Expose the stdlib surface
+needed by tooling and keep Vulcan-specific exports lazy so dependency-light test
+collection does not import web/research stacks.
+"""
+from __future__ import annotations
+
+import importlib.util as _util
+import sysconfig as _sysconfig
+from pathlib import Path as _Path
+
+_stdlib_platform = _Path(_sysconfig.get_path("stdlib")) / "platform.py"
+_spec = _util.spec_from_file_location("_stdlib_platform", _stdlib_platform)
+if _spec and _spec.loader:
+    _module = _util.module_from_spec(_spec)
+    _spec.loader.exec_module(_module)
+    for _name in dir(_module):
+        if not _name.startswith("_"):
+            globals().setdefault(_name, getattr(_module, _name))
+
+_LAZY = {
+    "AuthMethod": ".auth", "JWTAuth": ".auth", "AuthenticationError": ".auth",
+    "SecretsManager": ".secrets", "UnifiedPlatformSettings": ".settings",
+    "FlashMessage": ".session", "FlashMessageManager": ".session",
+    "ServiceImportResult": ".service_imports", "import_service_async": ".service_imports",
+    "check_service_health_async": ".service_imports", "stop_service": ".service_lifecycle",
+    "start_service": ".service_lifecycle",
+}
+
+
+def __getattr__(name: str):
+    module_name = _LAZY.get(name)
+    if module_name is None:
+        raise AttributeError(name)
+    from importlib import import_module
+    return getattr(import_module(module_name, __name__), name)

--- a/src/vulcan/__init__.py
+++ b/src/vulcan/__init__.py
@@ -1,256 +1,30 @@
-"""
-VULCAN-AGI: Volumetric Unified Learning Cognitive Architecture Network
+"""Lightweight package root for VULCAN.
 
-A production-grade AGI system integrating multiple cognitive architectures:
-- Memory: Hierarchical, distributed memory systems
-- Reasoning: Multi-paradigm reasoning (symbolic, probabilistic, causal, analogical)
-- Learning: Continual, curriculum, meta-learning with RLHF
-- Safety: Comprehensive safety validation and governance
-- Routing: Dual-mode query routing with collaboration support
-- Curiosity Engine: Autonomous knowledge gap exploration
-- Problem Decomposer: Hierarchical problem decomposition
-- Knowledge Crystallizer: Extract and store crystallized knowledge principles
-
-All modules export their key classes and provide availability flags for
-graceful degradation when dependencies are missing.
+Canonical runtime and security tests must be importable without optional neural,
+research, web, or graph dependencies.  Heavy historical subsystems remain
+available through their explicit submodule paths instead of being imported as a
+side effect of ``import vulcan``.
 """
 
-import logging
+from __future__ import annotations
 
-logger = logging.getLogger(__name__)
-
-# Version info
 __version__ = "2.0.0"
 __author__ = "Vulcan AI Team"
 
-# ============================================================================
-# MEMORY MODULE
-# ============================================================================
-try:
-    from .memory import (
-        Memory,
-        MemoryConfig,
-        MemoryType,
-        HierarchicalMemory,
-        DistributedMemory,
-        MemoryIndex,
-        VectorMemoryStore,
-        EpisodicMemory,
-        SemanticMemory,
-        ProceduralMemory,
-        WorkingMemory,
-    )
-
-    MEMORY_AVAILABLE = True
-except ImportError as e:
-    logger.warning(f"Memory module not available: {e}")
-    MEMORY_AVAILABLE = False
-
-# ============================================================================
-# REASONING MODULE
-# ============================================================================
-try:
-    from .reasoning import (
-        UnifiedReasoner,
-        ReasoningType,
-        ReasoningStrategy,
-        ProbabilisticReasoner,
-        CausalReasoner,
-        SymbolicReasoner,
-        AnalogicalReasoner,
-        MultimodalReasoner,
-        UNIFIED_AVAILABLE,
-        PROBABILISTIC_AVAILABLE,
-        CAUSAL_AVAILABLE,
-        SYMBOLIC_AVAILABLE,
-        ANALOGICAL_AVAILABLE,
-        MULTIMODAL_AVAILABLE,
-    )
-
-    REASONING_AVAILABLE = UNIFIED_AVAILABLE
-except ImportError as e:
-    logger.warning(f"Reasoning module not available: {e}")
-    REASONING_AVAILABLE = False
-    UNIFIED_AVAILABLE = False
-    PROBABILISTIC_AVAILABLE = False
-    CAUSAL_AVAILABLE = False
-    SYMBOLIC_AVAILABLE = False
-    ANALOGICAL_AVAILABLE = False
-    MULTIMODAL_AVAILABLE = False
-
-# ============================================================================
-# LEARNING MODULE
-# ============================================================================
-try:
-    from .learning import (
-        UnifiedLearningSystem,
-        CurriculumLearner,
-        LearningConfig,
-        LearningMode,
-    )
-
-    LEARNING_AVAILABLE = True
-except ImportError as e:
-    logger.warning(f"Learning module not available: {e}")
-    LEARNING_AVAILABLE = False
-
-# ============================================================================
-# ROUTING MODULE - Query Routing and Dual-Mode Learning
-# ============================================================================
-try:
-    from .routing import (
-        route_query,
-        analyze_query,
-        QueryAnalyzer,
-        QueryPlan,
-        ProcessingPlan,
-        QueryType,
-        LearningMode as RoutingLearningMode,
-        trigger_agent_collaboration,
-        record_telemetry,
-        log_to_governance,
-        initialize_routing_components,
-        get_routing_status,
-        QUERY_ROUTER_AVAILABLE,
-        COLLABORATION_AVAILABLE,
-        TELEMETRY_AVAILABLE,
-        GOVERNANCE_AVAILABLE,
-    )
-
-    ROUTING_AVAILABLE = QUERY_ROUTER_AVAILABLE
-except ImportError as e:
-    logger.warning(f"Routing module not available: {e}")
-    ROUTING_AVAILABLE = False
-    QUERY_ROUTER_AVAILABLE = False
-    COLLABORATION_AVAILABLE = False
-    TELEMETRY_AVAILABLE = False
-    GOVERNANCE_AVAILABLE = False
-
-# ============================================================================
-# CURIOSITY ENGINE MODULE
-# ============================================================================
-try:
-    from .curiosity_engine import (
-        CuriosityEngine,
-        GapAnalyzer,
-        ExperimentGenerator,
-        KnowledgeGap,
-        Experiment,
-        CURIOSITY_ENGINE_AVAILABLE,
-        GAP_ANALYZER_AVAILABLE,
-        EXPERIMENT_GENERATOR_AVAILABLE,
-    )
-
-    CURIOSITY_AVAILABLE = CURIOSITY_ENGINE_AVAILABLE
-except ImportError as e:
-    logger.warning(f"Curiosity engine module not available: {e}")
-    CURIOSITY_AVAILABLE = False
-    CURIOSITY_ENGINE_AVAILABLE = False
-    GAP_ANALYZER_AVAILABLE = False
-    EXPERIMENT_GENERATOR_AVAILABLE = False
-
-# ============================================================================
-# PROBLEM DECOMPOSER MODULE
-# ============================================================================
-try:
-    from .problem_decomposer import (
-        ProblemDecomposer,
-        DecompositionMode,
-        DecompositionPlan,
-        ProblemExecutor,
-        FallbackChain,
-        DecompositionLibrary,
-        PROBLEM_DECOMPOSER_AVAILABLE,
-        STRATEGIES_AVAILABLE,
-        EXECUTOR_AVAILABLE,
-    )
-
-    DECOMPOSER_AVAILABLE = PROBLEM_DECOMPOSER_AVAILABLE
-except ImportError as e:
-    logger.warning(f"Problem decomposer module not available: {e}")
-    DECOMPOSER_AVAILABLE = False
-    PROBLEM_DECOMPOSER_AVAILABLE = False
-    STRATEGIES_AVAILABLE = False
-    EXECUTOR_AVAILABLE = False
-
-# ============================================================================
-# KNOWLEDGE CRYSTALLIZER MODULE
-# ============================================================================
-try:
-    from .knowledge_crystallizer import (
-        KnowledgeCrystallizer,
-        KnowledgeApplicator,
-        PrincipleExtractor,
-        KnowledgeValidator,
-        VersionedKnowledgeBase,
-        CrystallizationSelector,
-        ContraindicationDatabase,
-        KNOWLEDGE_CRYSTALLIZER_AVAILABLE,
-        PRINCIPLE_EXTRACTOR_AVAILABLE,
-        VALIDATION_ENGINE_AVAILABLE,
-        KNOWLEDGE_STORAGE_AVAILABLE,
-        CRYSTALLIZATION_SELECTOR_AVAILABLE,
-        CONTRAINDICATION_TRACKER_AVAILABLE,
-    )
-
-    CRYSTALLIZER_AVAILABLE = KNOWLEDGE_CRYSTALLIZER_AVAILABLE
-except ImportError as e:
-    logger.warning(f"Knowledge crystallizer module not available: {e}")
-    CRYSTALLIZER_AVAILABLE = False
-    KNOWLEDGE_CRYSTALLIZER_AVAILABLE = False
-    PRINCIPLE_EXTRACTOR_AVAILABLE = False
-    VALIDATION_ENGINE_AVAILABLE = False
-    KNOWLEDGE_STORAGE_AVAILABLE = False
-    CRYSTALLIZATION_SELECTOR_AVAILABLE = False
-    CONTRAINDICATION_TRACKER_AVAILABLE = False
-
-# ============================================================================
-# SAFETY MODULE
-# ============================================================================
-try:
-    from .safety import (
-        SAFETY_VALIDATOR_AVAILABLE,
-        GOVERNANCE_ORCHESTRATOR_AVAILABLE,
-        get_safety_validator,
-        SafetyUnavailable,
-    )
-
-    SAFETY_AVAILABLE = SAFETY_VALIDATOR_AVAILABLE
-except ImportError as e:
-    logger.warning(f"Safety module not available: {e}")
-    SAFETY_AVAILABLE = False
-    SAFETY_VALIDATOR_AVAILABLE = False
-    GOVERNANCE_ORCHESTRATOR_AVAILABLE = False
-
-# ============================================================================
-# CONFIG MODULE
-# ============================================================================
-try:
-    from .config import AgentConfig, get_config
-
-    CONFIG_AVAILABLE = True
-except ImportError as e:
-    logger.warning(f"Config module not available: {e}")
-    CONFIG_AVAILABLE = False
-
-# ============================================================================
-# ORCHESTRATOR MODULE
-# ============================================================================
-try:
-    from .orchestrator import ProductionDeployment
-
-    ORCHESTRATOR_AVAILABLE = True
-except ImportError as e:
-    logger.warning(f"Orchestrator module not available: {e}")
-    ORCHESTRATOR_AVAILABLE = False
-
-# ============================================================================
-# MODULE STATUS
-# ============================================================================
+MEMORY_AVAILABLE = False
+REASONING_AVAILABLE = False
+LEARNING_AVAILABLE = False
+ROUTING_AVAILABLE = False
+CURIOSITY_AVAILABLE = False
+DECOMPOSER_AVAILABLE = False
+CRYSTALLIZER_AVAILABLE = False
+SAFETY_AVAILABLE = False
+CONFIG_AVAILABLE = False
+ORCHESTRATOR_AVAILABLE = False
 
 
 def get_vulcan_status() -> dict:
-    """Get availability status of all VULCAN components."""
+    """Get availability status without importing optional subsystems."""
     return {
         "version": __version__,
         "memory": MEMORY_AVAILABLE,
@@ -266,65 +40,15 @@ def get_vulcan_status() -> dict:
     }
 
 
-def print_vulcan_status():
-    """Print a formatted status report of all VULCAN components."""
+def print_vulcan_status() -> None:
     status = get_vulcan_status()
-    print("\n" + "=" * 60)
-    print(f"VULCAN-AGI Module Status (v{status['version']})")
-    print("=" * 60)
+    print(status)
 
-    for component, available in status.items():
-        if component == "version":
-            continue
-        status_icon = "✓" if available else "✗"
-        status_text = "Available" if available else "Not Available"
-        print(f"{status_icon} {component.capitalize():15s}: {status_text}")
-
-    print("=" * 60)
-
-    available_count = sum(1 for k, v in status.items() if k != "version" and v)
-    total_count = len(status) - 1  # Exclude version
-    print(f"Total: {available_count}/{total_count} components available")
-    print("=" * 60 + "\n")
-
-
-# ============================================================================
-# PUBLIC API EXPORTS
-# ============================================================================
 
 __all__ = [
-    # Version
-    "__version__",
-    # Status functions
-    "get_vulcan_status",
-    "print_vulcan_status",
-    # Availability flags
-    "MEMORY_AVAILABLE",
-    "REASONING_AVAILABLE",
-    "LEARNING_AVAILABLE",
-    "ROUTING_AVAILABLE",
-    "CURIOSITY_AVAILABLE",
-    "DECOMPOSER_AVAILABLE",
-    "CRYSTALLIZER_AVAILABLE",
-    "SAFETY_AVAILABLE",
-    "CONFIG_AVAILABLE",
+    "__version__", "get_vulcan_status", "print_vulcan_status",
+    "MEMORY_AVAILABLE", "REASONING_AVAILABLE", "LEARNING_AVAILABLE",
+    "ROUTING_AVAILABLE", "CURIOSITY_AVAILABLE", "DECOMPOSER_AVAILABLE",
+    "CRYSTALLIZER_AVAILABLE", "SAFETY_AVAILABLE", "CONFIG_AVAILABLE",
     "ORCHESTRATOR_AVAILABLE",
 ]
-
-# Log initialization
-available_count = sum(
-    [
-        MEMORY_AVAILABLE,
-        REASONING_AVAILABLE,
-        LEARNING_AVAILABLE,
-        ROUTING_AVAILABLE,
-        CURIOSITY_AVAILABLE,
-        DECOMPOSER_AVAILABLE,
-        CRYSTALLIZER_AVAILABLE,
-        SAFETY_AVAILABLE,
-    ]
-)
-
-logger.info(
-    f"VULCAN-AGI v{__version__} initialized: {available_count}/8 core modules available"
-)

--- a/src/vulcan/runtime/case.py
+++ b/src/vulcan/runtime/case.py
@@ -92,7 +92,7 @@ class CognitiveCase:
         proposed_evidence = (*self._evidence, *evidence)
         proposed_derivations = (*self._derivations, derivation)
         proposed_claims = (*self._claims, claim)
-        validate_ledger(proposed_evidence, proposed_derivations, proposed_claims)
+        validate_ledger(proposed_evidence, proposed_derivations, proposed_claims, case_id=self.case_id)
         self._evidence.extend(evidence)
         self._derivations.append(derivation)
         self._claims.append(claim)

--- a/src/vulcan/runtime/kernel.py
+++ b/src/vulcan/runtime/kernel.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from typing import Any
-from vulcan.memory.governed import GovernedMemoryPort
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from vulcan.memory.governed import GovernedMemoryPort
 from .case import CognitiveCase, CognitiveCaseStatus
 from .finalization import ResponseFinalizerPort
-from .semantic import (ClarificationRequest, DeterministicLanguageInput, LanguageInputPort, RESPONSE_IR_VERSION, ResponseIR, ResponseMode, Utterance, accept, execute, render_strict, validate_proposal)
+from .semantic import (ClarificationRequest, DeterministicLanguageInput, LanguageInputPort, RESPONSE_IR_VERSION, ResponseIR, ResponseMode, Utterance, accept, build_graphix_plan, compile_graphix_plan, execute, execute_graphix_plan, render_strict, validate_proposal)
 from .output import DeterministicLanguageOutput, LanguageOutputPort, SemanticFirewall, project
 @dataclass(frozen=True)
 class KernelRequest:
@@ -21,7 +23,7 @@ class KernelResult:
     def transport(self, *, case_id: str, runtime_id: str, snapshot_id: str | None) -> dict[str, object]:
         return {"response": self.response, "metadata": {"case_id":case_id,"runtime_id":runtime_id,"state_snapshot_id":snapshot_id,"semantic_schema_version":self.response_ir.schema_version,"finalized":True,"finalization_safety_decision":self.finalization}}
 class CognitiveKernel:
-    def __init__(self, *, state_authority: Any, finalizer: ResponseFinalizerPort, language_input: LanguageInputPort | None = None, language_output: LanguageOutputPort | None = None, memory: GovernedMemoryPort | None = None) -> None:
+    def __init__(self, *, state_authority: Any, finalizer: ResponseFinalizerPort, language_input: LanguageInputPort | None = None, language_output: LanguageOutputPort | None = None, memory: "GovernedMemoryPort | None" = None) -> None:
         # The kernel owns the only memory port exposed to the production path.
         # It deliberately does not turn retrieved text into executable semantics.
         self._state_authority=state_authority; self._finalizer=finalizer; self._language_input=language_input or DeterministicLanguageInput(); self._language_output=language_output or DeterministicLanguageOutput(); self._memory=memory; self.calls=0
@@ -49,8 +51,13 @@ class CognitiveKernel:
                 claim, derivation=execute(type("Unsupported", (), {"operation":"unsupported", "expression":"", "assumptions":()})())
                 case.append_ledger(claim=claim,derivation=derivation); mode=ResponseMode.CLARIFICATION; status=CognitiveCaseStatus.ABSTAINED; accepted_id=None
             else:
-                case.accepted_interpretation=selection; claim,derivation=execute(selection,case_id=case.case_id); case.append_ledger(claim=claim,derivation=derivation)
-                mode=ResponseMode.STRICT if claim.status.value=="computed" else ResponseMode.UNKNOWN; status=CognitiveCaseStatus.SUCCESS if mode is ResponseMode.STRICT else CognitiveCaseStatus.ABSTAINED; accepted_id=selection.interpretation_id
+                case.accepted_interpretation=selection
+                domain_snapshot_id=getattr(getattr(self._state_authority,"domain",None),"domain_snapshot_id","domain:none")
+                plan=build_graphix_plan(selection, request_digest=request.utterance.digest, state_snapshot_id=case.state_snapshot_id or "", domain_snapshot_id=domain_snapshot_id)
+                compiled=compile_graphix_plan(plan, request_digest=request.utterance.digest, state_snapshot_id=case.state_snapshot_id or "", domain_snapshot_id=domain_snapshot_id)
+                claim,derivation,evidence=execute_graphix_plan(compiled, request_digest=request.utterance.digest, state_snapshot_id=case.state_snapshot_id or "", domain_snapshot_id=domain_snapshot_id, case_id=case.case_id, domain=getattr(self._state_authority,"domain",None))
+                case.append_ledger(claim=claim,derivation=derivation,evidence=evidence)
+                mode=ResponseMode.STRICT if claim.status.value in {"computed","retrieved"} else ResponseMode.UNKNOWN; status=CognitiveCaseStatus.SUCCESS if mode is ResponseMode.STRICT else CognitiveCaseStatus.ABSTAINED; accepted_id=selection.interpretation_id
             response_ir=ResponseIR(RESPONSE_IR_VERSION,f"response-{case.case_id}",case.case_id,accepted_id,case.state_snapshot_id,mode,(claim.claim_id,))
             case.response_ir=response_ir
             # The adapter sees only the projection; firewall rejection is always strict fallback.

--- a/src/vulcan/runtime/semantic.py
+++ b/src/vulcan/runtime/semantic.py
@@ -12,7 +12,7 @@ import math
 import operator
 import re
 import unicodedata
-from dataclasses import asdict, dataclass, is_dataclass
+from dataclasses import asdict, dataclass, is_dataclass, replace
 from datetime import datetime, timezone
 from enum import Enum
 from fractions import Fraction
@@ -37,6 +37,14 @@ class EvidenceKind(str, Enum):
     SOURCE_DOCUMENT="source_document"; SOURCE_EXCERPT="source_excerpt"; OBSERVATION="observation"; TOOL_OUTPUT="tool_output"; RETRIEVED_RECORD="retrieved_record"; FORMAL_PREMISE="formal_premise"; USER_ASSERTION="user_assertion"; POLICY_FACT="policy_fact"; STATE_SNAPSHOT="state_snapshot"
 class ExecutionStatus(str, Enum): SUCCESS="success"; PARTIAL="partial"; NOT_APPLICABLE="not_applicable"; UNKNOWN="unknown"; ERROR="error"; CANCELLED="cancelled"
 class ResponseMode(str, Enum): STRICT="strict"; CLARIFICATION="clarification"; PARTIAL="partial"; UNKNOWN="unknown"; ERROR="error"; ACTION_CONFIRMATION="action_confirmation"
+
+@dataclass(frozen=True)
+class GraphixPlan:
+    schema_version: str; plan_id: str; operation: str; request_digest: str; state_snapshot_id: str; domain_snapshot_id: str; operands: tuple[tuple[str, str], ...]; parameters: tuple[tuple[str, str], ...] = ()
+
+@dataclass(frozen=True)
+class CompiledGraphixPlan:
+    plan: GraphixPlan; plan_digest: str
 
 @dataclass(frozen=True)
 class Utterance:
@@ -78,6 +86,10 @@ class InterpretationProposal:
 
 class LanguageInputPort(Protocol):
     async def propose(self, utterance: Utterance) -> InterpretationProposal: ...
+
+class DomainLookupPort(Protocol):
+    domain_snapshot_id: str
+    def lookup_exact(self, key: str) -> tuple[str, str | None]: ...
 
 @dataclass(frozen=True)
 class InterpretationBundle:
@@ -147,7 +159,7 @@ def validate_proposal(utterance: Utterance, proposal: InterpretationProposal) ->
         raise ValueError("unsupported interpretation proposal")
     validated: list[ProposedCandidate] = []
     for candidate in proposal.candidates:
-        if candidate.operation not in {"arithmetic", "unsupported"} or not _valid_text(candidate.expression):
+        if candidate.operation not in {"arithmetic", "lookup", "memory_read", "memory_write", "memory_forget", "unsupported"} or not _valid_text(candidate.expression):
             raise ValueError("unsupported proposal operation")
         if candidate.diagnostic_confidence is not None and (not isinstance(candidate.diagnostic_confidence, float) or not math.isfinite(candidate.diagnostic_confidence)):
             raise ValueError("invalid proposal confidence")
@@ -164,6 +176,8 @@ def accept(bundle: InterpretationBundle) -> AcceptedInterpretation | Clarificati
     if len(bundle.candidates) != 1:
         return ClarificationRequest("interpretation", "Please provide one supported, unambiguous request.", f"clarification-{uuid4().hex}")
     candidate = bundle.candidates[0]
+    if candidate.operation == "unsupported":
+        return ClarificationRequest("interpretation", "Please provide one supported, unambiguous request.", f"clarification-{uuid4().hex}")
     return AcceptedInterpretation(0, candidate.operation, candidate.expression, f"accepted-{uuid4().hex}")
 
 _BIN = {ast.Add: operator.add, ast.Sub: operator.sub, ast.Mult: operator.mul, ast.Div: operator.truediv, ast.Mod: operator.mod, ast.Pow: operator.pow}
@@ -200,25 +214,95 @@ def execute(accepted: AcceptedInterpretation, *, case_id: str = "case") -> tuple
         return Claim(cid, Proposition(accepted.expression, "evaluates_to", value, expression=accepted.expression), EpistemicStatus.COMPUTED, derivation_ids=(did,), assumptions=accepted.assumptions), derivation
     except (SyntaxError, ValueError, OverflowError):
         derivation = Derivation(did, "bounded-arithmetic-ast", "2", (), cid, (), (), True, ExecutionStatus.NOT_APPLICABLE, "", "unsupported or bounded expression")
-        return Claim(cid, Proposition("request", "support", "unsupported"), EpistemicStatus.UNKNOWN, caveat="No factual result was inferred."), derivation
+        return Claim(cid, Proposition("request", "support", "unsupported"), EpistemicStatus.UNKNOWN, derivation_ids=(did,), caveat="No factual result was inferred."), derivation
 
-def validate_ledger(evidence: tuple[EvidenceArtifact, ...], derivations: tuple[Derivation, ...], claims: tuple[Claim, ...]) -> None:
+def build_graphix_plan(accepted: AcceptedInterpretation, *, request_digest: str, state_snapshot_id: str, domain_snapshot_id: str = "domain:none") -> GraphixPlan:
+    if accepted.operation == "arithmetic":
+        operands = (("expression", accepted.expression),)
+    elif accepted.operation == "lookup":
+        operands = (("key", accepted.expression),)
+    elif accepted.operation in {"memory_read", "memory_write", "memory_forget"}:
+        operands = (("request_span", accepted.expression),)
+    else:
+        raise ValueError("unsupported operation")
+    return GraphixPlan("graphix-plan/1", f"plan-{uuid4().hex}", accepted.operation, request_digest, state_snapshot_id, domain_snapshot_id, operands)
+
+def compile_graphix_plan(plan: GraphixPlan, *, request_digest: str, state_snapshot_id: str, domain_snapshot_id: str) -> CompiledGraphixPlan:
+    _validate_graphix_plan(plan, request_digest=request_digest, state_snapshot_id=state_snapshot_id, domain_snapshot_id=domain_snapshot_id)
+    return CompiledGraphixPlan(plan, canonical_digest(plan))
+
+def _operand(plan: GraphixPlan, name: str) -> str:
+    matches = [v for k, v in plan.operands if k == name]
+    if len(matches) != 1: raise ValueError("invalid operands")
+    return matches[0]
+
+def _validate_graphix_plan(plan: GraphixPlan, *, request_digest: str, state_snapshot_id: str, domain_snapshot_id: str) -> None:
+    if plan.schema_version != "graphix-plan/1" or not re.fullmatch(r"plan-[0-9a-f]{32}", plan.plan_id): raise ValueError("invalid plan identity")
+    if plan.request_digest != request_digest or plan.state_snapshot_id != state_snapshot_id or plan.domain_snapshot_id != domain_snapshot_id: raise ValueError("plan snapshot mismatch")
+    if plan.operation not in {"arithmetic", "lookup", "memory_read", "memory_write", "memory_forget"}: raise ValueError("operation is not closed")
+    if plan.parameters: raise ValueError("plan parameters are closed")
+    keys = [k for k, _ in plan.operands]
+    if len(keys) != len(set(keys)) or not keys: raise ValueError("invalid operands")
+    if any(k in {"domain_hint", "domain_filter", "evidence_domain", "answer", "evidence", "code"} for k, _ in plan.operands): raise ValueError("evidence selection override rejected")
+    for key, value in plan.operands:
+        if not _valid_text(key, 64) or not _valid_text(value, MAX_REFERENCE): raise ValueError("invalid operand text")
+    if plan.operation == "arithmetic" and set(keys) != {"expression"}: raise ValueError("invalid arithmetic operands")
+    if plan.operation == "lookup" and set(keys) != {"key"}: raise ValueError("invalid lookup operands")
+
+def execute_graphix_plan(compiled: CompiledGraphixPlan, *, request_digest: str, state_snapshot_id: str, domain_snapshot_id: str, case_id: str = "case", domain: DomainLookupPort | None = None) -> tuple[Claim, Derivation, tuple[EvidenceArtifact, ...]]:
+    if canonical_digest(compiled.plan) != compiled.plan_digest: raise ValueError("compiled plan was mutated")
+    _validate_graphix_plan(compiled.plan, request_digest=request_digest, state_snapshot_id=state_snapshot_id, domain_snapshot_id=domain_snapshot_id)
+    accepted = AcceptedInterpretation(0, compiled.plan.operation, _operand(compiled.plan, "expression") if compiled.plan.operation == "arithmetic" else _operand(compiled.plan, "key"), compiled.plan.plan_id)
+    if compiled.plan.operation == "arithmetic":
+        claim, derivation = execute(accepted, case_id=case_id)
+        return claim, derivation, ()
+    if compiled.plan.operation == "lookup":
+        if domain is None or getattr(domain, "domain_snapshot_id", None) != domain_snapshot_id: raise ValueError("domain snapshot mismatch")
+        value, citation = domain.lookup_exact(accepted.expression)
+        if not _valid_text(value): raise ValueError("lookup miss")
+        eid, cid, did = f"evidence-{uuid4().hex}", f"claim-{uuid4().hex}", f"derivation-{uuid4().hex}"
+        ev = EvidenceArtifact(eid, EvidenceKind.RETRIEVED_RECORD, canonical_digest(value), citation or f"domain:{domain_snapshot_id}:{accepted.expression}", "injected-domain-port", "exact-key", case_id, state_snapshot_id=state_snapshot_id, observed_at=datetime.now(timezone.utc), source_integrity="digest-verified", trust_policy="domain-port", citation=citation)
+        der = Derivation(did, "exact-domain-lookup", "1", (eid,), cid, (), (("key", accepted.expression),), True, ExecutionStatus.SUCCESS, canonical_digest((accepted.expression, value)))
+        cl = Claim(cid, Proposition(accepted.expression, "lookup_value", value), EpistemicStatus.RETRIEVED, (eid,), (did,), citation_ids=(eid,), temporal_validity="snapshot-bound")
+        return cl, der, (ev,)
+    raise ValueError("unsupported canonical operation")
+
+def _bounded_id(value: str) -> bool:
+    return isinstance(value, str) and 1 <= len(value) <= 96 and re.fullmatch(r"[A-Za-z0-9_.:-]+", value) is not None
+
+def validate_ledger(evidence: tuple[EvidenceArtifact, ...], derivations: tuple[Derivation, ...], claims: tuple[Claim, ...], *, case_id: str | None = None) -> None:
     eids, dids, cids = {e.artifact_id for e in evidence}, {d.derivation_id for d in derivations}, {c.claim_id for c in claims}
+    all_ids = [*(e.artifact_id for e in evidence), *(d.derivation_id for d in derivations), *(c.claim_id for c in claims)]
+    if len(set(all_ids)) != len(all_ids) or not all(_bounded_id(i) for i in all_ids): raise ValueError("duplicate or invalid ledger id")
     if len(eids) != len(evidence) or len(dids) != len(derivations) or len(cids) != len(claims): raise ValueError("duplicate ledger id")
+    for e in evidence:
+        if case_id is not None and e.case_id != case_id: raise ValueError("cross-case evidence")
+        if e.schema_version != LEDGER_VERSION or not re.fullmatch(r"[0-9a-f]{64}", e.content_digest): raise ValueError("invalid evidence integrity")
+        if not _valid_text(e.reference) or not _valid_text(e.origin) or not _valid_text(e.acquisition_method): raise ValueError("invalid evidence provenance")
+        if e.citation is not None and not _valid_text(e.citation): raise ValueError("invalid citation")
+        if e.observed_at is not None and e.observed_at.tzinfo is None: raise ValueError("temporal metadata must be timezone aware")
+        if e.valid_until is not None and (e.valid_until.tzinfo is None or (e.observed_at and e.valid_until < e.observed_at)): raise ValueError("invalid temporal metadata")
     for derivation in derivations:
         if derivation.output_claim_id not in cids or len(derivation.trace_digest) > MAX_TRACE: raise ValueError("invalid derivation reference")
+        if len(set(derivation.inputs)) != len(derivation.inputs) or derivation.derivation_id in derivation.inputs or derivation.output_claim_id in derivation.inputs: raise ValueError("invalid derivation inputs")
+        if not set(derivation.inputs) <= (eids | cids): raise ValueError("dangling derivation input")
+    referenced_derivations = {d for c in claims for d in c.derivation_ids}
+    if referenced_derivations != dids: raise ValueError("dangling or unused derivation")
     for claim in claims:
-        if not set(claim.evidence_ids) <= eids or not set(claim.derivation_ids) <= dids or not set(claim.contradictions) <= cids or not set(claim.citation_ids) <= eids: raise ValueError("dangling ledger reference")
-        output = [d for d in derivations if d.output_claim_id == claim.claim_id and d.status is ExecutionStatus.SUCCESS]
-        if claim.status is EpistemicStatus.COMPUTED and not output: raise ValueError("computed claim lacks successful derivation")
-        if claim.status is EpistemicStatus.PROVEN and (not output or not any(e.kind is EvidenceKind.FORMAL_PREMISE for e in evidence if e.artifact_id in claim.evidence_ids)): raise ValueError("proven claim lacks formal evidence")
-        if claim.status is EpistemicStatus.OBSERVED and not any(e.kind is EvidenceKind.OBSERVATION for e in evidence if e.artifact_id in claim.evidence_ids): raise ValueError("observed claim lacks observation")
-        if claim.status is EpistemicStatus.RETRIEVED and not any(e.kind is EvidenceKind.RETRIEVED_RECORD for e in evidence if e.artifact_id in claim.evidence_ids): raise ValueError("retrieved claim lacks retrieved evidence")
+        if len(set(claim.evidence_ids)) != len(claim.evidence_ids) or len(set(claim.derivation_ids)) != len(claim.derivation_ids): raise ValueError("duplicate claim reference")
+        if not set(claim.evidence_ids) <= eids or not set(claim.derivation_ids) <= dids or not set(claim.contradictions) <= cids or not set(claim.citation_ids) <= set(claim.evidence_ids): raise ValueError("dangling ledger reference")
+        if any(d.output_claim_id != claim.claim_id for d in derivations if d.derivation_id in claim.derivation_ids): raise ValueError("claim derivation output mismatch")
+        successful = [d for d in derivations if d.derivation_id in claim.derivation_ids and d.status is ExecutionStatus.SUCCESS]
+        evs = [e for e in evidence if e.artifact_id in claim.evidence_ids]
+        if claim.status is EpistemicStatus.COMPUTED and not successful: raise ValueError("computed claim lacks successful derivation")
+        if claim.status is EpistemicStatus.PROVEN and (not successful or not any(e.kind is EvidenceKind.FORMAL_PREMISE for e in evs)): raise ValueError("proven claim lacks formal evidence")
+        if claim.status is EpistemicStatus.OBSERVED and not any(e.kind is EvidenceKind.OBSERVATION for e in evs): raise ValueError("observed claim lacks observation")
+        if claim.status is EpistemicStatus.RETRIEVED and not any(e.kind is EvidenceKind.RETRIEVED_RECORD for e in evs): raise ValueError("retrieved claim lacks retrieved evidence")
         if claim.status is EpistemicStatus.ASSUMED and not claim.assumptions: raise ValueError("assumption not visible")
 
 def render_strict(ir: ResponseIR, claims: tuple[Claim, ...], derivations: tuple[Derivation, ...] = (), evidence: tuple[EvidenceArtifact, ...] = ()) -> RenderArtifact:
     if ir.schema_version != RESPONSE_IR_VERSION or ir.literals or ir.max_chars <= 0: raise ValueError("invalid response IR")
-    validate_ledger(evidence, derivations, claims)
+    validate_ledger(evidence, derivations, claims, case_id=ir.case_id)
     by_id = {claim.claim_id: claim for claim in claims}
     if not set(ir.required_claim_ids) <= set(by_id) or set(ir.required_claim_ids) & set(ir.optional_claim_ids): raise ValueError("IR references unknown or duplicate claim")
     parts: list[str] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,9 +12,16 @@ import traceback
 import uuid
 from unittest.mock import MagicMock
 
-import numpy as np
+try:
+    import numpy as np
+except ImportError:  # dependency-light canonical/security tests do not need NumPy
+    np = None
 import pytest
-from dotenv import load_dotenv  # <<< --- ADDED DOTENV --- >>>
+try:
+    from dotenv import load_dotenv  # <<< --- ADDED DOTENV --- >>>
+except ImportError:
+    def load_dotenv(*args, **kwargs):
+        return False
 
 # ============================================================
 # CI-Specific Optimizations for Faster Test Execution
@@ -278,7 +285,8 @@ _alias_all_src_modules()
 @pytest.fixture(autouse=True)
 def reset_random_state():
     """Ensure each test starts with a fresh random state."""
-    np.random.seed(12345)
+    if np is not None:
+        np.random.seed(12345)
     yield
 
 

--- a/tests/security/test_graphix_ledger_hardening.py
+++ b/tests/security/test_graphix_ledger_hardening.py
@@ -1,0 +1,93 @@
+from dataclasses import replace
+from datetime import datetime, timezone
+import pytest
+
+from vulcan.runtime.case import CognitiveCase
+from vulcan.runtime.semantic import (
+    AcceptedInterpretation, Claim, CompiledGraphixPlan, Derivation, EpistemicStatus,
+    EvidenceArtifact, EvidenceKind, ExecutionStatus, GraphixPlan, InterpretationProposal,
+    ProposedCandidate, Proposition, RESPONSE_IR_VERSION, ResponseIR, ResponseMode,
+    SourceSpan, Utterance, build_graphix_plan, canonical_digest, compile_graphix_plan,
+    execute_graphix_plan, render_strict, validate_ledger, validate_proposal,
+)
+
+
+def _ledger(case_id="case"):
+    e = EvidenceArtifact("e1", EvidenceKind.RETRIEVED_RECORD, canonical_digest("v"), "ref", "origin", "exact", case_id, observed_at=datetime.now(timezone.utc), source_integrity="digest-verified", trust_policy="test", citation="ref")
+    d = Derivation("d1", "exact-domain-lookup", "1", ("e1",), "c1", (), (), True, ExecutionStatus.SUCCESS, canonical_digest("trace"))
+    c = Claim("c1", Proposition("k", "lookup_value", "v"), EpistemicStatus.RETRIEVED, ("e1",), ("d1",), citation_ids=("e1",), temporal_validity="snapshot-bound")
+    return e, d, c
+
+
+def test_cross_case_evidence_rejected():
+    e, d, c = _ledger("other")
+    with pytest.raises(ValueError): validate_ledger((e,), (d,), (c,), case_id="case")
+
+
+def test_dangling_unused_derivation_rejected():
+    e, d, c = _ledger()
+    unused = replace(d, derivation_id="d2")
+    with pytest.raises(ValueError): validate_ledger((e,), (d, unused), (c,), case_id="case")
+
+
+def test_derivation_self_reference_rejected():
+    e, d, c = _ledger()
+    d = replace(d, inputs=("d1",))
+    with pytest.raises(ValueError): validate_ledger((e,), (d,), (c,), case_id="case")
+
+
+def test_citation_borrowed_from_another_claim_rejected():
+    e, d, c = _ledger()
+    e2 = replace(e, artifact_id="e2")
+    c = replace(c, evidence_ids=("e1",), citation_ids=("e2",))
+    with pytest.raises(ValueError): validate_ledger((e, e2), (d,), (c,), case_id="case")
+
+
+def test_plan_mutation_after_compilation_rejected():
+    acc = AcceptedInterpretation(0, "arithmetic", "2+2")
+    plan = build_graphix_plan(acc, request_digest="r", state_snapshot_id="s")
+    compiled = compile_graphix_plan(plan, request_digest="r", state_snapshot_id="s", domain_snapshot_id="domain:none")
+    mutated = CompiledGraphixPlan(replace(plan, operands=(("expression", "2+3"),)), compiled.plan_digest)
+    with pytest.raises(ValueError): execute_graphix_plan(mutated, request_digest="r", state_snapshot_id="s", domain_snapshot_id="domain:none")
+
+
+def test_valid_digest_domain_filter_plan_rejected():
+    plan = GraphixPlan("graphix-plan/1", "plan-" + "a" * 32, "lookup", "r", "s", "d", (("key", "alpha"), ("domain_hint", "private")))
+    with pytest.raises(ValueError): compile_graphix_plan(plan, request_digest="r", state_snapshot_id="s", domain_snapshot_id="d")
+
+
+def test_transformer_supplied_factual_values_rejected():
+    utterance = Utterance.from_text("2+2")
+    proposal = InterpretationProposal("semantic-ingress/2", (ProposedCandidate("arithmetic", "4", SourceSpan(0, 3)),), "bad")
+    with pytest.raises(ValueError): validate_proposal(utterance, proposal)
+
+
+def test_response_values_absent_from_ledger_rejected():
+    e, d, c = _ledger()
+    ir = ResponseIR(RESPONSE_IR_VERSION, "r", "case", None, "s", ResponseMode.STRICT, ("c1",), literals=("laundered",))
+    with pytest.raises(ValueError): render_strict(ir, (c,), (d,), (e,))
+
+
+def test_arithmetic_precedence_and_resource_syntax_violations():
+    acc = AcceptedInterpretation(0, "arithmetic", "2 + 3 * 4")
+    plan = build_graphix_plan(acc, request_digest="r", state_snapshot_id="s")
+    comp = compile_graphix_plan(plan, request_digest="r", state_snapshot_id="s", domain_snapshot_id="domain:none")
+    claim, derivation, evidence = execute_graphix_plan(comp, request_digest="r", state_snapshot_id="s", domain_snapshot_id="domain:none")
+    assert claim.proposition.object == "14"
+    assert evidence == ()
+    bad = build_graphix_plan(AcceptedInterpretation(0, "arithmetic", "2 ** 999"), request_digest="r", state_snapshot_id="s")
+    claim, _, _ = execute_graphix_plan(compile_graphix_plan(bad, request_digest="r", state_snapshot_id="s", domain_snapshot_id="domain:none"), request_digest="r", state_snapshot_id="s", domain_snapshot_id="domain:none")
+    assert claim.status is EpistemicStatus.UNKNOWN
+
+
+def test_lookup_plan_executes_through_injected_domain_and_strict_rendering():
+    class Domain:
+        domain_snapshot_id = "domain:1"
+        def lookup_exact(self, key): return ("Paris", "cities:paris")
+    acc = AcceptedInterpretation(0, "lookup", "france.capital")
+    plan = build_graphix_plan(acc, request_digest="r", state_snapshot_id="s", domain_snapshot_id="domain:1")
+    claim, derivation, evidence = execute_graphix_plan(compile_graphix_plan(plan, request_digest="r", state_snapshot_id="s", domain_snapshot_id="domain:1"), request_digest="r", state_snapshot_id="s", domain_snapshot_id="domain:1", case_id="case", domain=Domain())
+    ir = ResponseIR(RESPONSE_IR_VERSION, "r", "case", None, "s", ResponseMode.STRICT, (claim.claim_id,))
+    artifact = render_strict(ir, (claim,), (derivation,), evidence)
+    assert "Paris" in artifact.text
+    assert "cities:paris" not in artifact.text


### PR DESCRIPTION
### Motivation
- Make the canonical runtime and security/test collection dependency-light so import-time collection does not pull in optional research/web stacks (NumPy, Torch, NetworkX, FastAPI, etc.).
- Prevent transformer-provided facts, evidence, code, or evidence-selection overrides from influencing execution by forcing server-side reconstruction, compilation, and strict validation of plans bound to request/state/domain snapshots.
- Strengthen ledger invariants to block cross-case evidence laundering, dangling or unused derivations, derivation self-reference, citation misuse, and other adversarial ledger/plan mutation paths.

### Description
- Commit `fc09b1827fc0c4152b3f65f9978042983222acb7`: make `vulcan` package root and `platform` shim dependency-light and lazy-export platform utilities to avoid stdlib shadowing (changed `src/vulcan/__init__.py`, `src/platform/__init__.py`).
- Add closed Graphix plan model and server-side build/compile/execute path with snapshot binding, mutation detection, closed operation set, parameter/operand rejection, and injected domain lookup execution (`src/vulcan/runtime/semantic.py`).
- Harden ledger validation and append-time checks: bounded unique IDs, case-scoped evidence, evidence integrity/provenance/temporal checks, derivation input/output invariants, citation subset rules, and status-specific evidence/derivation requirements; bind `append_ledger` to `case_id` (`src/vulcan/runtime/semantic.py`, `src/vulcan/runtime/case.py`).
- Route the canonical kernel through compiled Graphix plans and preserve strict rendering from the validated ledger; add a focused adversarial pytest exercising the required rejection cases (`src/vulcan/runtime/kernel.py`, `tests/security/test_graphix_ledger_hardening.py`).

### Testing
- Ran focused adversarial pytest: `PYTHONPATH=/workspace/VulcanAMI_LLM/src pytest -q tests/security/test_graphix_ledger_hardening.py`, result: 10 passed.
- Performed bytecode/compile checks: `PYTHONPATH=src python -m compileall` and `PYTHONPATH=src python -O -m compileall` on modified runtime and test modules, result: success.
- Verified dependency-light imports by importing `vulcan.runtime.semantic`, `vulcan.runtime.case`, and `vulcan.runtime.kernel` and asserting that blocked optional modules (`numpy`, `torch`, `networkx`, `fastapi`) were not imported, result: success.
- Exercised canonical async request path with an explicit `asyncio.run(...)` diagnostic covering compute and abstain outcomes because `pytest-asyncio`/`anyio` were not available in the environment, result: success; note that full pytest async execution of broader test suites remains unverified until an async pytest plugin is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b5989cb50832fb631928b933afbf7)