### PR TITLE
Implement persistent evidence-bound domain hotloading

### DIFF
--- a/src/vulcan/runtime/domain_registry.py
+++ b/src/vulcan/runtime/domain_registry.py
@@ -1,0 +1,221 @@
+"""Persistent evidence-bound factual domain registry for Graphix lookup.
+
+Domain bundles are governed data. Raw documents must pass a separate governed
+extraction/review step that emits exact line-oriented JSON assertions before
+Vulcan may use them as factual support. Digest integrity proves the reviewed
+bytes used by Vulcan; it does not prove those bytes are true.
+"""
+from __future__ import annotations
+
+import copy, hashlib, json, os, re, tempfile, threading, unicodedata
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Callable
+from urllib.parse import urlparse
+
+SCHEMA_VERSION = "vulcan-domain/1"
+MAX_FILE_BYTES = 1_000_000
+MAX_ENTRIES = 1024
+MAX_CONTENT = 65536
+MAX_RETURNED_EVIDENCE = 16
+_ID = re.compile(r"[a-z0-9][a-z0-9_.-]{0,63}")
+_NAME = re.compile(r"([a-z0-9][a-z0-9_.-]{0,63})-(\d{10}).json")
+_ALLOWED_TOP = {"schema_version","domain","version","revision","evidence","facts","digest"}
+_ALLOWED_EVID = {"evidence_id","uri","content","content_digest","acquired_at","valid_until","acquisition_method","license","provenance"}
+_ALLOWED_FACT = {"fact_id","subject","predicate","object","evidence_ids","valid_from","valid_until"}
+_ALLOWED_PROV = {"reviewer","source_system","notes","case_id"}
+
+@dataclass(frozen=True)
+class DomainEvidenceSupport:
+    domain: str; revision: int; fact_id: str; evidence_id: str; uri: str; content_digest: str; acquired_at: datetime; valid_until: datetime | None; acquisition_method: str; license: str; provenance: tuple[tuple[str,str], ...]
+
+@dataclass(frozen=True)
+class DomainLookupResult:
+    status: str; key: str; value: str | None; domain_snapshot_id: str; evidence: tuple[DomainEvidenceSupport, ...] = (); contested_values: tuple[str, ...] = (); truncated: bool = False; total_evidence: int = 0; truncation_limit: int = MAX_RETURNED_EVIDENCE
+
+@dataclass(frozen=True)
+class _Evidence:
+    evidence_id: str; uri: str; content: str; content_digest: str; acquired_at: datetime; valid_until: datetime | None; acquisition_method: str; license: str; provenance: tuple[tuple[str,str], ...]
+@dataclass(frozen=True)
+class _Fact:
+    fact_id: str; subject: str; predicate: str; object: str; evidence_ids: tuple[str, ...]; valid_from: datetime | None; valid_until: datetime | None
+@dataclass(frozen=True)
+class _Bundle:
+    domain: str; version: str; revision: int; digest: str; evidence: MappingProxyType; facts: tuple[_Fact, ...]
+@dataclass(frozen=True)
+class _Snapshot:
+    snapshot_id: str; domains: MappingProxyType; index: MappingProxyType
+
+class _Lease:
+    def __init__(self, reg: 'PersistentDomainRegistry', snap: _Snapshot): self._r=reg; self._s=snap; self.domain_snapshot_id=snap.snapshot_id; self._closed=False
+    def __enter__(self): return self
+    def __exit__(self, *a): self.close()
+    def close(self):
+        if not self._closed: self._closed=True; self._r._release(self._s.snapshot_id)
+    def lookup_exact(self, key: str) -> DomainLookupResult: return self._r._lookup(self._s, key)
+
+class PersistentDomainRegistry:
+    def __init__(self, root: str | os.PathLike[str], *, audit: Callable[[dict[str,Any]],None] | None=None, retain_snapshots: int=4):
+        self.root=Path(root); self.audit=audit; self.retain=max(1, retain_snapshots); self._lock=threading.RLock(); self._leases: dict[str,int]={}
+        self.root.mkdir(parents=True, exist_ok=True); self._active=self._restore(); self._snapshots={self._active.snapshot_id:self._active}
+    @property
+    def domain_snapshot_id(self)->str: return self._active.snapshot_id
+    def lease(self)->_Lease:
+        with self._lock:
+            self._leases[self._active.snapshot_id]=self._leases.get(self._active.snapshot_id,0)+1
+            return _Lease(self,self._active)
+    def close(self): pass
+    def lookup_exact(self, key: str): return self.lease().lookup_exact(key)
+    def load_bundle(self, data: bytes | str, *, expected_previous_digest: str | None=None)->str:
+        bundle=_parse_bundle(data)
+        with self._lock:
+            old=self._active.domains.get(bundle.domain)
+            if old:
+                if bundle.revision <= old.revision: raise ValueError("non-monotonic revision")
+                if not expected_previous_digest or expected_previous_digest != old.digest: raise ValueError("stale expected_previous_digest")
+            elif expected_previous_digest is not None: raise ValueError("unexpected previous digest")
+            self._persist(bundle)
+            domains=dict(self._active.domains); domains[bundle.domain]=bundle
+            snap=_build_snapshot(domains); self._active=snap; self._snapshots[snap.snapshot_id]=snap
+            self._evict()
+            if self.audit: self.audit({"event":"domain_activated","domain":bundle.domain,"revision":bundle.revision,"digest":bundle.digest,"snapshot_id":snap.snapshot_id})
+            return snap.snapshot_id
+    def _release(self, sid):
+        with self._lock:
+            n=self._leases.get(sid,0)-1
+            if n>0: self._leases[sid]=n
+            else: self._leases.pop(sid,None)
+    def _evict(self):
+        extra=len(self._snapshots)-self.retain
+        if extra<=0: return
+        victims=[sid for sid in self._snapshots if sid != self._active.snapshot_id][:extra]
+        if any(self._leases.get(sid) for sid in victims): raise RuntimeError("snapshot retention exhausted by live lease")
+        for sid in victims: self._snapshots.pop(sid, None)
+    def _persist(self,b:_Bundle):
+        name=f"{b.domain}-{b.revision:010d}.json"; final=self.root/name; raw=_canonical_bytes(_bundle_to_public(b))
+        fd,tmp=tempfile.mkstemp(prefix=f".{name}.",suffix=".tmp",dir=self.root)
+        with os.fdopen(fd,"wb") as f: f.write(raw); f.flush(); os.fsync(f.fileno())
+        os.replace(tmp, final)
+        try:
+            d=os.open(self.root, os.O_DIRECTORY); os.fsync(d); os.close(d)
+        except OSError: pass
+    def _restore(self)->_Snapshot:
+        domains={}; files=[]
+        for p in self.root.iterdir():
+            if p.is_symlink() or not p.is_file(): raise ValueError("unexpected persisted file")
+            m=_NAME.fullmatch(p.name)
+            if not m: raise ValueError("malformed persisted filename")
+            files.append((m.group(1), int(m.group(2)), p))
+        for dom,rev,p in sorted(files):
+            if p.stat().st_size>MAX_FILE_BYTES: raise ValueError("oversized persisted file")
+            b=_parse_bundle(p.read_bytes())
+            if b.domain!=dom or b.revision!=rev: raise ValueError("filename/bundle mismatch")
+            old=domains.get(dom)
+            if old and b.revision<=old.revision: raise ValueError("conflicting history")
+            domains[dom]=b
+        return _build_snapshot(domains)
+    def _lookup(self,snap:_Snapshot,key:str)->DomainLookupResult:
+        sub,pred=_split_key(key); now=datetime.now(timezone.utc); supports=[]; vals={}
+        for fact, bundle, evs in snap.index.get((sub,pred),()):
+            if fact.valid_until and fact.valid_until < now: continue
+            good=[]
+            for ev in evs:
+                if ev.valid_until and ev.valid_until < now: good=[]; break
+                good.append(DomainEvidenceSupport(bundle.domain,bundle.revision,fact.fact_id,ev.evidence_id,ev.uri,ev.content_digest,ev.acquired_at,ev.valid_until,ev.acquisition_method,ev.license,ev.provenance))
+            if good: vals.setdefault(fact.object,[]).extend(good)
+        if not vals: return DomainLookupResult("unknown", key, None, snap.snapshot_id)
+        if len(vals)>1: return DomainLookupResult("contested", key, None, snap.snapshot_id, contested_values=tuple(sorted(vals)))
+        val, ev=list(vals.items())[0]; trunc=len(ev)>MAX_RETURNED_EVIDENCE
+        return DomainLookupResult("retrieved", key, val, snap.snapshot_id, tuple(ev[:MAX_RETURNED_EVIDENCE]), truncated=trunc, total_evidence=len(ev))
+
+def _split_key(k):
+    if not isinstance(k,str) or "." not in k: raise ValueError("lookup key must be subject.predicate")
+    a,b=k.rsplit('.',1); return _norm_term(a), _norm_term(b)
+def _norm_term(s): return _text(s,256).casefold().strip()
+def _text(v,maxlen):
+    if not isinstance(v,str) or not v or len(v)>maxlen: raise ValueError("invalid text")
+    n=unicodedata.normalize("NFC",v)
+    if any((ord(c)<32 and c not in "\n\t\r") or 0xD800<=ord(c)<=0xDFFF for c in n): raise ValueError("invalid unicode/control")
+    return n
+def _dt(v, optional=False):
+    if v is None and optional: return None
+    s=_text(v,64).replace('Z','+00:00')
+    try: d=datetime.fromisoformat(s)
+    except ValueError: raise ValueError("invalid timestamp") from None
+    if d.tzinfo is None: raise ValueError("invalid timestamp")
+    return d.astimezone(timezone.utc)
+def _loads(data):
+    raw=data.encode('utf-8') if isinstance(data,str) else data
+    if len(raw)>MAX_FILE_BYTES: raise ValueError("oversized bundle")
+    def pairs(p):
+        seen={}
+        for k,v in p:
+            if k in seen: raise ValueError("duplicate JSON key")
+            seen[k]=v
+        return seen
+    return json.loads(raw.decode('utf-8'), object_pairs_hook=pairs, parse_constant=lambda x: (_ for _ in()).throw(ValueError("NaN/Infinity rejected")))
+def _parse_bundle(data):
+    o=_loads(data)
+    if set(o)!=_ALLOWED_TOP or o.get('schema_version')!=SCHEMA_VERSION: raise ValueError("invalid bundle schema")
+    dom=_text(o['domain'],64).casefold();
+    if not _ID.fullmatch(dom): raise ValueError("invalid domain")
+    rev=o['revision'];
+    if type(rev) is not int or rev<0: raise ValueError("invalid revision")
+    if not isinstance(o['evidence'],list) or len(o['evidence'])>MAX_ENTRIES or not isinstance(o['facts'],list) or len(o['facts'])>MAX_ENTRIES: raise ValueError("entry bound")
+    evmap={}
+    for e in o['evidence']:
+        if set(e)-_ALLOWED_EVID or not _ALLOWED_EVID-{"valid_until","provenance"} <= set(e): raise ValueError("invalid evidence fields")
+        eid=_text(e['evidence_id'],96); uri=_text(e['uri'],512); scheme=urlparse(uri).scheme
+        if scheme not in {'https','urn','file'}: raise ValueError("unsupported URI")
+        content=_text(e['content'],MAX_CONTENT); cd=e['content_digest']
+        if cd!=hashlib.sha256(content.encode()).hexdigest(): raise ValueError("source digest mismatch")
+        acq=_dt(e['acquired_at']); vu=_dt(e.get('valid_until'), True)
+        if vu and vu<acq: raise ValueError("reversed validity")
+        prov=e.get('provenance') or {}
+        if not isinstance(prov,dict) or set(prov)-_ALLOWED_PROV: raise ValueError("invalid provenance")
+        ev=_Evidence(eid,uri,content,cd,acq,vu,_text(e['acquisition_method'],64),_text(e['license'],64),tuple(sorted((str(k),_text(str(v),256)) for k,v in prov.items())))
+        if eid in evmap: raise ValueError("duplicate evidence id")
+        evmap[eid]=ev
+    facts=[]; fids=set()
+    for f in o['facts']:
+        if set(f)-_ALLOWED_FACT or not _ALLOWED_FACT-{"valid_from","valid_until"} <= set(f): raise ValueError("invalid fact fields")
+        fid=_text(f['fact_id'],96)
+        if fid in fids: raise ValueError("duplicate fact id")
+        refs=f['evidence_ids']
+        if not isinstance(refs,list) or not refs: raise ValueError("fact requires evidence")
+        refs=tuple(_text(r,96) for r in refs)
+        if not set(refs)<=set(evmap): raise ValueError("unknown evidence reference")
+        fact=_Fact(fid,_norm_term(f['subject']),_norm_term(f['predicate']),_norm_term(f['object']),refs,_dt(f.get('valid_from'),True),_dt(f.get('valid_until'),True))
+        if fact.valid_from and fact.valid_until and fact.valid_until<fact.valid_from: raise ValueError("reversed validity")
+        for r in refs:
+            assertions=[json.loads(line, object_pairs_hook=lambda p: dict(p)) for line in evmap[r].content.splitlines() if line.strip().startswith('{')]
+            if {"subject":fact.subject,"predicate":fact.predicate,"object":fact.object} not in [{k:_norm_term(v) for k,v in a.items()} for a in assertions if set(a)=={"subject","predicate","object"}]: raise ValueError("evidence does not assert fact")
+        fids.add(fid); facts.append(fact)
+    pub=copy.deepcopy(o); pub.pop('digest')
+    digest=hashlib.sha256(_canonical_bytes(pub)).hexdigest()
+    if o['digest']!=digest: raise ValueError("bundle digest mismatch")
+    return _Bundle(dom,_text(o['version'],64),rev,digest,MappingProxyType(evmap),tuple(facts))
+def _canonical_bytes(o): return json.dumps(o,ensure_ascii=False,sort_keys=True,separators=(',',':'),allow_nan=False).encode('utf-8')
+def _bundle_to_public(b):
+    evs=[]
+    for e in b.evidence.values():
+        d={"evidence_id":e.evidence_id,"uri":e.uri,"content":e.content,"content_digest":e.content_digest,"acquired_at":e.acquired_at.isoformat().replace('+00:00','Z'),"acquisition_method":e.acquisition_method,"license":e.license}
+        if e.valid_until is not None: d["valid_until"]=e.valid_until.isoformat().replace('+00:00','Z')
+        if e.provenance: d["provenance"]=dict(e.provenance)
+        evs.append(d)
+    facts=[]
+    for f in b.facts:
+        d={"fact_id":f.fact_id,"subject":f.subject,"predicate":f.predicate,"object":f.object,"evidence_ids":list(f.evidence_ids)}
+        if f.valid_from is not None: d["valid_from"]=f.valid_from.isoformat().replace('+00:00','Z')
+        if f.valid_until is not None: d["valid_until"]=f.valid_until.isoformat().replace('+00:00','Z')
+        facts.append(d)
+    return {"schema_version":SCHEMA_VERSION,"domain":b.domain,"version":b.version,"revision":b.revision,"evidence":evs,"facts":facts,"digest":b.digest}
+def _build_snapshot(domains):
+    temp={}
+    for b in domains.values():
+        for f in b.facts: temp.setdefault((f.subject,f.predicate),[]).append((f,b,tuple(b.evidence[e] for e in f.evidence_ids)))
+    frozen={k:tuple(v) for k,v in sorted(temp.items())}
+    sid='domain:'+hashlib.sha256(_canonical_bytes({d:(b.revision,b.digest) for d,b in sorted(domains.items())})).hexdigest()[:16]
+    return _Snapshot(sid, MappingProxyType(dict(domains)), MappingProxyType(frozen))

--- a/src/vulcan/runtime/kernel.py
+++ b/src/vulcan/runtime/kernel.py
@@ -52,10 +52,17 @@ class CognitiveKernel:
                 case.append_ledger(claim=claim,derivation=derivation); mode=ResponseMode.CLARIFICATION; status=CognitiveCaseStatus.ABSTAINED; accepted_id=None
             else:
                 case.accepted_interpretation=selection
-                domain_snapshot_id=getattr(getattr(self._state_authority,"domain",None),"domain_snapshot_id","domain:none")
-                plan=build_graphix_plan(selection, request_digest=request.utterance.digest, state_snapshot_id=case.state_snapshot_id or "", domain_snapshot_id=domain_snapshot_id)
-                compiled=compile_graphix_plan(plan, request_digest=request.utterance.digest, state_snapshot_id=case.state_snapshot_id or "", domain_snapshot_id=domain_snapshot_id)
-                claim,derivation,evidence=execute_graphix_plan(compiled, request_digest=request.utterance.digest, state_snapshot_id=case.state_snapshot_id or "", domain_snapshot_id=domain_snapshot_id, case_id=case.case_id, domain=getattr(self._state_authority,"domain",None))
+                domain_port=getattr(self._state_authority,"domain",None)
+                lease_cm=domain_port.lease() if hasattr(domain_port,"lease") else None
+                leased_domain=lease_cm if lease_cm is not None else domain_port
+                try:
+                    domain_snapshot_id=getattr(leased_domain,"domain_snapshot_id","domain:none")
+                    plan=build_graphix_plan(selection, request_digest=request.utterance.digest, state_snapshot_id=case.state_snapshot_id or "", domain_snapshot_id=domain_snapshot_id)
+                    compiled=compile_graphix_plan(plan, request_digest=request.utterance.digest, state_snapshot_id=case.state_snapshot_id or "", domain_snapshot_id=domain_snapshot_id)
+                    if getattr(leased_domain,"domain_snapshot_id",None) != compiled.plan.domain_snapshot_id: raise ValueError("plan snapshot mismatch")
+                    claim,derivation,evidence=execute_graphix_plan(compiled, request_digest=request.utterance.digest, state_snapshot_id=case.state_snapshot_id or "", domain_snapshot_id=domain_snapshot_id, case_id=case.case_id, domain=leased_domain)
+                finally:
+                    if lease_cm is not None: lease_cm.close()
                 case.append_ledger(claim=claim,derivation=derivation,evidence=evidence)
                 mode=ResponseMode.STRICT if claim.status.value in {"computed","retrieved"} else ResponseMode.UNKNOWN; status=CognitiveCaseStatus.SUCCESS if mode is ResponseMode.STRICT else CognitiveCaseStatus.ABSTAINED; accepted_id=selection.interpretation_id
             response_ir=ResponseIR(RESPONSE_IR_VERSION,f"response-{case.case_id}",case.case_id,accepted_id,case.state_snapshot_id,mode,(claim.claim_id,))

--- a/src/vulcan/runtime/semantic.py
+++ b/src/vulcan/runtime/semantic.py
@@ -89,7 +89,7 @@ class LanguageInputPort(Protocol):
 
 class DomainLookupPort(Protocol):
     domain_snapshot_id: str
-    def lookup_exact(self, key: str) -> tuple[str, str | None]: ...
+    def lookup_exact(self, key: str) -> object: ...
 
 @dataclass(frozen=True)
 class InterpretationBundle:
@@ -258,9 +258,28 @@ def execute_graphix_plan(compiled: CompiledGraphixPlan, *, request_digest: str, 
         return claim, derivation, ()
     if compiled.plan.operation == "lookup":
         if domain is None or getattr(domain, "domain_snapshot_id", None) != domain_snapshot_id: raise ValueError("domain snapshot mismatch")
-        value, citation = domain.lookup_exact(accepted.expression)
+        result = domain.lookup_exact(accepted.expression)
+        eid_base, cid, did = f"evidence-{uuid4().hex}", f"claim-{uuid4().hex}", f"derivation-{uuid4().hex}"
+        if hasattr(result, "status"):
+            status = getattr(result, "status")
+            if getattr(result, "domain_snapshot_id", None) != domain_snapshot_id: raise ValueError("domain result snapshot mismatch")
+            if status != "retrieved":
+                epistemic = EpistemicStatus.CONTESTED if status == "contested" else EpistemicStatus.UNKNOWN
+                der = Derivation(did, "exact-domain-lookup", "2", (), cid, (), (("key", accepted.expression), ("domain_status", status)), True, ExecutionStatus.NOT_APPLICABLE, canonical_digest((accepted.expression, status)), "domain data unavailable")
+                cl = Claim(cid, Proposition(accepted.expression, "lookup_value", "unavailable"), epistemic, (), (did,), caveat=f"Domain lookup abstained: {status}.")
+                return cl, der, ()
+            value = getattr(result, "value")
+            if not _valid_text(value): raise ValueError("lookup miss")
+            evidence_artifacts = []
+            for i, support in enumerate(getattr(result, "evidence", ())):
+                evidence_artifacts.append(EvidenceArtifact(f"{eid_base}-{i}", EvidenceKind.RETRIEVED_RECORD, support.content_digest, support.uri, f"domain:{support.domain}:{support.revision}:{support.fact_id}:{support.evidence_id}", support.acquisition_method, case_id, state_snapshot_id=state_snapshot_id, observed_at=support.acquired_at, valid_until=support.valid_until, source_integrity="digest-verified", trust_policy="domain-registry", citation=support.uri, limitations=("evidence-truncated",) if getattr(result, "truncated", False) else ()))
+            eids = tuple(e.artifact_id for e in evidence_artifacts)
+            der = Derivation(did, "exact-domain-lookup", "2", eids, cid, (), (("key", accepted.expression), ("domain_snapshot_id", domain_snapshot_id)), True, ExecutionStatus.SUCCESS, canonical_digest((accepted.expression, value, eids)))
+            cl = Claim(cid, Proposition(accepted.expression, "lookup_value", value), EpistemicStatus.RETRIEVED, eids, (did,), citation_ids=eids, temporal_validity="snapshot-bound")
+            return cl, der, tuple(evidence_artifacts)
+        value, citation = result
         if not _valid_text(value): raise ValueError("lookup miss")
-        eid, cid, did = f"evidence-{uuid4().hex}", f"claim-{uuid4().hex}", f"derivation-{uuid4().hex}"
+        eid = eid_base
         ev = EvidenceArtifact(eid, EvidenceKind.RETRIEVED_RECORD, canonical_digest(value), citation or f"domain:{domain_snapshot_id}:{accepted.expression}", "injected-domain-port", "exact-key", case_id, state_snapshot_id=state_snapshot_id, observed_at=datetime.now(timezone.utc), source_integrity="digest-verified", trust_policy="domain-port", citation=citation)
         der = Derivation(did, "exact-domain-lookup", "1", (eid,), cid, (), (("key", accepted.expression),), True, ExecutionStatus.SUCCESS, canonical_digest((accepted.expression, value)))
         cl = Claim(cid, Proposition(accepted.expression, "lookup_value", value), EpistemicStatus.RETRIEVED, (eid,), (did,), citation_ids=(eid,), temporal_validity="snapshot-bound")

--- a/tests/security/test_persistent_domain_registry.py
+++ b/tests/security/test_persistent_domain_registry.py
@@ -1,0 +1,80 @@
+import json, hashlib, os, pytest
+from vulcan.runtime.domain_registry import PersistentDomainRegistry
+from vulcan.runtime.semantic import AcceptedInterpretation, GraphixPlan, compile_graphix_plan, execute_graphix_plan
+
+def bundle(domain='geo', rev=1, value='Paris', evidence_contents=None, refs=None, acquired=None, valid_until=None):
+    if evidence_contents is None:
+        evidence_contents=[json.dumps({'subject':'france','predicate':'capital','object':value.lower()})]
+    ev=[]
+    for i,c in enumerate(evidence_contents):
+        d={'evidence_id':f'e{i}','uri':f'https://example.test/{domain}/{i}','content':c,'content_digest':hashlib.sha256(c.encode()).hexdigest(),'acquired_at':acquired or '2026-01-01T00:00:00Z','acquisition_method':'reviewed-jsonl','license':'CC0','provenance':{'reviewer':'test'}}
+        if valid_until is not None: d['valid_until']=valid_until
+        ev.append(d)
+    o={'schema_version':'vulcan-domain/1','domain':domain,'version':f'v{rev}','revision':rev,'evidence':ev,'facts':[{'fact_id':'f0','subject':'france','predicate':'capital','object':value.lower(),'evidence_ids':refs or [e['evidence_id'] for e in ev]}]}
+    o['digest']=hashlib.sha256(json.dumps(o,ensure_ascii=False,sort_keys=True,separators=(',',':'),allow_nan=False).encode()).hexdigest()
+    return json.dumps(o,separators=(',',':'))
+
+def test_exact_structured_assertion_accepted_and_lookup(tmp_path):
+    r=PersistentDomainRegistry(tmp_path/'r'); sid=r.load_bundle(bundle())
+    with r.lease() as l:
+        res=l.lookup_exact('France.capital')
+    assert res.status=='retrieved' and res.value=='paris' and res.domain_snapshot_id==sid and len(res.evidence)==1
+
+def test_natural_language_negations_and_cooccurrence_rejected(tmp_path):
+    bad=['The capital of France is Paris.','The capital of France is not Paris.','It is false that the capital of France is Paris.','France. capital. Paris.']
+    for i,txt in enumerate(bad):
+        with pytest.raises(ValueError): PersistentDomainRegistry(tmp_path/str(i)).load_bundle(bundle(evidence_contents=[txt]))
+
+def test_every_cited_source_must_support_and_refs_known(tmp_path):
+    with pytest.raises(ValueError): PersistentDomainRegistry(tmp_path/'a').load_bundle(bundle(evidence_contents=[json.dumps({'subject':'france','predicate':'capital','object':'paris'}), json.dumps({'subject':'france','predicate':'capital','object':'lyon'})]))
+    with pytest.raises(ValueError): PersistentDomainRegistry(tmp_path/'b').load_bundle(bundle(refs=['missing']))
+
+def test_duplicate_keys_unknown_fields_digest_nan_timestamps(tmp_path):
+    raw=b'{"schema_version":"vulcan-domain/1","schema_version":"x"}'
+    with pytest.raises(ValueError): PersistentDomainRegistry(tmp_path/'d').load_bundle(raw)
+    o=json.loads(bundle()); o['extra']=1; o['digest']='0'*64
+    with pytest.raises(ValueError): PersistentDomainRegistry(tmp_path/'u').load_bundle(json.dumps(o))
+    o=json.loads(bundle()); o['revision']=float('nan')
+    with pytest.raises(ValueError): PersistentDomainRegistry(tmp_path/'n').load_bundle(json.dumps(o, allow_nan=True))
+    o=json.loads(bundle()); o['evidence'][0]['acquired_at']='not-a-date'; o['digest']='bad'
+    with pytest.raises(ValueError): PersistentDomainRegistry(tmp_path/'t').load_bundle(json.dumps(o))
+    o=json.loads(bundle()); o['evidence'][0]['content']+='x'
+    with pytest.raises(ValueError): PersistentDomainRegistry(tmp_path/'m').load_bundle(json.dumps(o))
+
+def test_updates_require_monotonic_revision_and_cas(tmp_path):
+    r=PersistentDomainRegistry(tmp_path/'r'); r.load_bundle(bundle(rev=1)); old=r._active.domains['geo'].digest
+    with pytest.raises(ValueError): r.load_bundle(bundle(rev=1), expected_previous_digest=old)
+    with pytest.raises(ValueError): r.load_bundle(bundle(rev=2), expected_previous_digest='0'*64)
+    r.load_bundle(bundle(rev=2,value='Paris'), expected_previous_digest=old)
+
+def test_concordant_and_conflicting_domains(tmp_path):
+    r=PersistentDomainRegistry(tmp_path/'r'); r.load_bundle(bundle('a',1,'Paris')); r.load_bundle(bundle('b',1,'Paris'))
+    assert len(r.lease().lookup_exact('france.capital').evidence)==2
+    r2=PersistentDomainRegistry(tmp_path/'x'); r2.load_bundle(bundle('a',1,'Paris')); r2.load_bundle(bundle('b',1,'Lyon'))
+    assert r2.lease().lookup_exact('france.capital').status=='contested'
+    r3=PersistentDomainRegistry(tmp_path/'y'); r3.load_bundle(bundle('b',1,'Lyon')); r3.load_bundle(bundle('a',1,'Paris'))
+    assert r3.lease().lookup_exact('france.capital').status=='contested'
+
+def test_expired_unknown_snapshot_lease_persist_restore_and_bad_files(tmp_path):
+    r=PersistentDomainRegistry(tmp_path/'expired', retain_snapshots=1); r.load_bundle(bundle(acquired='2019-01-01T00:00:00Z', valid_until='2020-01-01T00:00:00Z'))
+    assert r.lease().lookup_exact('france.capital').status=='unknown'
+    r=PersistentDomainRegistry(tmp_path/'p', retain_snapshots=2); r.load_bundle(bundle(value='Paris')); lease=r.lease(); old=lease.domain_snapshot_id
+    r.load_bundle(bundle(rev=2,value='Lyon'), expected_previous_digest=r._active.domains['geo'].digest)
+    assert lease.lookup_exact('france.capital').value=='paris' and lease.domain_snapshot_id==old
+    lease.close(); assert PersistentDomainRegistry(tmp_path/'p').lease().lookup_exact('france.capital').value=='lyon'
+    (tmp_path/'bad').mkdir(); (tmp_path/'bad'/'junk.txt').write_text('x')
+    with pytest.raises(ValueError): PersistentDomainRegistry(tmp_path/'bad')
+    (tmp_path/'sym').mkdir(); os.symlink(tmp_path/'sym'/'missing', tmp_path/'sym'/'geo-0000000001.json')
+    with pytest.raises(ValueError): PersistentDomainRegistry(tmp_path/'sym')
+
+def test_graphix_snapshot_mismatch_and_domain_hint_cannot_filter(tmp_path):
+    r=PersistentDomainRegistry(tmp_path/'r'); r.load_bundle(bundle('a',1,'Paris')); r.load_bundle(bundle('b',1,'Lyon'))
+    acc=AcceptedInterpretation(0,'lookup','France.capital')
+    lease=r.lease(); plan=GraphixPlan('graphix-plan/1','plan-'+'a'*32,'lookup','req','state',lease.domain_snapshot_id,(('key','France.capital'),))
+    comp=compile_graphix_plan(plan, request_digest='req', state_snapshot_id='state', domain_snapshot_id=lease.domain_snapshot_id)
+    claim,_,_=execute_graphix_plan(comp, request_digest='req', state_snapshot_id='state', domain_snapshot_id=lease.domain_snapshot_id, domain=lease)
+    assert claim.status.value=='contested'
+    with pytest.raises(ValueError): execute_graphix_plan(comp, request_digest='req', state_snapshot_id='state', domain_snapshot_id='domain:other', domain=lease)
+    bad=GraphixPlan('graphix-plan/1','plan-'+'b'*32,'lookup','req','state',lease.domain_snapshot_id,(('key','France.capital'),('domain_hint','a')))
+    with pytest.raises(ValueError): compile_graphix_plan(bad, request_digest='req', state_snapshot_id='state', domain_snapshot_id=lease.domain_snapshot_id)
+    lease.close()


### PR DESCRIPTION
### Motivation

- Provide a safe, dependency-light, versioned, persistent domain registry that can add or update factual domains at runtime without restarting or retraining Vulcan.
- Enforce a strict, bounded `vulcan-domain/1` bundle contract so persisted domains are deterministic, auditable, and grounded in line-oriented JSON assertions rather than executable code.
- Preserve the closed Graphix lookup contract while integrating a canonical registry, ensuring request-local snapshot leases and immutable snapshot semantics for repeatable execution.

### Description

- Add `src/vulcan/runtime/domain_registry.py` which implements `PersistentDomainRegistry`, immutable snapshots, request-local `_Lease` objects, atomic persistence via temp-file write+fsync+`os.replace`, deterministic restore, snapshot retention and eviction, and typed `DomainLookupResult` with `retrieved`/`unknown`/`contested` semantics.
- Implement strict bundle parsing/validation including duplicate-JSON-key rejection, allowed-field checks, bounded text/content sizes, timestamp and URI scheme validation, SHA-256 content and bundle digest verification, duplicate-ID detection, evidence/fact cross-reference validation, and line-oriented JSON assertion checks for each cited evidence entry.
- Integrate registry results into the canonical execution path by adapting the closed `DomainLookupPort` use to accept typed registry results while maintaining backward compatibility with the legacy tuple-returning lookup; produced evidence is converted into ledger-ready `EvidenceArtifact`s containing case id, content digest, citation/URI, provenance and temporal metadata.
- Update `src/vulcan/runtime/kernel.py` to acquire a per-request domain snapshot lease during plan compilation, revalidate the plan snapshot just before execution, and release the lease in a `finally` cleanup path.
- Add adversarial tests `tests/security/test_persistent_domain_registry.py` that exercise structured-assertion acceptance, adversarial rejections (natural-language co-occurrence, negation, duplicate keys, unknown fields/references, NaN/timestamps), monotonic/CAS updates, concordance/contestation behavior, expiration handling, in-flight snapshot lease retention, persistence close/reopen, malformed/symlinked persisted file detection, plan snapshot mismatch, and domain-hint rejection.

### Testing

- Ran focused pytest suites: `pytest -q tests/security/test_persistent_domain_registry.py tests/security/test_graphix_ledger_hardening.py` and `PYTHONPATH=/workspace/VulcanAMI_LLM/src python3 -m pytest -q /workspace/VulcanAMI_LLM/tests/security/test_persistent_domain_registry.py /workspace/VulcanAMI_LLM/tests/security/test_graphix_ledger_hardening.py`, both reporting `18 passed` for the covered tests.
- Performed bytecode checks with `python3 -m compileall` (normal and `-OO`) for the modified runtime files and the new focused tests, which completed successfully.
- Ran standard-library diagnostics for persistence and concurrency (close/reopen and concurrent snapshot-lease diagnostics) which passed in this environment.
- Ran `git diff --check` to ensure no whitespace or diff issues remained.
- Outstanding: full async kernel tests in `tests/security/test_semantic_runtime.py` were not executed here because the test environment lacked an async pytest plugin, so those async-focused tests remain unverified in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b5c4d2b8c832fa05aaa2319b425c3)