### PR TITLE
Implement persistent audit and versioned alignment

### DIFF
--- a/src/vulcan/runtime/alignment.py
+++ b/src/vulcan/runtime/alignment.py
@@ -1,0 +1,122 @@
+"""Versioned evidence-bound alignment policy registry."""
+from __future__ import annotations
+import copy, hashlib, json, os, re, tempfile, threading, unicodedata
+from dataclasses import asdict, dataclass, replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from .semantic import EpistemicStatus
+
+SCHEMA_VERSION="vulcan-alignment/1"; POLICY_ID="canonical-evidence-bound"; MAX_HIST=16
+STATUSES={s.value for s in EpistemicStatus}; BEH={"abstain","allow_unknown"}
+REASONS={"too_many_claims","status_not_permitted","missing_evidence","missing_citation","bad_integrity","expired_evidence","dangling_reference","unknown_abstain","passed"}
+@dataclass(frozen=True)
+class AlignmentPolicy:
+    schema_version:str; policy_id:str; revision:int; permitted_epistemic_statuses:tuple[str,...]; explicit_unknown_behavior:str; require_citations:bool; require_verified_integrity:bool; require_temporal_validity:bool; max_claims_per_response:int; policy_digest:str=""
+@dataclass(frozen=True)
+class AlignmentDecision:
+    accepted:bool; reason_codes:tuple[str,...]; policy_digest:str; policy_revision:int
+
+def _canon_obj(v):
+    if isinstance(v,str):
+        n=unicodedata.normalize("NFC",v)
+        if len(n)>512 or any(ord(c)<32 for c in n): raise ValueError("invalid string")
+        return n
+    if type(v) is bool or v is None: return v
+    if type(v) is int: return v
+    if isinstance(v,float): raise ValueError("non-finite number")
+    if isinstance(v,tuple): return [_canon_obj(x) for x in v]
+    if isinstance(v,list): return [_canon_obj(x) for x in v]
+    if isinstance(v,dict): return {str(k):_canon_obj(val) for k,val in sorted(v.items())}
+    raise ValueError("unsupported policy value")
+def _bytes(o): return json.dumps(_canon_obj(o),ensure_ascii=False,sort_keys=True,separators=(",",":"),allow_nan=False).encode()
+def _digest_dict(d):
+    x=dict(d); x.pop("policy_digest",None); return hashlib.sha256(_bytes(x)).hexdigest()
+def _loads(b):
+    def pairs(p):
+        d={}
+        for k,v in p:
+            if k in d: raise ValueError("duplicate JSON key")
+            d[k]=v
+        return d
+    return json.loads(b.decode() if isinstance(b,bytes) else b, object_pairs_hook=pairs, parse_constant=lambda x: (_ for _ in()).throw(ValueError("non-finite number")))
+def validate_policy(o:dict[str,Any])->AlignmentPolicy:
+    allowed=set(AlignmentPolicy.__dataclass_fields__)
+    if set(o)!=allowed or o.get("schema_version")!=SCHEMA_VERSION or o.get("policy_id")!=POLICY_ID: raise ValueError("invalid policy schema")
+    if type(o["revision"]) is not int or o["revision"]<1: raise ValueError("invalid revision")
+    sts=o["permitted_epistemic_statuses"]
+    if not isinstance(sts,list) or not sts or len(sts)>len(STATUSES) or len(sts)!=len(set(sts)) or not set(sts)<=STATUSES: raise ValueError("invalid statuses")
+    if o["explicit_unknown_behavior"] not in BEH: raise ValueError("invalid unknown behavior")
+    for k in ("require_citations","require_verified_integrity","require_temporal_validity"):
+        if type(o[k]) is not bool: raise ValueError("invalid boolean")
+    if type(o["max_claims_per_response"]) is not int or not 1<=o["max_claims_per_response"]<=64: raise ValueError("invalid max claims")
+    if o["explicit_unknown_behavior"]=="allow_unknown" and "unknown" not in sts: raise ValueError("impossible policy")
+    if o["policy_digest"]!=_digest_dict(o): raise ValueError("policy digest mismatch")
+    return AlignmentPolicy(**{**o,"permitted_epistemic_statuses":tuple(sts)})
+def default_policy():
+    d={"schema_version":SCHEMA_VERSION,"policy_id":POLICY_ID,"revision":1,"permitted_epistemic_statuses":["computed","retrieved","proven"],"explicit_unknown_behavior":"abstain","require_citations":True,"require_verified_integrity":True,"require_temporal_validity":True,"max_claims_per_response":8,"policy_digest":""}
+    d["policy_digest"]=_digest_dict(d); return validate_policy(d)
+
+class AlignmentRegistry:
+    def __init__(self,path: str|os.PathLike[str], *, audit=None):
+        self.path=Path(path); self.audit=audit; self._lock=threading.RLock(); self._leases={}; self._hist={}; self.close_count=0
+        self.path.parent.mkdir(parents=True,exist_ok=True)
+        if self.path.is_symlink(): raise ValueError("symlinked policy path")
+        if self.path.exists(): pol=validate_policy(_loads(self.path.read_bytes()))
+        else:
+            pol=default_policy(); self._persist(pol)
+        self._active=pol; self._hist[pol.policy_digest]=pol
+    def close(self): self.close_count+=1
+    def active(self): return self._active
+    def active_metadata(self): return {"policy_digest":self._active.policy_digest,"revision":self._active.revision}
+    def lease(self):
+        reg=self; pol=self._active
+        class L:
+            policy=pol; policy_digest=pol.policy_digest; revision=pol.revision
+            def close(self): reg.release(pol.policy_digest)
+            def __enter__(self): return self
+            def __exit__(self,*a): self.close()
+        with self._lock: self._leases[pol.policy_digest]=self._leases.get(pol.policy_digest,0)+1
+        return L()
+    def release(self,d):
+        with self._lock:
+            n=self._leases.get(d,0)-1
+            if n>0: self._leases[d]=n
+            else: self._leases.pop(d,None)
+    def update(self, candidate:dict[str,Any], *, expected_previous_digest:str, actor_id:str|None=None):
+        pol=validate_policy(copy.deepcopy(candidate))
+        with self._lock:
+            if expected_previous_digest!=self._active.policy_digest: raise ValueError("stale CAS")
+            if pol.revision<=self._active.revision or pol.policy_digest in self._hist: raise ValueError("revision reuse")
+            if self.audit: self.audit.append("alignment.policy_activated", {"policy_id":pol.policy_id,"revision":pol.revision,"previous_digest":self._active.policy_digest,"policy_digest":pol.policy_digest,"actor_id":actor_id or "system"})
+            self._persist(pol); self._active=pol; self._hist[pol.policy_digest]=pol; self._evict(); return pol
+    def _evict(self):
+        for d in list(self._hist)[:-MAX_HIST]:
+            if d in self._leases: continue
+            if d!=self._active.policy_digest: self._hist.pop(d,None)
+    def _persist(self,pol):
+        raw=_bytes(asdict(pol)); fd,tmp=tempfile.mkstemp(prefix=".alignment.",suffix=".tmp",dir=self.path.parent)
+        with os.fdopen(fd,"wb") as f: f.write(raw); f.flush(); os.fsync(f.fileno())
+        os.replace(tmp,self.path)
+        try: dd=os.open(self.path.parent,os.O_DIRECTORY); os.fsync(dd); os.close(dd)
+        except OSError: pass
+    def readiness(self):
+        if validate_policy(_loads(self.path.read_bytes())).policy_digest!=self._active.policy_digest: raise RuntimeError("active policy persistence mismatch")
+        return True
+    def decide(self, claims, evidence, derivations, policy:AlignmentPolicy|None=None):
+        p=policy or self._active; reasons=[]; eids={e.artifact_id:e for e in evidence}; dids={d.derivation_id:d for d in derivations}
+        if len(claims)>p.max_claims_per_response: reasons.append("too_many_claims")
+        for c in claims:
+            st=c.status.value
+            if st not in p.permitted_epistemic_statuses: reasons.append("unknown_abstain" if st=="unknown" else "status_not_permitted")
+            if st in {"retrieved","observed","proven"}:
+                if not c.evidence_ids or not set(c.evidence_ids)<=set(eids): reasons.append("missing_evidence")
+                if not set(c.derivation_ids)<=set(dids): reasons.append("dangling_reference")
+                for eid in c.evidence_ids:
+                    e=eids.get(eid)
+                    if not e: continue
+                    if p.require_citations and not (e.citation and eid in c.citation_ids): reasons.append("missing_citation")
+                    if p.require_verified_integrity and e.source_integrity!="digest-verified": reasons.append("bad_integrity")
+                    if p.require_temporal_validity and e.valid_until and e.valid_until<datetime.now(timezone.utc): reasons.append("expired_evidence")
+        reasons=tuple(sorted(set(reasons))) or ("passed",)
+        return AlignmentDecision(reasons==("passed",), reasons, p.policy_digest, p.revision)

--- a/src/vulcan/runtime/audit.py
+++ b/src/vulcan/runtime/audit.py
@@ -1,0 +1,127 @@
+"""Dependency-light append-only canonical audit owner (vulcan-audit/1)."""
+from __future__ import annotations
+import copy, fcntl, hashlib, json, os, re, threading, unicodedata
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION="vulcan-audit/1"
+MAX_FILE_BYTES=8_000_000; MAX_LINE_BYTES=64_000; MAX_EVENTS=100_000; MAX_DEPTH=8; MAX_ITEMS=256; MAX_STRING=2048
+_FIELDS={"schema_version","sequence","event_type","timestamp","previous_hash","data","event_hash"}
+_EVENT=re.compile(r"(?:case|domain|alignment|runtime)\.[a-z][a-z0-9_]{0,31}")
+_ALLOWED={"case.started","case.interpreted","case.plan_compiled","case.ledger_committed","case.alignment_decided","case.finalized","case.completed","case.abstained","case.failed","domain.activated","alignment.policy_activated","runtime.ready"}
+_TRANS={None:{"case.started"},"case.started":{"case.interpreted","case.failed"},"case.interpreted":{"case.plan_compiled","case.failed"},"case.plan_compiled":{"case.ledger_committed","case.failed"},"case.ledger_committed":{"case.alignment_decided","case.failed"},"case.alignment_decided":{"case.finalized","case.abstained","case.failed"},"case.finalized":{"case.completed","case.abstained","case.failed"},"case.abstained":set(),"case.completed":set(),"case.failed":set()}
+
+class AuditError(RuntimeError): pass
+@dataclass(frozen=True)
+class AuditEvent:
+    schema_version:str; sequence:int; event_type:str; timestamp:str; previous_hash:str; data:dict[str,Any]; event_hash:str
+
+def _loads(raw:bytes)->Any:
+    def pairs(p):
+        d={}
+        for k,v in p:
+            if k in d: raise AuditError("duplicate JSON key")
+            d[k]=v
+        return d
+    return json.loads(raw.decode(), object_pairs_hook=pairs, parse_constant=lambda x: (_ for _ in()).throw(AuditError("non-finite number")))
+def _bound(v, depth=0):
+    if depth>MAX_DEPTH: raise AuditError("nested data bound")
+    if isinstance(v,str):
+        n=unicodedata.normalize("NFC",v)
+        if len(n)>MAX_STRING or any(ord(c)<32 for c in n): raise AuditError("invalid string")
+        return n
+    if type(v) in (int,bool) or v is None: return v
+    if isinstance(v,float): raise AuditError("non-finite number")
+    if isinstance(v,dict):
+        if len(v)>MAX_ITEMS: raise AuditError("object bound")
+        return { _bound(str(k),depth+1): _bound(val,depth+1) for k,val in sorted(v.items()) }
+    if isinstance(v,(list,tuple)):
+        if len(v)>MAX_ITEMS: raise AuditError("array bound")
+        return [_bound(x,depth+1) for x in v]
+    raise AuditError("unsupported data")
+def _canonical(o): return json.dumps(o,ensure_ascii=False,sort_keys=True,separators=(",",":"),allow_nan=False).encode()
+def _hash_event(o):
+    d=dict(o); d.pop("event_hash",None); return hashlib.sha256(_canonical(d)).hexdigest()
+def _ts(s):
+    if not isinstance(s,str) or not s.endswith("Z"): raise AuditError("invalid timestamp")
+    try: return datetime.fromisoformat(s.replace("Z","+00:00")).astimezone(timezone.utc)
+    except ValueError: raise AuditError("invalid timestamp")
+def _validate_type(t):
+    if not isinstance(t,str) or len(t)>40 or not _EVENT.fullmatch(t) or t not in _ALLOWED: raise AuditError("invalid event type")
+
+def _case_data(t,d):
+    cid=d.get("case_id"); rd=d.get("request_digest")
+    if not isinstance(cid,str) or not re.fullmatch(r"[A-Za-z0-9_.:-]{1,96}",cid): raise AuditError("invalid case id")
+    if not isinstance(rd,str) or not re.fullmatch(r"[0-9a-f]{64}",rd): raise AuditError("invalid request digest")
+    forbidden=("raw_prompt","prompt","authorization","jwt","token","secret","password","stack","exception_text")
+    if any(k in d for k in forbidden): raise AuditError("forbidden case data")
+
+class CanonicalAudit:
+    def __init__(self,path: str|os.PathLike[str]):
+        self.path=Path(path); self.lock_path=self.path.with_suffix(self.path.suffix+".lock"); self._lock=threading.RLock(); self._closed=False; self._seq=0; self._prev="0"*64; self._case_state={}; self.owner_id=f"audit:{self.path}"
+        try:
+            self.path.parent.mkdir(parents=True,exist_ok=True)
+            if self.path.is_symlink() or self.lock_path.is_symlink(): raise AuditError("symlinked audit path")
+            self._lfd=os.open(self.lock_path, os.O_CREAT|os.O_RDWR,0o600)
+            try: fcntl.flock(self._lfd, fcntl.LOCK_EX|fcntl.LOCK_NB)
+            except BlockingIOError: raise AuditError("second writer")
+            if self.path.exists(): self.verify()
+            else: self.path.touch(mode=0o600)
+        except Exception:
+            if hasattr(self,"_lfd"):
+                try: fcntl.flock(self._lfd, fcntl.LOCK_UN); os.close(self._lfd)
+                except OSError: pass
+            raise
+    def close(self):
+        with self._lock:
+            if self._closed: return
+            self._closed=True; fcntl.flock(self._lfd, fcntl.LOCK_UN); os.close(self._lfd)
+    def readiness(self): self.verify(); return True
+    def append(self,event_type:str,data:dict[str,Any])->AuditEvent:
+        _validate_type(event_type); frozen=_bound(copy.deepcopy(data))
+        if event_type.startswith("case."): _case_data(event_type,frozen)
+        raw_probe=_canonical(frozen)
+        if len(raw_probe)>MAX_LINE_BYTES//2: raise AuditError("event data bound")
+        with self._lock:
+            if self._closed: raise AuditError("audit closed")
+            prev_state=None
+            if event_type.startswith("case."):
+                prev_state=self._case_state.get(frozen["case_id"])
+                if event_type not in _TRANS.get(prev_state,set()): raise AuditError("invalid case lifecycle")
+            ev={"schema_version":SCHEMA_VERSION,"sequence":self._seq+1,"event_type":event_type,"timestamp":datetime.now(timezone.utc).isoformat().replace("+00:00","Z"),"previous_hash":self._prev,"data":frozen}
+            ev["event_hash"]=_hash_event(ev); line=_canonical(ev)+b"\n"
+            if len(line)>MAX_LINE_BYTES: raise AuditError("line bound")
+            with open(self.path,"ab",buffering=0) as f:
+                f.write(line); f.flush(); os.fsync(f.fileno())
+            self._seq+=1; self._prev=ev["event_hash"]
+            if event_type.startswith("case."): self._case_state[frozen["case_id"]]=event_type
+            return AuditEvent(**ev)
+    def verify(self):
+        if self.path.is_symlink(): raise AuditError("symlinked audit path")
+        if self.path.exists() and self.path.stat().st_size>MAX_FILE_BYTES: raise AuditError("audit file bound")
+        seq=0; prev="0"*64; states={}
+        data=self.path.read_bytes() if self.path.exists() else b""
+        if data and not data.endswith(b"\n"): raise AuditError("incomplete final line")
+        for line in data.splitlines():
+            if not line or len(line)>MAX_LINE_BYTES: raise AuditError("malformed or oversized line")
+            o=_loads(line)
+            if set(o)!=_FIELDS or o.get("schema_version")!=SCHEMA_VERSION: raise AuditError("unknown event fields")
+            _validate_type(o["event_type"]); _ts(o["timestamp"])
+            if type(o["sequence"]) is not int or o["sequence"]!=seq+1: raise AuditError("sequence gap or reuse")
+            if o["previous_hash"]!=prev or o["event_hash"]!=_hash_event(o): raise AuditError("audit hash mismatch")
+            d=_bound(o["data"])
+            if o["event_type"].startswith("case."):
+                _case_data(o["event_type"],d); cid=d["case_id"]
+                if o["event_type"] not in _TRANS.get(states.get(cid),set()): raise AuditError("invalid case lifecycle")
+                states[cid]=o["event_type"]
+            seq=o["sequence"]; prev=o["event_hash"]
+            if seq>MAX_EVENTS: raise AuditError("event bound")
+        self._seq=seq; self._prev=prev; self._case_state=states
+    def events_for_case(self,case_id:str):
+        self.verify(); out=[]
+        for line in self.path.read_bytes().splitlines():
+            o=_loads(line)
+            if o["event_type"].startswith("case.") and o["data"].get("case_id")==case_id: out.append(AuditEvent(**o))
+        return tuple(out)

--- a/src/vulcan/runtime/container.py
+++ b/src/vulcan/runtime/container.py
@@ -8,6 +8,9 @@ from uuid import uuid4
 
 from vulcan.memory.governed import GovernedMemoryPort, compose_governed_memory
 
+from .alignment import AlignmentRegistry
+from .audit import CanonicalAudit
+from .domain_registry import PersistentDomainRegistry
 from .finalization import SafetyResponseFinalizer
 from .kernel import CognitiveKernel
 from .output import DeterministicLanguageOutput, LanguageOutputPort
@@ -38,6 +41,9 @@ class RuntimeContainer:
     language_input: LanguageInputPort
     language_output: LanguageOutputPort
     language_config: LanguageRuntimeConfig
+    audit: CanonicalAudit | None = None
+    alignment: AlignmentRegistry | None = None
+    domain_registry: PersistentDomainRegistry | None = None
     closed: bool = False
 
     async def close(self) -> None:
@@ -57,6 +63,9 @@ class RuntimeContainer:
             self.language_output,
             self.language_input,
             self.memory,
+            self.alignment,
+            self.audit,
+            self.domain_registry,
             self.kernel,
             self.safety,
             self.world_state,
@@ -89,6 +98,9 @@ class RuntimeContainer:
             "memory": self.memory,
             "language_input": self.language_input,
             "language_output": self.language_output,
+            "audit": self.audit,
+            "alignment": self.alignment,
+            "domain_registry": self.domain_registry,
         }
         for name, owner in required.items():
             if owner is None:
@@ -125,14 +137,21 @@ class RuntimeContainer:
         language_input: LanguageInputPort = DeterministicLanguageInput()
         language_output: LanguageOutputPort = DeterministicLanguageOutput()
         memory = compose_governed_memory()
+        root = getattr(deployment, "runtime_root", None) or getattr(deployment, "data_dir", None) or "/tmp/vulcan-runtime"
+        audit = alignment = domain_registry = None
         try:
             memory.readiness()
+            audit = CanonicalAudit(f"{root}/audit/events.jsonl")
+            alignment = AlignmentRegistry(f"{root}/alignment/active.json", audit=audit)
+            domain_registry = PersistentDomainRegistry(f"{root}/domains", audit=audit)
+            setattr(world_state, "domain", domain_registry)
             kernel = CognitiveKernel(state_authority=world_state, finalizer=SafetyResponseFinalizer(safety),
-                                     language_input=language_input, language_output=language_output, memory=memory)
+                                     language_input=language_input, language_output=language_output, memory=memory, audit=audit, alignment=alignment)
             return cls(str(uuid4()), deployment, world_state, kernel, safety, memory,
-                       language_input, language_output, config)
+                       language_input, language_output, config, audit, alignment, domain_registry)
         except Exception:
-            memory.close()
-            language_output.close()
-            language_input.close()
+            for r in (domain_registry, alignment, audit, memory, language_output, language_input):
+                if r is not None:
+                    close=getattr(r,"close",None)
+                    if close: close()
             raise

--- a/src/vulcan/runtime/domain_registry.py
+++ b/src/vulcan/runtime/domain_registry.py
@@ -76,11 +76,16 @@ class PersistentDomainRegistry:
                 if bundle.revision <= old.revision: raise ValueError("non-monotonic revision")
                 if not expected_previous_digest or expected_previous_digest != old.digest: raise ValueError("stale expected_previous_digest")
             elif expected_previous_digest is not None: raise ValueError("unexpected previous digest")
-            self._persist(bundle)
             domains=dict(self._active.domains); domains[bundle.domain]=bundle
-            snap=_build_snapshot(domains); self._active=snap; self._snapshots[snap.snapshot_id]=snap
+            snap=_build_snapshot(domains)
+            if self.audit:
+                append = getattr(self.audit, "append", None)
+                event_data={"domain":bundle.domain,"revision":bundle.revision,"version":bundle.version,"prior_bundle_digest":old.digest if old else None,"new_bundle_digest":bundle.digest,"snapshot_id":snap.snapshot_id,"fact_count":len(bundle.facts),"evidence_count":len(bundle.evidence),"actor_id":"system"}
+                if append: append("domain.activated", event_data)
+                else: self.audit(event_data)
+            self._persist(bundle)
+            self._active=snap; self._snapshots[snap.snapshot_id]=snap
             self._evict()
-            if self.audit: self.audit({"event":"domain_activated","domain":bundle.domain,"revision":bundle.revision,"digest":bundle.digest,"snapshot_id":snap.snapshot_id})
             return snap.snapshot_id
     def _release(self, sid):
         with self._lock:

--- a/src/vulcan/runtime/kernel.py
+++ b/src/vulcan/runtime/kernel.py
@@ -23,10 +23,10 @@ class KernelResult:
     def transport(self, *, case_id: str, runtime_id: str, snapshot_id: str | None) -> dict[str, object]:
         return {"response": self.response, "metadata": {"case_id":case_id,"runtime_id":runtime_id,"state_snapshot_id":snapshot_id,"semantic_schema_version":self.response_ir.schema_version,"finalized":True,"finalization_safety_decision":self.finalization}}
 class CognitiveKernel:
-    def __init__(self, *, state_authority: Any, finalizer: ResponseFinalizerPort, language_input: LanguageInputPort | None = None, language_output: LanguageOutputPort | None = None, memory: "GovernedMemoryPort | None" = None) -> None:
+    def __init__(self, *, state_authority: Any, finalizer: ResponseFinalizerPort, language_input: LanguageInputPort | None = None, language_output: LanguageOutputPort | None = None, memory: "GovernedMemoryPort | None" = None, audit: Any = None, alignment: Any = None) -> None:
         # The kernel owns the only memory port exposed to the production path.
         # It deliberately does not turn retrieved text into executable semantics.
-        self._state_authority=state_authority; self._finalizer=finalizer; self._language_input=language_input or DeterministicLanguageInput(); self._language_output=language_output or DeterministicLanguageOutput(); self._memory=memory; self.calls=0
+        self._state_authority=state_authority; self._finalizer=finalizer; self._language_input=language_input or DeterministicLanguageInput(); self._language_output=language_output or DeterministicLanguageOutput(); self._memory=memory; self._audit=audit; self._alignment=alignment; self.calls=0
     def capabilities(self) -> tuple[str, ...]:
         """Capabilities implemented by this composed kernel, not marketing text."""
         return ("bounded-arithmetic",)
@@ -34,6 +34,9 @@ class CognitiveKernel:
         if case.terminal_status is not CognitiveCaseStatus.OPEN: raise RuntimeError("kernel received a closed cognitive case")
         if request.utterance.digest != case.input_hash or request.conversation_id != case.conversation_id: raise ValueError("request/case correlation mismatch")
         self.calls += 1; case.state_snapshot_id=self._snapshot_id(); case.record("semantic_ingress")
+        alignment_lease = self._alignment.lease() if self._alignment is not None else None
+        policy = getattr(alignment_lease, "policy", None)
+        if self._audit: self._audit.append("case.started", {"case_id":case.case_id,"request_id":case.request_id,"request_digest":case.input_hash,"conversation_id":case.conversation_id or "","state_snapshot_id":case.state_snapshot_id})
         try:
             try:
                 proposal=await self._language_input.propose(request.utterance)
@@ -45,11 +48,17 @@ class CognitiveKernel:
                 case.record("input_proposal_unavailable")
                 bundle=validate_proposal(request.utterance, await DeterministicLanguageInput().propose(request.utterance))
             case.interpretation=bundle; selection=accept(bundle)
+            if self._audit: self._audit.append("case.interpreted", {"case_id":case.case_id,"request_id":case.request_id,"request_digest":case.input_hash,"parser_identity":bundle.parser_identity,"candidate_count":len(bundle.candidates)})
             if isinstance(selection, ClarificationRequest):
                 case.clarification=selection
                 # A clarification is an explicit unknown claim, not an evaluation side effect.
                 claim, derivation=execute(type("Unsupported", (), {"operation":"unsupported", "expression":"", "assumptions":()})())
-                case.append_ledger(claim=claim,derivation=derivation); mode=ResponseMode.CLARIFICATION; status=CognitiveCaseStatus.ABSTAINED; accepted_id=None
+                if self._audit: self._audit.append("case.plan_compiled", {"case_id":case.case_id,"request_id":case.request_id,"request_digest":case.input_hash,"operation":"unsupported","plan_digest":"0"*64,"plan_shape":{"operands":0},"domain_snapshot_id":"domain:none","alignment_policy_digest":getattr(policy,"policy_digest","")})
+                case.append_ledger(claim=claim,derivation=derivation)
+                if self._audit: self._audit.append("case.ledger_committed", {"case_id":case.case_id,"request_id":case.request_id,"request_digest":case.input_hash,"claim_digests":[claim.claim_id],"derivation_digests":[derivation.derivation_id],"evidence_ids":[],"evidence":[]})
+                decision = self._alignment.decide(case.claims, case.evidence, case.derivations, policy) if self._alignment is not None else type("D",(),{"accepted": False, "reason_codes": ("unknown_abstain",), "policy_digest":"", "policy_revision":0})()
+                if self._audit: self._audit.append("case.alignment_decided", {"case_id":case.case_id,"request_id":case.request_id,"request_digest":case.input_hash,"accepted":False,"reason_codes":list(decision.reason_codes),"policy_digest":decision.policy_digest,"policy_revision":decision.policy_revision})
+                mode=ResponseMode.CLARIFICATION; status=CognitiveCaseStatus.ABSTAINED; accepted_id=None
             else:
                 case.accepted_interpretation=selection
                 domain_port=getattr(self._state_authority,"domain",None)
@@ -59,12 +68,16 @@ class CognitiveKernel:
                     domain_snapshot_id=getattr(leased_domain,"domain_snapshot_id","domain:none")
                     plan=build_graphix_plan(selection, request_digest=request.utterance.digest, state_snapshot_id=case.state_snapshot_id or "", domain_snapshot_id=domain_snapshot_id)
                     compiled=compile_graphix_plan(plan, request_digest=request.utterance.digest, state_snapshot_id=case.state_snapshot_id or "", domain_snapshot_id=domain_snapshot_id)
-                    if getattr(leased_domain,"domain_snapshot_id",None) != compiled.plan.domain_snapshot_id: raise ValueError("plan snapshot mismatch")
+                    if self._audit: self._audit.append("case.plan_compiled", {"case_id":case.case_id,"request_id":case.request_id,"request_digest":case.input_hash,"operation":compiled.plan.operation,"plan_digest":compiled.plan_digest,"plan_shape":{"operands":len(compiled.plan.operands)},"domain_snapshot_id":domain_snapshot_id,"alignment_policy_digest":getattr(policy,"policy_digest","")})
+                    if leased_domain is not None and getattr(leased_domain,"domain_snapshot_id",None) != compiled.plan.domain_snapshot_id: raise ValueError("plan snapshot mismatch")
                     claim,derivation,evidence=execute_graphix_plan(compiled, request_digest=request.utterance.digest, state_snapshot_id=case.state_snapshot_id or "", domain_snapshot_id=domain_snapshot_id, case_id=case.case_id, domain=leased_domain)
                 finally:
                     if lease_cm is not None: lease_cm.close()
                 case.append_ledger(claim=claim,derivation=derivation,evidence=evidence)
-                mode=ResponseMode.STRICT if claim.status.value in {"computed","retrieved"} else ResponseMode.UNKNOWN; status=CognitiveCaseStatus.SUCCESS if mode is ResponseMode.STRICT else CognitiveCaseStatus.ABSTAINED; accepted_id=selection.interpretation_id
+                if self._audit: self._audit.append("case.ledger_committed", {"case_id":case.case_id,"request_id":case.request_id,"request_digest":case.input_hash,"claim_digests":[c.claim_id for c in case.claims],"derivation_digests":[d.derivation_id for d in case.derivations],"evidence_ids":[e.artifact_id for e in case.evidence],"evidence":[{"evidence_id":e.artifact_id,"origin":e.origin,"content_digest":e.content_digest,"citation":e.citation or "","source_integrity":e.source_integrity,"valid_until":e.valid_until.isoformat().replace("+00:00","Z") if e.valid_until else ""} for e in case.evidence]})
+                decision = self._alignment.decide(case.claims, case.evidence, case.derivations, policy) if self._alignment is not None else type("D",(),{"accepted": claim.status.value in {"computed","retrieved"}, "reason_codes": ("passed",), "policy_digest":"", "policy_revision":0})()
+                if self._audit: self._audit.append("case.alignment_decided", {"case_id":case.case_id,"request_id":case.request_id,"request_digest":case.input_hash,"accepted":decision.accepted,"reason_codes":list(decision.reason_codes),"policy_digest":decision.policy_digest,"policy_revision":decision.policy_revision})
+                mode=ResponseMode.STRICT if decision.accepted and claim.status.value in {"computed","retrieved","proven"} else ResponseMode.UNKNOWN; status=CognitiveCaseStatus.SUCCESS if mode is ResponseMode.STRICT else CognitiveCaseStatus.ABSTAINED; accepted_id=selection.interpretation_id
             response_ir=ResponseIR(RESPONSE_IR_VERSION,f"response-{case.case_id}",case.case_id,accepted_id,case.state_snapshot_id,mode,(claim.claim_id,))
             case.response_ir=response_ir
             # The adapter sees only the projection; firewall rejection is always strict fallback.
@@ -81,14 +94,23 @@ class CognitiveKernel:
                 # Provider/adapter failures are diagnostics only; strict rendering remains authoritative.
                 case.record("output_draft_unavailable")
             artifact=render_strict(response_ir,case.claims,case.derivations,case.evidence); case.render_artifact=artifact; case.record("strict_rendered")
-            finalization=await self._finalizer.finalize(artifact); case.record_finalization(finalization.decision.value); case.close(status)
-            return KernelResult(finalization.public_text,response_ir,status,finalization.decision.value)
+            finalization=await self._finalizer.finalize(artifact); case.record_finalization(finalization.decision.value)
+            if self._audit: self._audit.append("case.finalized", {"case_id":case.case_id,"request_id":case.request_id,"request_digest":case.input_hash,"finalization":finalization.decision.value,"rendered_response_digest":artifact.ir_digest})
+            case.close(status)
+            if self._audit: self._audit.append("case.completed" if status is CognitiveCaseStatus.SUCCESS else "case.abstained", {"case_id":case.case_id,"request_id":case.request_id,"request_digest":case.input_hash,"status":status.value,"rendered_response_digest":artifact.ir_digest})
+            return KernelResult(finalization.public_text if status is CognitiveCaseStatus.SUCCESS else "I cannot complete this request with the available verified evidence.",response_ir,status,finalization.decision.value)
         except asyncio.CancelledError:
             if case.terminal_status is CognitiveCaseStatus.OPEN: case.close(CognitiveCaseStatus.CANCELLED,"cancelled")
             raise
         except Exception as exc:
-            if case.terminal_status is CognitiveCaseStatus.OPEN: case.close(CognitiveCaseStatus.FAILED,type(exc).__name__)
+            if case.terminal_status is CognitiveCaseStatus.OPEN:
+                if self._audit:
+                    try: self._audit.append("case.failed", {"case_id":case.case_id,"request_id":case.request_id,"request_digest":case.input_hash,"category":type(exc).__name__})
+                    except Exception: pass
+                case.close(CognitiveCaseStatus.FAILED,type(exc).__name__)
             raise
+        finally:
+            if alignment_lease is not None: alignment_lease.close()
     def _snapshot_id(self)->str:
         candidate=getattr(self._state_authority,"version",None) or getattr(self._state_authority,"snapshot_id",None)
         if candidate is None: return "world-state:unversioned"

--- a/src/vulcan/runtime/output.py
+++ b/src/vulcan/runtime/output.py
@@ -74,6 +74,8 @@ def project(ir: ResponseIR, claims: tuple[Claim, ...]) -> ResponseIRProjection:
         claim = indexed[claim_id]
         if claim.status is EpistemicStatus.COMPUTED:
             selected.append(ProjectedClaim(claim_id, "computed", claim.proposition.object, claim.status, claim.caveat, claim.citation_ids))
+        elif claim.status is EpistemicStatus.RETRIEVED:
+            selected.append(ProjectedClaim(claim_id, "retrieved", claim.proposition.object, claim.status, claim.caveat, claim.citation_ids))
         elif claim.status in {EpistemicStatus.UNKNOWN, EpistemicStatus.ERROR}:
             selected.append(ProjectedClaim(claim_id, claim.status.value, None, claim.status, claim.caveat, claim.citation_ids))
         else:

--- a/src/vulcan/runtime/semantic.py
+++ b/src/vulcan/runtime/semantic.py
@@ -273,17 +273,15 @@ def execute_graphix_plan(compiled: CompiledGraphixPlan, *, request_digest: str, 
             evidence_artifacts = []
             for i, support in enumerate(getattr(result, "evidence", ())):
                 evidence_artifacts.append(EvidenceArtifact(f"{eid_base}-{i}", EvidenceKind.RETRIEVED_RECORD, support.content_digest, support.uri, f"domain:{support.domain}:{support.revision}:{support.fact_id}:{support.evidence_id}", support.acquisition_method, case_id, state_snapshot_id=state_snapshot_id, observed_at=support.acquired_at, valid_until=support.valid_until, source_integrity="digest-verified", trust_policy="domain-registry", citation=support.uri, limitations=("evidence-truncated",) if getattr(result, "truncated", False) else ()))
+            if not evidence_artifacts:
+                der = Derivation(did, "exact-domain-lookup", "2", (), cid, (), (("key", accepted.expression), ("domain_status", "missing_evidence")), True, ExecutionStatus.NOT_APPLICABLE, canonical_digest((accepted.expression, "missing_evidence")), "domain data unavailable")
+                cl = Claim(cid, Proposition(accepted.expression, "lookup_value", "unavailable"), EpistemicStatus.UNKNOWN, (), (did,), caveat="Domain lookup lacked canonical evidence.")
+                return cl, der, ()
             eids = tuple(e.artifact_id for e in evidence_artifacts)
             der = Derivation(did, "exact-domain-lookup", "2", eids, cid, (), (("key", accepted.expression), ("domain_snapshot_id", domain_snapshot_id)), True, ExecutionStatus.SUCCESS, canonical_digest((accepted.expression, value, eids)))
             cl = Claim(cid, Proposition(accepted.expression, "lookup_value", value), EpistemicStatus.RETRIEVED, eids, (did,), citation_ids=eids, temporal_validity="snapshot-bound")
             return cl, der, tuple(evidence_artifacts)
-        value, citation = result
-        if not _valid_text(value): raise ValueError("lookup miss")
-        eid = eid_base
-        ev = EvidenceArtifact(eid, EvidenceKind.RETRIEVED_RECORD, canonical_digest(value), citation or f"domain:{domain_snapshot_id}:{accepted.expression}", "injected-domain-port", "exact-key", case_id, state_snapshot_id=state_snapshot_id, observed_at=datetime.now(timezone.utc), source_integrity="digest-verified", trust_policy="domain-port", citation=citation)
-        der = Derivation(did, "exact-domain-lookup", "1", (eid,), cid, (), (("key", accepted.expression),), True, ExecutionStatus.SUCCESS, canonical_digest((accepted.expression, value)))
-        cl = Claim(cid, Proposition(accepted.expression, "lookup_value", value), EpistemicStatus.RETRIEVED, (eid,), (did,), citation_ids=(eid,), temporal_validity="snapshot-bound")
-        return cl, der, (ev,)
+        raise ValueError("canonical domain lookup requires typed DomainLookupResult")
     raise ValueError("unsupported canonical operation")
 
 def _bounded_id(value: str) -> bool:

--- a/tests/security/test_graphix_ledger_hardening.py
+++ b/tests/security/test_graphix_ledger_hardening.py
@@ -3,6 +3,7 @@ from datetime import datetime, timezone
 import pytest
 
 from vulcan.runtime.case import CognitiveCase
+from vulcan.runtime.domain_registry import DomainEvidenceSupport, DomainLookupResult
 from vulcan.runtime.semantic import (
     AcceptedInterpretation, Claim, CompiledGraphixPlan, Derivation, EpistemicStatus,
     EvidenceArtifact, EvidenceKind, ExecutionStatus, GraphixPlan, InterpretationProposal,
@@ -81,9 +82,12 @@ def test_arithmetic_precedence_and_resource_syntax_violations():
 
 
 def test_lookup_plan_executes_through_injected_domain_and_strict_rendering():
+    from datetime import datetime, timezone
     class Domain:
         domain_snapshot_id = "domain:1"
-        def lookup_exact(self, key): return ("Paris", "cities:paris")
+        def lookup_exact(self, key):
+            support = DomainEvidenceSupport("geo", 1, "fact-1", "ev-1", "cities:paris", canonical_digest("Paris"), datetime.now(timezone.utc), None, "exact-key", "test", ())
+            return DomainLookupResult("retrieved", key, "Paris", self.domain_snapshot_id, (support,), total_evidence=1)
     acc = AcceptedInterpretation(0, "lookup", "france.capital")
     plan = build_graphix_plan(acc, request_digest="r", state_snapshot_id="s", domain_snapshot_id="domain:1")
     claim, derivation, evidence = execute_graphix_plan(compile_graphix_plan(plan, request_digest="r", state_snapshot_id="s", domain_snapshot_id="domain:1"), request_digest="r", state_snapshot_id="s", domain_snapshot_id="domain:1", case_id="case", domain=Domain())
@@ -91,3 +95,15 @@ def test_lookup_plan_executes_through_injected_domain_and_strict_rendering():
     artifact = render_strict(ir, (claim,), (derivation,), evidence)
     assert "Paris" in artifact.text
     assert "cities:paris" not in artifact.text
+
+
+def test_tuple_only_lookup_provider_cannot_produce_positive_canonical_claim():
+    class LegacyDomain:
+        domain_snapshot_id = "domain:legacy"
+        def lookup_exact(self, key): return ("Paris", "cities:paris")
+    acc = AcceptedInterpretation(0, "lookup", "france.capital")
+    plan = build_graphix_plan(acc, request_digest="r", state_snapshot_id="s", domain_snapshot_id="domain:legacy")
+    compiled = compile_graphix_plan(plan, request_digest="r", state_snapshot_id="s", domain_snapshot_id="domain:legacy")
+    import pytest
+    with pytest.raises(ValueError, match="typed DomainLookupResult"):
+        execute_graphix_plan(compiled, request_digest="r", state_snapshot_id="s", domain_snapshot_id="domain:legacy", case_id="case", domain=LegacyDomain())

--- a/tests/security/test_persistent_audit_alignment.py
+++ b/tests/security/test_persistent_audit_alignment.py
@@ -1,0 +1,96 @@
+import asyncio, json, os, hashlib
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from vulcan.runtime.alignment import AlignmentRegistry, default_policy
+from vulcan.runtime.audit import AuditError, CanonicalAudit
+from vulcan.runtime.case import CognitiveCase, CognitiveCaseStatus
+from vulcan.runtime.finalization import FinalizationDecision, FinalizationResult
+from vulcan.runtime.kernel import CognitiveKernel, KernelRequest
+from vulcan.runtime.semantic import (Claim, Derivation, EpistemicStatus, EvidenceArtifact, EvidenceKind,
+    ExecutionStatus, Proposition, Utterance, canonical_digest)
+
+class Finalizer:
+    async def finalize(self, artifact): return FinalizationResult(FinalizationDecision.ALLOW, artifact, artifact.text)
+
+def data(case="c", digest="0"*64): return {"case_id":case,"request_id":"r","request_digest":digest}
+
+def test_audit_append_reopen_tamper_truncate_duplicate_sequence_close_symlink(tmp_path):
+    p=tmp_path/"audit.jsonl"; a=CanonicalAudit(p); ev=a.append("case.started", data()); payload={"x":["y"]}; a.append("case.interpreted", {**data(), "payload": payload}); payload["x"].append("mutated"); a.close(); a.close()
+    b=CanonicalAudit(p); assert len(b.events_for_case("c"))==2; b.close()
+    with pytest.raises(AuditError): b.append("case.started", data("x"))
+    lines=p.read_text().splitlines(); o=json.loads(lines[0]); o["data"]["case_id"]="d"; p.write_text(json.dumps(o,separators=(",",":"))+"\n"+"\n".join(lines[1:])+"\n")
+    with pytest.raises(AuditError): CanonicalAudit(p)
+    p.write_text(lines[0])
+    with pytest.raises(AuditError): CanonicalAudit(p)
+    p.write_text(lines[0].replace('"sequence":1','"sequence":2')+"\n")
+    with pytest.raises(AuditError): CanonicalAudit(p)
+    p.write_text('{"schema_version":"vulcan-audit/1","schema_version":"x"}\n')
+    with pytest.raises(AuditError): CanonicalAudit(p)
+    os.symlink(tmp_path/"target", tmp_path/"sym.jsonl")
+    with pytest.raises(AuditError): CanonicalAudit(tmp_path/"sym.jsonl")
+
+def test_second_writer_invalid_type_timestamp_and_verified_case_retrieval(tmp_path):
+    a=CanonicalAudit(tmp_path/"a.jsonl"); a.append("case.started", data())
+    with pytest.raises(AuditError): a.append("bad.event", data())
+    with pytest.raises(AuditError): CanonicalAudit(tmp_path/"a.jsonl")
+    assert a.events_for_case("c")[0].event_type=="case.started"
+    a.close()
+    line=(tmp_path/"a.jsonl").read_text(); o=json.loads(line); o["timestamp"]="2020-01-01T00:00:00"; o["event_hash"]="0"*64
+    (tmp_path/"a.jsonl").write_text(json.dumps(o,separators=(",",":"))+"\n")
+    with pytest.raises(AuditError): CanonicalAudit(tmp_path/"a.jsonl")
+
+def test_alignment_policy_load_update_cas_lease_and_fail_closed(tmp_path):
+    a=CanonicalAudit(tmp_path/"audit.jsonl"); r=AlignmentRegistry(tmp_path/"policy.json", audit=a); old=r.active(); lease=r.lease()
+    cand=default_policy().__dict__.copy(); cand.update(revision=2, max_claims_per_response=4, policy_digest=""); cand["permitted_epistemic_statuses"]=list(cand["permitted_epistemic_statuses"]); cand["policy_digest"]=hashlib.sha256(json.dumps({k:v for k,v in sorted(cand.items()) if k!="policy_digest"},ensure_ascii=False,sort_keys=True,separators=(",",":"),allow_nan=False).encode()).hexdigest()
+    new=r.update(cand, expected_previous_digest=old.policy_digest); assert lease.policy.policy_digest==old.policy_digest and r.active().policy_digest==new.policy_digest
+    with pytest.raises(ValueError): r.update(cand, expected_previous_digest=old.policy_digest)
+    lease.close(); r.close(); a.close()
+    (tmp_path/"policy.json").write_text("{}")
+    with pytest.raises(ValueError): AlignmentRegistry(tmp_path/"policy.json")
+
+def test_alignment_blocks_bad_claims_and_passes_valid(tmp_path):
+    r=AlignmentRegistry(tmp_path/"p.json")
+    now=datetime.now(timezone.utc); ev=EvidenceArtifact("e1", EvidenceKind.RETRIEVED_RECORD, canonical_digest("v"), "ref", "origin", "exact", "case", observed_at=now, valid_until=now+timedelta(days=1), source_integrity="digest-verified", citation="ref")
+    d=Derivation("d1","m","1",("e1",),"c1",(),(),True,ExecutionStatus.SUCCESS,"t")
+    c=Claim("c1", Proposition("s","p","v"), EpistemicStatus.RETRIEVED, ("e1",), ("d1",), citation_ids=("e1",))
+    assert r.decide((c,), (ev,), (d,)).accepted
+    assert not r.decide((c,), (EvidenceArtifact("e1", EvidenceKind.RETRIEVED_RECORD, canonical_digest("v"), "ref", "origin", "exact", "case", observed_at=now, source_integrity="bad"),), (d,)).accepted
+    expired=EvidenceArtifact("e1", EvidenceKind.RETRIEVED_RECORD, canonical_digest("v"), "ref", "origin", "exact", "case", observed_at=now-timedelta(days=2), valid_until=now-timedelta(days=1), source_integrity="digest-verified", citation="ref")
+    assert not r.decide((c,), (expired,), (d,)).accepted
+    assert not r.decide(tuple([c]*9), (ev,), (d,)).accepted
+
+def test_completed_append_failure_blocks_positive_response(tmp_path):
+    class FailingAudit(CanonicalAudit):
+        def append(self,t,d):
+            if t=="case.completed": raise AuditError("disk full")
+            return super().append(t,d)
+    audit=FailingAudit(tmp_path/"a.jsonl"); align=AlignmentRegistry(tmp_path/"p.json")
+    k=CognitiveKernel(state_authority=SimpleNamespace(version="1"), finalizer=Finalizer(), audit=audit, alignment=align)
+    u=Utterance.from_text("2+2"); case=CognitiveCase.create(request_id="r", conversation_id=None, input_digest=u.digest)
+    with pytest.raises(AuditError): asyncio.run(k.handle(KernelRequest(u,None), case))
+    assert case.terminal_status is CognitiveCaseStatus.SUCCESS  # positive was computed but not released
+
+def test_no_raw_prompt_token_or_secret_in_case_events(tmp_path):
+    audit=CanonicalAudit(tmp_path/"a.jsonl"); align=AlignmentRegistry(tmp_path/"p.json")
+    k=CognitiveKernel(state_authority=SimpleNamespace(version="1"), finalizer=Finalizer(), audit=audit, alignment=align)
+    u=Utterance.from_text("secret token 2+2"); case=CognitiveCase.create(request_id="r", conversation_id=None, input_digest=u.digest)
+    asyncio.run(k.handle(KernelRequest(u,None), case))
+    txt=(tmp_path/"a.jsonl").read_text().lower()
+    assert "secret token" not in txt and "authorization" not in txt
+
+def test_activation_audit_failures_leave_prior_domain_and_policy_active(tmp_path):
+    from tests.security.test_persistent_domain_registry import bundle
+    class Fail:
+        def __init__(self): self.fail=False
+        def append(self, t, d):
+            if self.fail: raise AuditError("audit down")
+    fail=Fail(); from vulcan.runtime.domain_registry import PersistentDomainRegistry
+    dom=PersistentDomainRegistry(tmp_path/"dom", audit=fail); sid1=dom.load_bundle(bundle('geo',1,'Paris')); fail.fail=True
+    with pytest.raises(AuditError): dom.load_bundle(bundle('geo',2,'Lyon'), expected_previous_digest=dom._active.domains['geo'].digest)
+    assert dom.domain_snapshot_id==sid1 and dom.lookup_exact('france.capital').value=='paris'
+    fail.fail=False; ar=AlignmentRegistry(tmp_path/"policy2.json", audit=fail); old=ar.active(); cand=default_policy().__dict__.copy(); cand.update(revision=2, max_claims_per_response=4, policy_digest=""); cand["permitted_epistemic_statuses"]=list(cand["permitted_epistemic_statuses"]); cand["policy_digest"]=hashlib.sha256(json.dumps({k:v for k,v in sorted(cand.items()) if k!="policy_digest"},ensure_ascii=False,sort_keys=True,separators=(",",":"),allow_nan=False).encode()).hexdigest(); fail.fail=True
+    with pytest.raises(AuditError): ar.update(cand, expected_previous_digest=old.policy_digest)
+    assert ar.active().policy_digest==old.policy_digest


### PR DESCRIPTION
### Motivation
- Close the Phase 3 compatibility gap and remove accidental canonical acceptance of legacy `(value, citation)` tuple domain lookups by requiring typed domain lookup results with explicit evidence. 
- Provide a single dependency-light, append-only canonical audit owner to enforce durable, verifiable case and activation lifecycles and to fail closed on audit problems. 
- Introduce a versioned, CAS-updated alignment policy registry that can be leased per-request so in-flight requests use a stable immutable policy snapshot.
- Wire a single shared audit and alignment owner into the canonical runtime composition so kernel, domain registry, and alignment decisions share one trusted source of truth.

### Description
- Added `vulcan-audit/1` canonical audit owner (`src/vulcan/runtime/audit.py`) implementing append-only JSONL events with duplicate-key rejection, canonical UTF-8 JSON hashing (SHA-256), sequence/hash chaining verification, bounded/validated event data, UTC timestamps, writer lock, fsync-backed append, idempotent close, startup integrity verification, and verified per-case retrieval.
- Added `vulcan-alignment/1` alignment registry (`src/vulcan/runtime/alignment.py`) implementing strict duplicate-key-free policy parsing, canonical policy digests, conservative default policy, CAS-based updates requiring larger revisions and expected previous digest, atomic persistence with tmp-file replace + fsync, leasing semantics, readiness verification, and deterministic ledger-based decision reasoning with bounded reason codes.
- Required typed domain lookup results in `execute_graphix_plan` and removed the legacy tuple-to-positive-claim conversion, returning an error when a legacy tuple is supplied; added a regression test proving a tuple-only provider cannot produce a positive canonical claim. (`src/vulcan/runtime/semantic.py`, `tests/security/test_graphix_ledger_hardening.py`)
- Wired `RuntimeContainer` to own exactly one `CanonicalAudit`, one `AlignmentRegistry`, and the `PersistentDomainRegistry`, injecting them into the `CognitiveKernel`, readiness, and shutdown flows, and ensuring deduplicated close behavior. (`src/vulcan/runtime/container.py`)
- Extended `CognitiveKernel` to: lease the ingress alignment snapshot, emit audited lifecycle events (`case.started`, `case.interpreted`, `case.plan_compiled`, `case.ledger_committed`, `case.alignment_decided`, `case.finalized`, `case.completed` / `case.abstained` / `case.failed`), evaluate alignment deterministically against the validated case-local ledger, prevent positive release unless `case.completed` is durably appended, and fail closed on audit append failures. (`src/vulcan/runtime/kernel.py`)
- Changed domain activation ordering so activation is audited before persistence/publication to avoid publishing unaudited active revisions. (`src/vulcan/runtime/domain_registry.py`)
- Expanded strict rendering projection to permit `RETRIEVED` claims that have passed ledger and alignment checks. (`src/vulcan/runtime/output.py`)
- Added a focused adversarial test module covering audit and alignment behaviors and lifecycle edge cases. (`tests/security/test_persistent_audit_alignment.py`)

### Testing
- Ran focused unit tests: `pytest -q tests/security/test_persistent_domain_registry.py tests/security/test_graphix_ledger_hardening.py tests/security/test_persistent_audit_alignment.py` and observed `26 passed`.
- Verified repository-in-path run from `/tmp`: `cd /tmp && PYTHONPATH=/workspace/VulcanAMI_LLM/src pytest -q /workspace/VulcanAMI_LLM/tests/security/test_persistent_domain_registry.py /workspace/VulcanAMI_LLM/tests/security/test_graphix_ledger_hardening.py /workspace/VulcanAMI_LLM/tests/security/test_persistent_audit_alignment.py` and observed `26 passed`.
- Performed bytecode checks: `python -m compileall -q src` and `python -O -m compileall -q src`; both succeeded.
- Ran dependency-light diagnostics demonstrating runtime behavior: a small async diagnostic exercised arithmetic and typed domain lookup (computed and retrieved successes), an audit tamper/reopen diagnostic produced a detected `audit hash mismatch`, and a concurrent alignment snapshot diagnostic showed leased policy immutability (`leased` stayed on old digest while `active` moved to the new revision).
- `git diff --check` reported no whitespace or diff-check issues.

All automated tests and compile checks executed for this phase passed locally; async pytest plugin constraints prevented running some async test harness permutations, so `asyncio.run(...)` diagnostics were used where appropriate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b5ec0f6e4832fbdeeaea4fc6996c2)