### PR TITLE
Implement verified local transformer language adapter

### DIFF
--- a/src/vulcan/local_language/__init__.py
+++ b/src/vulcan/local_language/__init__.py
@@ -12,7 +12,8 @@ from .release import (
     verify_release,
 )
 
-__all__ = ["LocalLanguageRelease", "ReleaseRole", "ReleaseVerificationError", "verify_release"]
+__all__ = ["LocalLanguageRelease", "ReleaseRole", "ReleaseVerificationError", "verify_release", "VerifiedLocalSpanCompletion", "VerifiedAdapterMetadata", "parse_transformer_span_proposal", "SpanProposalError", "RUNTIME_ABI", "ImmutableTokenizerContract", "load_tokenizer_contract", "validate_tokenizer_contract", "decode_generated_suffix", "build_verified_adapter"]
 
 from .governance import DatasetManifest, DatasetSource, ExampleRole, LanguageExample, ReleaseState
-from .tokenizer import ImmutableTokenizerContract, load_tokenizer_contract
+from .tokenizer import ImmutableTokenizerContract, load_tokenizer_contract, validate_tokenizer_contract, decode_generated_suffix
+from .adapter import VerifiedLocalSpanCompletion, VerifiedAdapterMetadata, parse_transformer_span_proposal, SpanProposalError, RUNTIME_ABI, build_verified_adapter

--- a/src/vulcan/local_language/adapter.py
+++ b/src/vulcan/local_language/adapter.py
@@ -1,0 +1,134 @@
+"""Verified transformer span adapter for the canonical language input port."""
+from __future__ import annotations
+import asyncio, json, math, threading
+from dataclasses import dataclass
+from typing import Any, Protocol
+from vulcan.runtime.semantic import InterpretationProposal, ProposedCandidate, SCHEMA_VERSION, SourceSpan, Utterance
+
+PROPOSAL_SCHEMA="transformer-span-proposal/1"
+RUNTIME_ABI="vulcan-transformer-span/1"
+ALLOWED_OPERATIONS=frozenset({"arithmetic","lookup","memory_read","memory_write","memory_forget","unsupported"})
+ARGS={"arithmetic":frozenset({"expression"}),"lookup":frozenset({"key"}),"memory_read":frozenset({"request_span"}),"memory_write":frozenset({"request_span"}),"memory_forget":frozenset({"request_span"}),"unsupported":frozenset({"request_span"})}
+FORBIDDEN=frozenset({"answer","response","prose","markdown","evidence","citation","citations","domain_hint","domain","graphix_plan","plan","code","tool","tools","sql","path","parameters","facts","value","values","memory_identity","policy"})
+
+class SpanProposalError(ValueError): pass
+class AdapterClosedError(RuntimeError): pass
+
+def _pairs(pairs):
+    d={}
+    for k,v in pairs:
+        if k in d: raise SpanProposalError(f"duplicate JSON key: {k}")
+        d[k]=v
+    return d
+
+def _bad_const(x): raise SpanProposalError("non-finite JSON number")
+
+def _loads_exact(raw: str) -> Any:
+    if not isinstance(raw,str) or not raw or len(raw)>16384: raise SpanProposalError("invalid proposal bytes")
+    dec=json.JSONDecoder(object_pairs_hook=_pairs, parse_constant=_bad_const)
+    try: obj,end=dec.raw_decode(raw)
+    except json.JSONDecodeError as exc: raise SpanProposalError("invalid proposal JSON") from exc
+    if end != len(raw): raise SpanProposalError("proposal has trailing data")
+    # Enforce canonical/minimal JSON so prose stripping and alternate NaN spellings never pass.
+    if json.dumps(obj,ensure_ascii=False,sort_keys=True,separators=(",",":"),allow_nan=False) != raw:
+        raise SpanProposalError("noncanonical proposal JSON")
+    return obj
+
+def _span(v: Any, text_len:int) -> SourceSpan:
+    if not isinstance(v,dict) or set(v)!={"start","end"}: raise SpanProposalError("invalid span schema")
+    s,e=v["start"],v["end"]
+    if type(s) is not int or type(e) is not int or s<0 or e<=s or e>text_len: raise SpanProposalError("invalid source span")
+    return SourceSpan(s,e)
+
+def parse_transformer_span_proposal(raw: str, utterance: Utterance) -> InterpretationProposal:
+    obj=_loads_exact(raw)
+    if not isinstance(obj,dict) or set(obj)!={"schema_version","candidates"}: raise SpanProposalError("invalid proposal schema")
+    if obj["schema_version"]!=PROPOSAL_SCHEMA: raise SpanProposalError("unsupported proposal schema")
+    cands=obj["candidates"]
+    if not isinstance(cands,list) or not 1<=len(cands)<=4: raise SpanProposalError("invalid candidates")
+    out=[]
+    occupied=[]
+    for c in cands:
+        if not isinstance(c,dict) or set(c)!={"operation","span","argument_spans","confidence"}: raise SpanProposalError("invalid candidate schema")
+        if set(c) & FORBIDDEN: raise SpanProposalError("forbidden proposal field")
+        op=c["operation"]
+        if op not in ALLOWED_OPERATIONS: raise SpanProposalError("invalid operation")
+        conf=c["confidence"]
+        if isinstance(conf,bool) or not isinstance(conf,(int,float)) or not math.isfinite(float(conf)) or not (0.0<=float(conf)<=1.0): raise SpanProposalError("invalid confidence")
+        span=_span(c["span"], len(utterance.text))
+        args=c["argument_spans"]
+        allowed=ARGS[op]
+        if not isinstance(args,dict) or set(args)!=allowed: raise SpanProposalError("invalid operation arguments")
+        spans=[span]
+        for name,val in args.items():
+            if name in FORBIDDEN: raise SpanProposalError("forbidden argument")
+            if not isinstance(val,dict): raise SpanProposalError("literal argument value rejected")
+            spans.append(_span(val,len(utterance.text)))
+        # no overlapping argument spans; candidate span may contain them
+        argsp=spans[1:]
+        for i,a in enumerate(argsp):
+            for b in argsp[i+1:]:
+                if max(a.start,b.start) < min(a.end,b.end): raise SpanProposalError("overlapping argument spans")
+        expr_span=next(iter(args.values()))
+        expr=utterance.text[expr_span["start"]:expr_span["end"]].strip()
+        out.append(ProposedCandidate(op, expr, _span(expr_span,len(utterance.text)), float(conf)))
+        occupied.append((span.start,span.end))
+    out.sort(key=lambda x: x.diagnostic_confidence or 0.0, reverse=True)
+    return InterpretationProposal(SCHEMA_VERSION, tuple(out), "verified-local-transformer-span/1")
+
+class RawSpanProvider(Protocol):
+    def generate(self, prompt: str, *, max_tokens:int) -> str: ...
+
+PROMPT_CONTRACT='Return exactly canonical JSON schema transformer-span-proposal/1 with operation and spans only. Request:'
+
+@dataclass(frozen=True)
+class VerifiedAdapterMetadata:
+    release_digest: str; runtime_abi: str=RUNTIME_ABI; mode: str="transformer_proposal"
+
+class VerifiedLocalSpanCompletion:
+    def __init__(self, *, provider: RawSpanProvider, tokenizer: Any, metadata: VerifiedAdapterMetadata, context_length:int, max_generated_tokens:int, timeout_seconds:float=2.0, concurrency_safe:bool=False):
+        self._provider=provider; self._tokenizer=tokenizer; self.metadata=metadata; self.context_length=context_length; self.max_generated_tokens=max_generated_tokens; self.timeout_seconds=timeout_seconds; self._closed=False; self._lock=threading.Lock() if not concurrency_safe else None
+    def readiness(self):
+        if self._closed: raise AdapterClosedError("adapter closed")
+        return {"mode":"transformer_proposal","runtime_abi":self.metadata.runtime_abi,"release_digest":self.metadata.release_digest}
+    def _enc_len(self, text:str)->int:
+        enc=getattr(self._tokenizer,"encode",None)
+        return len(enc(text)) if callable(enc) else len(text)
+    async def propose(self, utterance: Utterance) -> InterpretationProposal:
+        if self._closed: raise AdapterClosedError("adapter closed")
+        prompt=f"{PROMPT_CONTRACT}\n{utterance.text}\n"
+        if self._enc_len(PROMPT_CONTRACT)+self._enc_len(utterance.text)+2+self.max_generated_tokens>self.context_length: raise SpanProposalError("context overflow")
+        def call():
+            if self._lock:
+                with self._lock: return self._provider.generate(prompt,max_tokens=self.max_generated_tokens)
+            return self._provider.generate(prompt,max_tokens=self.max_generated_tokens)
+        raw=await asyncio.wait_for(asyncio.to_thread(call), timeout=self.timeout_seconds)
+        if not isinstance(raw,str): raise SpanProposalError("provider returned non-text")
+        return parse_transformer_span_proposal(raw, utterance)
+    def close(self):
+        if self._closed: return
+        self._closed=True
+        close=getattr(self._provider,"close",None)
+        if close: close()
+
+def build_verified_adapter(*, release_root: str, provider_factory, tokenizer_loader=None, timeout_seconds: float = 2.0) -> VerifiedLocalSpanCompletion:
+    """Verify release, construct provider, verify again, closing provider on mutation."""
+    from pathlib import Path
+    from .release import verify_release
+    from .tokenizer import load_tokenizer_contract
+    root=Path(release_root)
+    first=verify_release(root)
+    provider=None
+    try:
+        provider=provider_factory(first)
+        tokenizer=(tokenizer_loader or load_tokenizer_contract)(root / first.tokenizer_artifact)
+        second=verify_release(root)
+        if second.manifest_digest != first.manifest_digest:
+            raise SpanProposalError("release changed during adapter construction")
+        cfg=second.provider_config
+        return VerifiedLocalSpanCompletion(provider=provider, tokenizer=tokenizer, metadata=VerifiedAdapterMetadata(second.manifest_digest), context_length=cfg.approved_context_length if cfg else 0, max_generated_tokens=cfg.max_generated_proposal_tokens if cfg else 0, timeout_seconds=timeout_seconds)
+    except Exception:
+        if provider is not None:
+            close=getattr(provider,"close",None)
+            if close: close()
+        raise

--- a/src/vulcan/local_language/release.py
+++ b/src/vulcan/local_language/release.py
@@ -1,179 +1,173 @@
-"""Fail-closed, offline verification for a local language adapter release.
+"""Fail-closed verification for local transformer span language releases.
 
-A manifest identifies a complete, role-specific artifact set.  This module does
-*not* load models or select a release for serving; it only gives offline release
-processes a small, deterministic verifier.  It intentionally makes no signing,
-provenance, safety, or quality claim beyond the fields and bytes it verifies.
+Approval fields and hashes prove only local byte integrity and promotion state
+within this verifier. They do not prove publisher identity unless paired with an
+external signature, and they do not prove general reasoning correctness. This
+repository intentionally bundles no promoted neural release; deterministic mode
+therefore remains the safe default whenever an approved release is absent.
 """
 from __future__ import annotations
-
-import hashlib
-import json
-import re
+import hashlib,json,math,os,re,stat,unicodedata
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Any
+from .adapter import RUNTIME_ABI
 
-_MANIFEST_SCHEMA = "local-language-release/1"
-_SHA256 = re.compile(r"^[0-9a-f]{64}$")
-_IDENTIFIER = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
-_REQUIRED_ARTIFACTS = frozenset({"weights", "tokenizer", "config", "evaluation_report"})
-
-
-class ReleaseVerificationError(ValueError):
-    """The release is incomplete, unapproved, or differs from its manifest."""
-
-
-class ReleaseRole(str, Enum):
-    INPUT = "input-language-adapter"
-    OUTPUT = "output-language-adapter"
-
-
+_MANIFEST_SCHEMA="local-language-release/1"; _PROVIDER_SCHEMA="local-gpt-span-provider/1"; _EVAL_SCHEMA="local-language-evaluation/1"
+_SHA256=re.compile(r"^[0-9a-f]{64}$"); _IDENTIFIER=re.compile(r"^[a-z0-9][a-z0-9._:-]{0,127}$")
+_REQUIRED_ARTIFACTS=frozenset({"weights","tokenizer","config","evaluation_report"})
+_ARTIFACT_FILES={"weights":"weights.safetensors","tokenizer":"tokenizer.json","config":"config.json","evaluation_report":"evaluation.json"}
+MAX_MANIFEST=262_144; MAX_ARTIFACT=64*1024*1024; MAX_JSON=4*1024*1024
+REQ_CATS=frozenset({"valid_operation_span_accuracy","malformed_output_rejection","fact_answer_injection_rejection","domain_hint_rejection","unicode_span_correctness","context_overflow_handling","deterministic_repeated_generation","fallback_behavior"})
+class ReleaseVerificationError(ValueError): pass
+class ReleaseRole(str,Enum): INPUT="input-language-adapter"; OUTPUT="output-language-adapter"
 @dataclass(frozen=True)
-class Artifact:
-    name: str
-    path: str
-    sha256: str
-
-
+class Artifact: name:str; path:str; sha256:str; byte_size:int
 @dataclass(frozen=True)
-class Evaluation:
-    report_sha256: str
-    deterministic_baseline: str
-    baseline_score: float
-    candidate_score: float
-    zero_tolerance_passed: bool
-
-
+class Evaluation: report_sha256:str; passed:bool; categories:tuple[str,...]
+@dataclass(frozen=True)
+class ProviderConfig:
+    architecture:str; vocabulary_size:int; embedding_width:int; layer_count:int; attention_head_count:int; feed_forward_width:int; approved_context_length:int; max_generated_proposal_tokens:int; special_token_ids:dict[str,int]; dropout:float; generation_method:str
 @dataclass(frozen=True)
 class LocalLanguageRelease:
-    release_id: str
-    role: ReleaseRole
-    runtime_abi: str
-    license_identifier: str
-    promotion_state: str
-    approval_id: str | None
-    artifacts: tuple[Artifact, ...]
-    evaluation: Evaluation
+    release_id:str; version:str; role:ReleaseRole; runtime_abi:str; provider_implementation:str; provider_config_artifact:str; tokenizer_artifact:str; weights_artifact:str; evaluation_report_artifact:str; release_created:str; manifest_digest:str; promotion_state:str; approval_id:str; artifacts:tuple[Artifact,...]; evaluation:Evaluation; provider_config:ProviderConfig|None=None
 
+def _pairs(p):
+    d={}
+    for k,v in p:
+        if k in d: raise ReleaseVerificationError(f"duplicate JSON key: {k}")
+        d[k]=v
+    return d
 
-def _no_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
-    result: dict[str, Any] = {}
-    for key, value in pairs:
-        if key in result:
-            raise ReleaseVerificationError(f"duplicate JSON key: {key}")
-        result[key] = value
-    return result
+def _bad_const(x): raise ReleaseVerificationError("non-finite JSON number")
+def _read(path:Path,limit:int)->bytes:
+    st1=path.lstat()
+    if stat.S_ISLNK(st1.st_mode) or not stat.S_ISREG(st1.st_mode): raise ReleaseVerificationError("artifact is not a regular release file")
+    if st1.st_size<0 or st1.st_size>limit: raise ReleaseVerificationError("artifact size bound")
+    data=path.read_bytes()
+    st2=path.lstat()
+    if (st1.st_mode,st1.st_size)!=(st2.st_mode,st2.st_size): raise ReleaseVerificationError("artifact changed during verification")
+    if len(data)!=st1.st_size: raise ReleaseVerificationError("artifact read race")
+    return data
 
+def _load_json(path:Path,limit:int):
+    try: return json.loads(_read(path,limit).decode("utf-8"), object_pairs_hook=_pairs, parse_constant=_bad_const)
+    except ReleaseVerificationError: raise
+    except Exception as exc: raise ReleaseVerificationError("invalid bounded JSON artifact") from exc
 
-def _mapping(value: object, label: str, expected: set[str]) -> dict[str, Any]:
-    if not isinstance(value, dict) or set(value) != expected:
-        raise ReleaseVerificationError(f"invalid {label} schema")
-    return value
+def _mapping(v,label,keys):
+    if not isinstance(v,dict) or set(v)!=set(keys): raise ReleaseVerificationError(f"invalid {label} schema")
+    return v
 
+def _str(v,label,pat=_IDENTIFIER):
+    if not isinstance(v,str) or not pat.fullmatch(v): raise ReleaseVerificationError(f"invalid {label}")
+    return v
 
-def _string(value: object, label: str) -> str:
-    if not isinstance(value, str) or not value:
-        raise ReleaseVerificationError(f"invalid {label}")
-    return value
+def _num(v,label,lo,hi,integer=True):
+    if isinstance(v,bool) or not isinstance(v,(int,float)) or not math.isfinite(float(v)): raise ReleaseVerificationError(f"invalid {label}")
+    if integer and type(v) is not int: raise ReleaseVerificationError(f"invalid {label}")
+    if not lo<=float(v)<=hi: raise ReleaseVerificationError(f"invalid {label}")
+    return int(v) if integer else float(v)
 
-
-def _score(value: object, label: str) -> float:
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        raise ReleaseVerificationError(f"invalid {label}")
-    result = float(value)
-    if result != result or result in (float("inf"), float("-inf")):
-        raise ReleaseVerificationError(f"invalid {label}")
-    return result
-
-
-def _safe_path(root: Path, relative: str) -> Path:
-    candidate = Path(relative)
-    if candidate.is_absolute() or ".." in candidate.parts or not relative:
-        raise ReleaseVerificationError("artifact path escapes release root")
-    resolved_root = root.resolve(strict=True)
-    resolved = (resolved_root / candidate).resolve(strict=True)
-    if resolved_root not in resolved.parents:
-        raise ReleaseVerificationError("artifact path escapes release root")
-    if not resolved.is_file() or resolved.is_symlink():
-        raise ReleaseVerificationError("artifact is not a regular release file")
+def _safe_path(root:Path,relative:str, *, exact_filename:bool=True)->Path:
+    if not isinstance(relative,str) or not relative or Path(relative).is_absolute() or ".." in Path(relative).parts: raise ReleaseVerificationError("artifact path escapes release root")
+    if exact_filename and ("/" in relative or "\\" in relative): raise ReleaseVerificationError("artifact filename must not contain separators")
+    try:
+        base=root.resolve(strict=True); resolved=(base/relative).resolve(strict=True)
+    except OSError as exc: raise ReleaseVerificationError("artifact path missing") from exc
+    if base != resolved.parent and base not in resolved.parents: raise ReleaseVerificationError("artifact path escapes release root")
     return resolved
 
+def _digest_bytes(data:bytes)->str: return hashlib.sha256(data).hexdigest()
+def _manifest_claim_digest(raw:Any)->str:
+    clone=json.loads(json.dumps(raw,ensure_ascii=False,sort_keys=True,separators=(",",":")))
+    if isinstance(clone,dict):
+        clone["canonical_manifest_digest"]="0"*64
+        if isinstance(clone.get("approval"),dict): clone["approval"]["manifest_digest"]="0"*64
+    return hashlib.sha256(json.dumps(clone,ensure_ascii=False,sort_keys=True,separators=(",",":"),allow_nan=False).encode()).hexdigest()
+def _timestamp(v):
+    if not isinstance(v,str) or not re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z",v): raise ReleaseVerificationError("invalid timestamp")
+    return v
 
-def _digest(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as stream:
-        for block in iter(lambda: stream.read(1024 * 1024), b""):
-            digest.update(block)
-    return digest.hexdigest()
+def validate_provider_config(raw:Any)->ProviderConfig:
+    keys={"schema_version","model_architecture","vocabulary_size","embedding_width","layer_count","attention_head_count","feed_forward_width","approved_context_length","max_generated_proposal_tokens","special_token_ids","dropout","generation_method"}
+    r=_mapping(raw,"provider config",keys)
+    if r["schema_version"]!=_PROVIDER_SCHEMA: raise ReleaseVerificationError("unsupported provider schema")
+    arch=_str(r["model_architecture"],"architecture")
+    vocab=_num(r["vocabulary_size"],"vocabulary_size",32,65536); emb=_num(r["embedding_width"],"embedding_width",8,4096); heads=_num(r["attention_head_count"],"attention_head_count",1,128)
+    if emb%heads: raise ReleaseVerificationError("embedding width must divide by attention heads")
+    layers=_num(r["layer_count"],"layer_count",1,96); ff=_num(r["feed_forward_width"],"feed_forward_width",8,16384); ctx=_num(r["approved_context_length"],"context",64,32768); maxg=_num(r["max_generated_proposal_tokens"],"max generated",8,2048)
+    specials=_mapping(r["special_token_ids"],"special_token_ids",{"bos","eos","pad","unk"})
+    spec={k:_num(v,k,0,vocab-1) for k,v in specials.items()}
+    if len(set(spec.values()))!=4: raise ReleaseVerificationError("special-token collision")
+    dropout=_num(r["dropout"],"dropout",0,0,integer=False)
+    if r["generation_method"]!="greedy": raise ReleaseVerificationError("serving generation must be deterministic greedy")
+    return ProviderConfig(arch,vocab,emb,layers,heads,ff,ctx,maxg,spec,dropout,"greedy")
 
+def validate_evaluation_report(raw:Any, release_id:str)->Evaluation:
+    r=_mapping(raw,"evaluation",{"schema_version","release_id","runtime_abi","dataset_digest","categories","metrics","thresholds","passed","evaluated_at","evaluator"})
+    if r["schema_version"]!=_EVAL_SCHEMA or r["release_id"]!=release_id or r["runtime_abi"]!=RUNTIME_ABI: raise ReleaseVerificationError("evaluation identity mismatch")
+    _str(r["dataset_digest"],"dataset digest",_SHA256); _timestamp(r["evaluated_at"]); _str(r["evaluator"],"evaluator")
+    cats=r["categories"]
+    if not isinstance(cats,list) or set(cats)!=REQ_CATS or len(cats)!=len(set(cats)): raise ReleaseVerificationError("evaluation categories incomplete")
+    metrics=_mapping(r["metrics"],"metrics",REQ_CATS); thresholds=_mapping(r["thresholds"],"thresholds",REQ_CATS)
+    for c in REQ_CATS:
+        if _num(metrics[c],c,0,1,integer=False) < _num(thresholds[c],c,0,1,integer=False):
+            if r["passed"] is True: raise ReleaseVerificationError("evaluation metric/status inconsistency")
+            raise ReleaseVerificationError("evaluation failed")
+    if r["passed"] is not True: raise ReleaseVerificationError("evaluation failed")
+    return Evaluation("", True, tuple(sorted(cats)))
 
-def _parse_manifest(raw: object) -> LocalLanguageRelease:
-    manifest = _mapping(raw, "release manifest", {
-        "schema_version", "release_id", "role", "runtime_abi", "license_identifier",
-        "promotion", "artifacts", "evaluation",
-    })
-    release_id = _string(manifest["release_id"], "release_id")
-    if not _IDENTIFIER.fullmatch(release_id):
-        raise ReleaseVerificationError("invalid release_id")
-    if manifest["schema_version"] != _MANIFEST_SCHEMA:
-        raise ReleaseVerificationError("unsupported manifest schema")
-    try:
-        role = ReleaseRole(manifest["role"])
-    except (TypeError, ValueError) as exc:
-        raise ReleaseVerificationError("unsupported language-adapter role") from exc
-    promotion = _mapping(manifest["promotion"], "promotion", {"state", "approval_id"})
-    state = _string(promotion["state"], "promotion state")
-    approval = promotion["approval_id"]
-    if state != "approved" or not isinstance(approval, str) or not _IDENTIFIER.fullmatch(approval):
-        raise ReleaseVerificationError("release is not explicitly approved")
-    items = manifest["artifacts"]
-    if not isinstance(items, list) or not items:
-        raise ReleaseVerificationError("invalid artifacts")
-    artifacts: list[Artifact] = []
-    for item in items:
-        artifact = _mapping(item, "artifact", {"name", "path", "sha256"})
-        name, path, digest = (_string(artifact[key], key) for key in ("name", "path", "sha256"))
-        if not _IDENTIFIER.fullmatch(name) or not _SHA256.fullmatch(digest):
-            raise ReleaseVerificationError("invalid artifact identity")
-        artifacts.append(Artifact(name, path, digest))
-    if {item.name for item in artifacts} != _REQUIRED_ARTIFACTS or len({item.path for item in artifacts}) != len(artifacts):
-        raise ReleaseVerificationError("release must bind weights, tokenizer, config, and evaluation report exactly once")
-    evaluation_raw = _mapping(manifest["evaluation"], "evaluation", {
-        "report_sha256", "deterministic_baseline", "baseline_score", "candidate_score", "zero_tolerance_passed",
-    })
-    report = _string(evaluation_raw["report_sha256"], "evaluation report digest")
-    if not _SHA256.fullmatch(report):
-        raise ReleaseVerificationError("invalid evaluation report digest")
-    evaluation = Evaluation(report, _string(evaluation_raw["deterministic_baseline"], "deterministic baseline"),
-                            _score(evaluation_raw["baseline_score"], "baseline score"),
-                            _score(evaluation_raw["candidate_score"], "candidate score"),
-                            evaluation_raw["zero_tolerance_passed"] is True)
-    if next(item.sha256 for item in artifacts if item.name == "evaluation_report") != evaluation.report_sha256:
-        raise ReleaseVerificationError("evaluation report is not bound to its artifact")
-    if not evaluation.zero_tolerance_passed or evaluation.candidate_score <= evaluation.baseline_score:
-        raise ReleaseVerificationError("evaluation does not justify neural activation")
-    return LocalLanguageRelease(release_id, role, _string(manifest["runtime_abi"], "runtime ABI"),
-                                _string(manifest["license_identifier"], "license identifier"), state, approval,
-                                tuple(artifacts), evaluation)
+def _parse_manifest(raw:Any)->LocalLanguageRelease:
+    keys={"schema_version","release_id","version","role","runtime_abi","provider_implementation","provider_config_artifact","tokenizer_artifact","weights_artifact","evaluation_report_artifact","release_created","canonical_manifest_digest","approval","evaluation","artifacts"}
+    m=_mapping(raw,"release manifest",keys)
+    if m["schema_version"]!=_MANIFEST_SCHEMA: raise ReleaseVerificationError("unsupported manifest schema")
+    rid=_str(m["release_id"],"release_id"); ver=_str(m["version"],"version")
+    if m["role"]!=ReleaseRole.INPUT.value: raise ReleaseVerificationError("unsupported language-adapter role")
+    if m["runtime_abi"]!=RUNTIME_ABI: raise ReleaseVerificationError("unsupported runtime ABI")
+    impl=_str(m["provider_implementation"],"provider implementation")
+    approval=_mapping(m["approval"],"approval",{"state","approval_id","approved_by","approved_at","manifest_digest"})
+    if approval["state"]!="approved" or not _IDENTIFIER.fullmatch(str(approval["approval_id"])): raise ReleaseVerificationError("release is not explicitly approved")
+    _timestamp(approval["approved_at"]); _str(approval["approved_by"],"approved_by"); _str(approval["manifest_digest"],"approval digest",_SHA256)
+    evmeta=_mapping(m["evaluation"],"evaluation metadata",{"passed","report_sha256"})
+    if evmeta["passed"] is not True or not _SHA256.fullmatch(str(evmeta["report_sha256"])): raise ReleaseVerificationError("evaluation metadata not passing")
+    artifacts=[]; items=m["artifacts"]
+    if not isinstance(items,list): raise ReleaseVerificationError("invalid artifacts")
+    for it in items:
+        a=_mapping(it,"artifact",{"name","path","sha256","byte_size"}); name=_str(a["name"],"artifact name")
+        path=a["path"]; sha=_str(a["sha256"],"artifact digest",_SHA256); size=_num(a["byte_size"],"artifact size",1,MAX_ARTIFACT)
+        artifacts.append(Artifact(name,path,sha,size))
+    if {a.name for a in artifacts}!=_REQUIRED_ARTIFACTS or len(artifacts)!=4 or len({a.path for a in artifacts})!=4: raise ReleaseVerificationError("release must bind fixed artifacts exactly once")
+    amap={a.name:a for a in artifacts}
+    for name,fn in _ARTIFACT_FILES.items():
+        if amap[name].path != fn: raise ReleaseVerificationError("unexpected artifact filename")
+    if m["provider_config_artifact"]!=amap["config"].path or m["tokenizer_artifact"]!=amap["tokenizer"].path or m["weights_artifact"]!=amap["weights"].path or m["evaluation_report_artifact"]!=amap["evaluation_report"].path: raise ReleaseVerificationError("artifact selector mismatch")
+    return LocalLanguageRelease(rid,ver,ReleaseRole.INPUT,RUNTIME_ABI,impl,m["provider_config_artifact"],m["tokenizer_artifact"],m["weights_artifact"],m["evaluation_report_artifact"],_timestamp(m["release_created"]),str(m["canonical_manifest_digest"]),approval["state"],approval["approval_id"],tuple(artifacts),Evaluation(evmeta["report_sha256"],True,()))
 
-
-def verify_release(release_root: str | Path) -> LocalLanguageRelease:
-    """Verify one local release directory without network or model execution."""
-    root = Path(release_root)
-    if not root.is_dir() or root.is_symlink():
-        raise ReleaseVerificationError("release root is not a directory")
-    try:
-        manifest_path = _safe_path(root, "manifest.json")
-    except OSError as exc:
-        raise ReleaseVerificationError("unreadable release root") from exc
-    try:
-        raw = json.loads(manifest_path.read_text(encoding="utf-8"), object_pairs_hook=_no_duplicates)
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise ReleaseVerificationError("unreadable release manifest") from exc
-    release = _parse_manifest(raw)
-    for artifact in release.artifacts:
-        if _digest(_safe_path(root, artifact.path)) != artifact.sha256:
-            raise ReleaseVerificationError(f"artifact digest mismatch: {artifact.name}")
-    return release
+def verify_release(release_root: str|Path)->LocalLanguageRelease:
+    root=Path(release_root)
+    if not root.is_absolute(): root=root.resolve()
+    if not root.is_dir() or root.is_symlink(): raise ReleaseVerificationError("release root is not a directory")
+    allowed=set(_ARTIFACT_FILES.values())|{"manifest.json"}
+    for child in root.iterdir():
+        if child.name not in allowed: raise ReleaseVerificationError(f"unexpected file in release root: {child.name}")
+    manifest_path=_safe_path(root,"manifest.json")
+    manifest_bytes=_read(manifest_path,MAX_MANIFEST)
+    try: raw=json.loads(manifest_bytes.decode(),object_pairs_hook=_pairs,parse_constant=_bad_const)
+    except ReleaseVerificationError: raise
+    except Exception as exc: raise ReleaseVerificationError("unreadable release manifest") from exc
+    rel=_parse_manifest(raw)
+    manifest_digest=_manifest_claim_digest(raw)
+    if rel.manifest_digest!=manifest_digest: raise ReleaseVerificationError("canonical manifest digest mismatch")
+    amap={a.name:a for a in rel.artifacts}
+    artifact_bytes={}
+    for a in rel.artifacts:
+        path=_safe_path(root,a.path); data=_read(path,MAX_ARTIFACT)
+        if len(data)!=a.byte_size or _digest_bytes(data)!=a.sha256: raise ReleaseVerificationError(f"artifact digest or byte-size mismatch: {a.name}")
+        artifact_bytes[a.name]=data
+    cfg=validate_provider_config(json.loads(artifact_bytes["config"].decode(),object_pairs_hook=_pairs,parse_constant=_bad_const))
+    eval_report=validate_evaluation_report(json.loads(artifact_bytes["evaluation_report"].decode(),object_pairs_hook=_pairs,parse_constant=_bad_const), rel.release_id)
+    from .tokenizer import validate_tokenizer_contract
+    validate_tokenizer_contract(json.loads(artifact_bytes["tokenizer"].decode(),object_pairs_hook=_pairs,parse_constant=_bad_const), cfg)
+    return LocalLanguageRelease(**{**rel.__dict__,"provider_config":cfg,"evaluation":Evaluation(amap["evaluation_report"].sha256,eval_report.passed,eval_report.categories)})

--- a/src/vulcan/local_language/tokenizer.py
+++ b/src/vulcan/local_language/tokenizer.py
@@ -1,46 +1,68 @@
-"""Strict immutable custom-tokenizer contract for offline artifact review."""
+"""Strict immutable tokenizer and exact decoder contract for span proposals."""
 from __future__ import annotations
-import json
+import json, unicodedata
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 from .release import ReleaseVerificationError
-
-TOKENIZER_SCHEMA = "local-tokenizer/1"
-MAX_VOCABULARY = 65_536
-
-
+TOKENIZER_SCHEMA="local-tokenizer/1"; MAX_VOCABULARY=65536
+REQ_GRAMMAR=set('{}[],:"-0123456789')|{"schema_version","transformer-span-proposal/1","candidates","operation","span","argument_spans","confidence","start","end","arithmetic","lookup","memory_read","memory_write","memory_forget","unsupported","expression","key","request_span"}
 @dataclass(frozen=True)
 class ImmutableTokenizerContract:
-    normalization: str
-    vocabulary: tuple[str, ...]
-    special_tokens: tuple[str, ...]
-    max_length: int
+    normalization:str; vocabulary:tuple[str,...]; special_tokens:dict[str,int]; max_length:int
+    def encode(self,text:str)->tuple[int,...]:
+        # deterministic longest-token fallback adequate for contract diagnostics
+        ids=[]; i=0; pairs=sorted(((t,n) for n,t in enumerate(self.vocabulary)), key=lambda x:len(x[0]), reverse=True)
+        while i<len(text):
+            for tok,tid in pairs:
+                if text.startswith(tok,i): ids.append(tid); i+=len(tok); break
+            else: raise ReleaseVerificationError("tokenizer cannot encode input")
+        return tuple(ids)
+    def decode(self,ids)->str:
+        return "".join(self.vocabulary[i] for i in ids)
 
+def _pairs(p):
+    d={}
+    for k,v in p:
+        if k in d: raise ReleaseVerificationError("duplicate tokenizer JSON key")
+        d[k]=v
+    return d
 
-def _pairs(pairs):
-    result = {}
-    for key, value in pairs:
-        if key in result:
-            raise ReleaseVerificationError("duplicate tokenizer JSON key")
-        result[key] = value
-    return result
+def validate_tokenizer_contract(raw:Any, provider_config:Any|None=None)->ImmutableTokenizerContract:
+    expected={"schema_version","normalization","vocabulary","special_tokens","max_length"}
+    if not isinstance(raw,dict) or set(raw)!=expected or raw["schema_version"]!=TOKENIZER_SCHEMA: raise ReleaseVerificationError("invalid tokenizer contract schema")
+    vocab=raw["vocabulary"]
+    if not isinstance(vocab,list) or not 4<=len(vocab)<=MAX_VOCABULARY: raise ReleaseVerificationError("invalid immutable vocabulary")
+    if len(set(vocab))!=len(vocab): raise ReleaseVerificationError("duplicate tokenizer tokens")
+    for i,tok in enumerate(vocab):
+        if not isinstance(tok,str) or tok=="" or unicodedata.normalize("NFC",tok)!=tok: raise ReleaseVerificationError("tokenizer controls/non-NFC tokens rejected")
+        if any(ord(c)==0 or (ord(c)<32 and c not in "\t\n\r") for c in tok): raise ReleaseVerificationError("tokenizer controls/non-NFC tokens rejected")
+    specials=raw["special_tokens"]
+    if not isinstance(specials,dict) or set(specials)!={"bos","eos","pad","unk"}: raise ReleaseVerificationError("invalid special token map")
+    spec={}
+    for name,val in specials.items():
+        if type(val) is not int or not 0<=val<len(vocab): raise ReleaseVerificationError("invalid special token id")
+        spec[name]=val
+    if len(set(spec.values()))!=4: raise ReleaseVerificationError("special-token collision")
+    if provider_config is not None and getattr(provider_config,"special_token_ids",spec)!=spec: raise ReleaseVerificationError("special-token mismatch")
+    if raw["normalization"]!="NFC" or type(raw["max_length"]) is not int or not 0<raw["max_length"]<=10000: raise ReleaseVerificationError("invalid tokenizer bounds")
+    missing=[t for t in REQ_GRAMMAR if t not in vocab]
+    if missing: raise ReleaseVerificationError("tokenizer missing proposal grammar token")
+    return ImmutableTokenizerContract("NFC",tuple(vocab),spec,raw["max_length"])
 
+def load_tokenizer_contract(path: str|Path)->ImmutableTokenizerContract:
+    try: raw=json.loads(Path(path).read_text(encoding="utf-8"), object_pairs_hook=_pairs)
+    except Exception as exc: raise ReleaseVerificationError("unreadable tokenizer contract") from exc
+    return validate_tokenizer_contract(raw)
 
-def load_tokenizer_contract(path: str | Path) -> ImmutableTokenizerContract:
-    try:
-        raw = json.loads(Path(path).read_text(encoding="utf-8"), object_pairs_hook=_pairs)
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise ReleaseVerificationError("unreadable tokenizer contract") from exc
-    expected = {"schema_version", "normalization", "vocabulary", "special_tokens", "max_length"}
-    if not isinstance(raw, dict) or set(raw) != expected or raw["schema_version"] != TOKENIZER_SCHEMA:
-        raise ReleaseVerificationError("invalid tokenizer contract schema")
-    vocabulary, special = raw["vocabulary"], raw["special_tokens"]
-    if (not isinstance(vocabulary, list) or not 0 < len(vocabulary) <= MAX_VOCABULARY or
-            any(not isinstance(token, str) or not token for token in vocabulary) or len(set(vocabulary)) != len(vocabulary)):
-        raise ReleaseVerificationError("invalid immutable vocabulary")
-    if (not isinstance(special, list) or not special or any(token not in vocabulary for token in special) or
-            len(set(special)) != len(special)):
-        raise ReleaseVerificationError("invalid special token map")
-    if raw["normalization"] != "NFC" or isinstance(raw["max_length"], bool) or not isinstance(raw["max_length"], int) or not 0 < raw["max_length"] <= 10_000:
-        raise ReleaseVerificationError("invalid tokenizer bounds")
-    return ImmutableTokenizerContract(raw["normalization"], tuple(vocabulary), tuple(special), raw["max_length"])
+def decode_generated_suffix(token_ids, tokenizer:ImmutableTokenizerContract, *, max_tokens:int, require_eos:bool=True)->str:
+    ids=list(token_ids)
+    if len(ids)>max_tokens: raise ReleaseVerificationError("excessive generated tokens")
+    spec=tokenizer.special_tokens; eos=spec["eos"]
+    if spec["unk"] in ids or spec["bos"] in ids or spec["pad"] in ids: raise ReleaseVerificationError("UNK/BOS/PAD misuse rejected")
+    if require_eos:
+        if not ids or eos not in ids: raise ReleaseVerificationError("missing EOS")
+        if ids[-1]!=eos or ids.count(eos)!=1: raise ReleaseVerificationError("early EOS and data after EOS rejected")
+        ids=ids[:-1]
+    try: return tokenizer.decode(ids)
+    except Exception as exc: raise ReleaseVerificationError("undecodable token IDs") from exc

--- a/src/vulcan/runtime/__init__.py
+++ b/src/vulcan/runtime/__init__.py
@@ -1,21 +1,17 @@
-"""The canonical production runtime for VULCAN.
-
-Only this package is allowed to assemble the production cognitive graph.
-"""
-
-from .case import CognitiveCase, CognitiveCaseStatus
-from .container import RuntimeContainer
-from .kernel import CognitiveKernel, KernelRequest, KernelResult
-
-__all__ = [
-    "CognitiveCase", "CognitiveCaseStatus",
-    "RuntimeContainer", "CognitiveKernel", "KernelRequest", "KernelResult",
-]
-
-
+"""The canonical production runtime for VULCAN."""
+from __future__ import annotations
+__all__=["CognitiveCase","CognitiveCaseStatus","RuntimeContainer","CognitiveKernel","KernelRequest","KernelResult"]
 def __getattr__(name: str):
-    """Keep domain runtime imports independent of the ASGI optional dependency."""
-    if name in {"app", "create_app"}:
+    if name in {"CognitiveCase","CognitiveCaseStatus"}:
+        from .case import CognitiveCase, CognitiveCaseStatus
+        return {"CognitiveCase":CognitiveCase,"CognitiveCaseStatus":CognitiveCaseStatus}[name]
+    if name == "RuntimeContainer":
+        from .container import RuntimeContainer
+        return RuntimeContainer
+    if name in {"CognitiveKernel","KernelRequest","KernelResult"}:
+        from .kernel import CognitiveKernel, KernelRequest, KernelResult
+        return {"CognitiveKernel":CognitiveKernel,"KernelRequest":KernelRequest,"KernelResult":KernelResult}[name]
+    if name in {"app","create_app"}:
         from .app import app, create_app
-        return {"app": app, "create_app": create_app}[name]
+        return {"app":app,"create_app":create_app}[name]
     raise AttributeError(name)

--- a/src/vulcan/runtime/case.py
+++ b/src/vulcan/runtime/case.py
@@ -40,13 +40,13 @@ class CognitiveCase:
     schema_version: str = "1"
     privacy_classification: str = "request-confidential"
     state_snapshot_id: str | None = None
-    interpretation: "InterpretationBundle | None" = None
-    accepted_interpretation: "AcceptedInterpretation | None" = None
-    clarification: "ClarificationRequest | None" = None
+    interpretation: "InterpretationBundle | None" = field(default=None, repr=False)
+    accepted_interpretation: "AcceptedInterpretation | None" = field(default=None, repr=False)
+    clarification: "ClarificationRequest | None" = field(default=None, repr=False)
     _evidence: list["EvidenceArtifact"] = field(default_factory=list, repr=False)
     _claims: list["Claim"] = field(default_factory=list, repr=False)
     _derivations: list["Derivation"] = field(default_factory=list, repr=False)
-    response_ir: "ResponseIR | None" = None
+    response_ir: "ResponseIR | None" = field(default=None, repr=False)
     selected_components: tuple[str, ...] = ()
     terminal_status: CognitiveCaseStatus = CognitiveCaseStatus.OPEN
     failure_kind: str | None = None

--- a/src/vulcan/runtime/container.py
+++ b/src/vulcan/runtime/container.py
@@ -16,17 +16,24 @@ from .kernel import CognitiveKernel
 from .output import DeterministicLanguageOutput, LanguageOutputPort
 from .semantic import DeterministicLanguageInput, LanguageInputPort
 
-LanguageMode = Literal["disabled", "deterministic_only"]
+
+LanguageMode = Literal["disabled", "deterministic_only", "transformer_proposal"]
 
 
 @dataclass(frozen=True)
 class LanguageRuntimeConfig:
     """Closed deployment selection; local/provider modes are not yet selectable."""
     mode: LanguageMode = "deterministic_only"
+    release_path: str | None = None
+    provider_factory: Any = None
 
     def validated(self) -> "LanguageRuntimeConfig":
-        if self.mode not in {"disabled", "deterministic_only"}:
+        if self.mode not in {"disabled", "deterministic_only", "transformer_proposal"}:
             raise RuntimeError("unapproved language-interface mode")
+        if self.mode == "transformer_proposal":
+            from pathlib import Path
+            if not self.release_path or not Path(self.release_path).is_absolute():
+                raise RuntimeError("transformer mode requires an absolute approved release path")
         return self
 
 
@@ -119,6 +126,13 @@ class RuntimeContainer:
         if not callable(advertised):
             raise RuntimeError("canonical kernel does not expose its capabilities")
         result = advertised()
+        if self.language_config.mode == "transformer_proposal":
+            try:
+                meta = self.language_input.readiness()
+                abi = meta["runtime_abi"]
+                result = tuple(dict.fromkeys((*result, "verified-transformer-span", f"language-abi:{abi}")))
+            except Exception:
+                pass
         if not isinstance(result, tuple) or not all(isinstance(value, str) for value in result):
             raise RuntimeError("canonical kernel returned an invalid capability list")
         return result
@@ -133,11 +147,16 @@ class RuntimeContainer:
         if safety is None:
             raise RuntimeError("required safety finalization service is unavailable")
         config = (language_config or LanguageRuntimeConfig()).validated()
-        # Both supported modes intentionally construct only deterministic, no-model ports.
+        # Deterministic remains default/fallback; transformer mode is admitted only after strict release verification.
         language_input: LanguageInputPort = DeterministicLanguageInput()
+        if config.mode == "transformer_proposal":
+            if config.provider_factory is None:
+                raise RuntimeError("verified transformer release present but no safe provider factory is configured")
+            from vulcan.local_language import build_verified_adapter
+            language_input = build_verified_adapter(release_root=config.release_path or "", provider_factory=config.provider_factory)
         language_output: LanguageOutputPort = DeterministicLanguageOutput()
         memory = compose_governed_memory()
-        root = getattr(deployment, "runtime_root", None) or getattr(deployment, "data_dir", None) or "/tmp/vulcan-runtime"
+        root = getattr(deployment, "runtime_root", None) or getattr(deployment, "data_dir", None) or f"/tmp/vulcan-runtime-{uuid4().hex}"
         audit = alignment = domain_registry = None
         try:
             memory.readiness()

--- a/src/vulcan/runtime/kernel.py
+++ b/src/vulcan/runtime/kernel.py
@@ -103,7 +103,7 @@ class CognitiveKernel:
             if self._audit: self._audit.append("case.finalized", {"case_id":case.case_id,"request_id":case.request_id,"request_digest":case.input_hash,"finalization":finalization.decision.value,"rendered_response_digest":artifact.ir_digest})
             case.close(status)
             if self._audit: self._audit.append("case.completed" if status is CognitiveCaseStatus.SUCCESS else "case.abstained", {"case_id":case.case_id,"request_id":case.request_id,"request_digest":case.input_hash,"status":status.value,"rendered_response_digest":artifact.ir_digest})
-            return KernelResult(finalization.public_text if status is CognitiveCaseStatus.SUCCESS else "I cannot complete this request with the available verified evidence.",response_ir,status,finalization.decision.value)
+            return KernelResult(finalization.public_text,response_ir,status,finalization.decision.value)
         except asyncio.CancelledError:
             if case.terminal_status is CognitiveCaseStatus.OPEN: case.close(CognitiveCaseStatus.CANCELLED,"cancelled")
             raise

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -533,3 +533,14 @@ def pytest_sessionfinish(session, exitstatus):
     os.environ["PYTEST_CLEANUP_DONE"] = "1"
 
     print(f"[conftest] Test session finished with exit status {exitstatus}")
+
+# Dependency-light asyncio marker support when pytest-asyncio is unavailable.
+def pytest_pyfunc_call(pyfuncitem):
+    if pyfuncitem.get_closest_marker("asyncio") is not None:
+        import asyncio, inspect
+        testfunction = pyfuncitem.obj
+        if inspect.iscoroutinefunction(testfunction):
+            kwargs = {name: pyfuncitem.funcargs[name] for name in pyfuncitem._fixtureinfo.argnames}
+            asyncio.run(testfunction(**kwargs))
+            return True
+    return None

--- a/tests/security/test_language_contracts.py
+++ b/tests/security/test_language_contracts.py
@@ -37,3 +37,67 @@ async def test_failed_output_adapter_falls_back_to_strict_renderer():
     assert result.response == "The computed result is 4."
     assert [event.stage for event in case.events].count("output_draft_unavailable") == 1
     assert case.render_artifact.renderer == "strict-template"
+
+import json
+from vulcan.local_language import SpanProposalError, VerifiedAdapterMetadata, VerifiedLocalSpanCompletion, parse_transformer_span_proposal
+
+
+def _proposal(operation="arithmetic", s=0, e=5, conf=0.9):
+    obj={"schema_version":"transformer-span-proposal/1","candidates":[{"operation":operation,"span":{"start":s,"end":e},"argument_spans":{"expression":{"start":s,"end":e}},"confidence":conf}]}
+    return json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",",":"))
+
+
+def test_valid_exact_span_proposal_reconstructs_operand_server_side():
+    u=Utterance.from_text("2 + 2")
+    p=parse_transformer_span_proposal(_proposal(), u)
+    assert p.candidates[0].expression == "2 + 2"
+
+
+@pytest.mark.parametrize("raw", [
+    '{"schema_version":"transformer-span-proposal/1","schema_version":"transformer-span-proposal/1","candidates":[]}',
+    '{"candidates":[],"schema_version":"transformer-span-proposal/1"} prose',
+    '{"candidates":[{"argument_spans":{"expression":{"end":5,"start":0}},"confidence":NaN,"operation":"arithmetic","span":{"end":5,"start":0}}],"schema_version":"transformer-span-proposal/1"}',
+])
+def test_strict_transformer_json_rejects_duplicates_trailing_and_nan(raw):
+    with pytest.raises(SpanProposalError): parse_transformer_span_proposal(raw, Utterance.from_text("2 + 2"))
+
+
+@pytest.mark.parametrize("field", ["answer","domain_hint","graphix_plan","code","evidence"])
+def test_transformer_forbidden_fields_rejected(field):
+    obj=json.loads(_proposal())
+    obj["candidates"][0][field]="bad"
+    raw=json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",",":"))
+    with pytest.raises(SpanProposalError): parse_transformer_span_proposal(raw, Utterance.from_text("2 + 2"))
+
+
+@pytest.mark.parametrize("span", [{"start":5,"end":1},{"start":0,"end":99},{"start":0,"end":0}])
+def test_transformer_invalid_spans_rejected(span):
+    obj=json.loads(_proposal()); obj["candidates"][0]["argument_spans"]["expression"]=span
+    raw=json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",",":"))
+    with pytest.raises(SpanProposalError): parse_transformer_span_proposal(raw, Utterance.from_text("2 + 2"))
+
+
+class _Provider:
+    def __init__(self, raw=None, fail=False): self.raw=raw; self.fail=fail; self.closed=False
+    def generate(self, prompt, *, max_tokens):
+        if self.fail: raise RuntimeError("boom")
+        return self.raw
+    def close(self): self.closed=True
+class _Tok:
+    def encode(self, text): return list(text)
+
+@pytest.mark.asyncio
+async def test_verified_adapter_close_and_context_overflow():
+    adapter=VerifiedLocalSpanCompletion(provider=_Provider(_proposal()), tokenizer=_Tok(), metadata=VerifiedAdapterMetadata("0"*64), context_length=10, max_generated_tokens=10)
+    with pytest.raises(SpanProposalError): await adapter.propose(Utterance.from_text("2 + 2"))
+    adapter.close()
+    with pytest.raises(RuntimeError): await adapter.propose(Utterance.from_text("2 + 2"))
+
+@pytest.mark.asyncio
+async def test_malformed_proposal_falls_back_deterministically():
+    utterance=Utterance.from_text("2 + 2")
+    case=CognitiveCase.create(request_id="r2", conversation_id=None, input_digest=utterance.digest)
+    adapter=VerifiedLocalSpanCompletion(provider=_Provider('{"bad":true}'), tokenizer=_Tok(), metadata=VerifiedAdapterMetadata("0"*64), context_length=10000, max_generated_tokens=10)
+    result=await CognitiveKernel(state_authority=object(), finalizer=_Finalizer(), language_input=adapter).handle(KernelRequest(utterance,None),case)
+    assert result.response == "The computed result is 4."
+    assert [event.stage for event in case.events].count("input_proposal_unavailable") == 1

--- a/tests/security/test_local_language_release.py
+++ b/tests/security/test_local_language_release.py
@@ -1,57 +1,62 @@
 """Offline gates for local language-adapter artifact manifests."""
-import hashlib
-import json
-
+import hashlib, json, unicodedata
 import pytest
+from vulcan.local_language import ReleaseRole, ReleaseVerificationError, verify_release, decode_generated_suffix, load_tokenizer_contract
+from vulcan.local_language.release import REQ_CATS
 
-from vulcan.local_language import ReleaseRole, ReleaseVerificationError, verify_release
-
-
-def _sha(value: bytes) -> str:
-    return hashlib.sha256(value).hexdigest()
-
-
-def _release(root, *, promotion="approved", candidate=2.0, baseline=1.0):
-    contents = {"weights.bin": b"weights", "tokenizer.json": b"tokenizer", "config.json": b"config", "evaluation.json": b"report"}
-    for name, value in contents.items():
-        (root / name).write_bytes(value)
-    artifacts = [
-        {"name": "weights", "path": "weights.bin", "sha256": _sha(contents["weights.bin"])},
-        {"name": "tokenizer", "path": "tokenizer.json", "sha256": _sha(contents["tokenizer.json"])},
-        {"name": "config", "path": "config.json", "sha256": _sha(contents["config.json"])},
-        {"name": "evaluation_report", "path": "evaluation.json", "sha256": _sha(contents["evaluation.json"])},
-    ]
-    manifest = {
-        "schema_version": "local-language-release/1", "release_id": "adapter-01",
-        "role": "input-language-adapter", "runtime_abi": "semantic-ingress/2", "license_identifier": "LicenseRef-reviewed",
-        "promotion": {"state": promotion, "approval_id": "review-01"}, "artifacts": artifacts,
-        "evaluation": {"report_sha256": artifacts[-1]["sha256"], "deterministic_baseline": "deterministic-parser/2", "baseline_score": baseline, "candidate_score": candidate, "zero_tolerance_passed": True},
-    }
-    (root / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
-
+def _sha(b: bytes) -> str: return hashlib.sha256(b).hexdigest()
+def _j(o): return json.dumps(o, ensure_ascii=False, sort_keys=True, separators=(",",":"))
+def _tok():
+    vocab=["<bos>","<eos>","<pad>","<unk>"]+sorted(set('{}[],:\"-0123456789').union({"schema_version","transformer-span-proposal/1","candidates","operation","span","argument_spans","confidence","start","end","arithmetic","lookup","memory_read","memory_write","memory_forget","unsupported","expression","key","request_span"}))
+    return {"schema_version":"local-tokenizer/1","normalization":"NFC","vocabulary":vocab,"special_tokens":{"bos":0,"eos":1,"pad":2,"unk":3},"max_length":1000}
+def _cfg(**kw):
+    d={"schema_version":"local-gpt-span-provider/1","model_architecture":"tiny-gpt-span","vocabulary_size":64,"embedding_width":32,"layer_count":2,"attention_head_count":4,"feed_forward_width":64,"approved_context_length":512,"max_generated_proposal_tokens":128,"special_token_ids":{"bos":0,"eos":1,"pad":2,"unk":3},"dropout":0.0,"generation_method":"greedy"}; d.update(kw); return d
+def _eval(release_id="adapter-01", passed=True, bad=False):
+    metrics={c:1.0 for c in REQ_CATS}; thresholds={c:0.9 for c in REQ_CATS}
+    if bad: metrics["fallback_behavior"]=0.0
+    return {"schema_version":"local-language-evaluation/1","release_id":release_id,"runtime_abi":"vulcan-transformer-span/1","dataset_digest":"0"*64,"categories":sorted(REQ_CATS),"metrics":metrics,"thresholds":thresholds,"passed":passed,"evaluated_at":"2026-07-18T00:00:00Z","evaluator":"eval-tool"}
+def _release(root, *, cfg=None, tok=None, ev=None, role="input-language-adapter", abi="vulcan-transformer-span/1"):
+    files={"weights.safetensors":b"SAFE","tokenizer.json":_j(tok or _tok()).encode(),"config.json":_j(cfg or _cfg()).encode(),"evaluation.json":_j(ev or _eval()).encode()}
+    for n,b in files.items(): (root/n).write_bytes(b)
+    arts=[]
+    for name,path in [("weights","weights.safetensors"),("tokenizer","tokenizer.json"),("config","config.json"),("evaluation_report","evaluation.json")]: arts.append({"name":name,"path":path,"sha256":_sha(files[path]),"byte_size":len(files[path])})
+    manifest={"schema_version":"local-language-release/1","release_id":"adapter-01","version":"1.0.0","role":role,"runtime_abi":abi,"provider_implementation":"local-gpt-span-provider","provider_config_artifact":"config.json","tokenizer_artifact":"tokenizer.json","weights_artifact":"weights.safetensors","evaluation_report_artifact":"evaluation.json","release_created":"2026-07-18T00:00:00Z","canonical_manifest_digest":"0"*64,"approval":{"state":"approved","approval_id":"review-01","approved_by":"release-authority","approved_at":"2026-07-18T00:00:00Z","manifest_digest":"0"*64},"evaluation":{"passed":True,"report_sha256":arts[-1]["sha256"]},"artifacts":arts}
+    b=_j(manifest).encode(); digest=_sha(b); manifest["canonical_manifest_digest"]=digest; manifest["approval"]["manifest_digest"]=digest; (root/"manifest.json").write_text(_j(manifest),encoding="utf-8")
 
 def test_verify_release_binds_complete_approved_role_specific_artifacts(tmp_path):
-    _release(tmp_path)
-    release = verify_release(tmp_path)
-    assert release.role is ReleaseRole.INPUT
-    assert release.release_id == "adapter-01"
-
-
-@pytest.mark.parametrize("mutate", ["digest", "path", "unpromoted", "not_better"])
-def test_verify_release_fails_closed_for_tampering_or_unjustified_promotion(tmp_path, mutate):
-    _release(tmp_path, promotion="candidate" if mutate == "unpromoted" else "approved", candidate=1.0 if mutate == "not_better" else 2.0)
-    if mutate == "digest":
-        (tmp_path / "weights.bin").write_bytes(b"tampered")
-    elif mutate == "path":
-        manifest = json.loads((tmp_path / "manifest.json").read_text())
-        manifest["artifacts"][0]["path"] = "../outside"
-        (tmp_path / "manifest.json").write_text(json.dumps(manifest))
-    with pytest.raises(ReleaseVerificationError):
-        verify_release(tmp_path)
-
+    root=tmp_path/"release"; root.mkdir(); _release(root); release=verify_release(root)
+    assert release.role is ReleaseRole.INPUT and release.runtime_abi == "vulcan-transformer-span/1"
 
 def test_duplicate_manifest_keys_are_rejected(tmp_path):
-    _release(tmp_path)
-    (tmp_path / "manifest.json").write_text('{"schema_version":"local-language-release/1","schema_version":"local-language-release/1"}')
-    with pytest.raises(ReleaseVerificationError, match="duplicate JSON key"):
-        verify_release(tmp_path)
+    root=tmp_path/"release"; root.mkdir(); _release(root); (root/"manifest.json").write_text('{"schema_version":"local-language-release/1","schema_version":"local-language-release/1"}')
+    with pytest.raises(ReleaseVerificationError, match="duplicate JSON key"): verify_release(root)
+
+@pytest.mark.parametrize("mutate", ["extra","missing","digest","size","absolute","traversal","symlink","role","abi","unpassed_eval","eval_inconsistent","dims","dropout","sampling","tok_dup","tok_control","tok_missing","special"])
+def test_strict_release_rejections(tmp_path, mutate):
+    cfg=_cfg(); tok=_tok(); ev=_eval(); role="input-language-adapter"; abi="vulcan-transformer-span/1"
+    if mutate=="dims": cfg["embedding_width"]=30
+    if mutate=="dropout": cfg["dropout"]=0.1
+    if mutate=="sampling": cfg["generation_method"]="sampling"
+    if mutate=="tok_dup": tok["vocabulary"][4]=tok["vocabulary"][5]
+    if mutate=="tok_control": tok["vocabulary"][4]="bad\x00"
+    if mutate=="tok_missing": tok["vocabulary"].remove("domain_hint") if "domain_hint" in tok["vocabulary"] else tok["vocabulary"].remove("arithmetic")
+    if mutate=="special": tok["special_tokens"]["unk"]=tok["special_tokens"]["pad"]
+    if mutate=="unpassed_eval": ev=_eval(passed=False)
+    if mutate=="eval_inconsistent": ev=_eval(bad=True)
+    if mutate=="role": role="output-language-adapter"
+    if mutate=="abi": abi="semantic-ingress/2"
+    root=tmp_path/"release"; root.mkdir(); _release(root,cfg=cfg,tok=tok,ev=ev,role=role,abi=abi)
+    if mutate=="extra": (root/"extra.bin").write_bytes(b"x")
+    if mutate=="missing": (root/"weights.safetensors").unlink()
+    if mutate=="digest": (root/"weights.safetensors").write_bytes(b"BAD")
+    if mutate=="size":
+        m=json.loads((root/"manifest.json").read_text()); m["artifacts"][0]["byte_size"]+=1; (root/"manifest.json").write_text(_j(m))
+    if mutate in {"absolute","traversal"}:
+        m=json.loads((root/"manifest.json").read_text()); m["artifacts"][0]["path"]="/tmp/x" if mutate=="absolute" else "../x"; (root/"manifest.json").write_text(_j(m))
+    if mutate=="symlink": (root/"weights.safetensors").unlink(); (root/"weights.safetensors").symlink_to(root/"config.json")
+    with pytest.raises(ReleaseVerificationError): verify_release(root)
+
+def test_exact_decoder_rejects_special_misuse(tmp_path):
+    root=tmp_path/"release"; root.mkdir(); _release(root); verify_release(root); tok=load_tokenizer_contract(root/"tokenizer.json")
+    with pytest.raises(ReleaseVerificationError): decode_generated_suffix([tok.special_tokens["unk"], tok.special_tokens["eos"]], tok, max_tokens=4)
+    with pytest.raises(ReleaseVerificationError): decode_generated_suffix([tok.special_tokens["eos"], 4], tok, max_tokens=4)


### PR DESCRIPTION
### Motivation
- Provide a safe, auditable bridge that lets a verified local transformer propose only closed operations and exact character spans, while the server reconstructs operands and enforces deterministic execution.
- Harden offline release verification so only explicitly approved, byte-verified, bounded artifact sets (weights, tokenizer, config, evaluation) can enable transformer proposal mode.
- Prevent model-provided facts, prose, domain hints, plans, code, or arbitrary parameters from entering the canonical execution path and keep deterministic parsing as the fail-closed default.

### Description
- Add a strict span-only proposal parser and owner: `parse_transformer_span_proposal` and `VerifiedLocalSpanCompletion` in `src/vulcan/local_language/adapter.py`, enforcing duplicate-key-free canonical JSON, finite confidence, closed operation enum, argument span shapes, non-overlapping/out-of-range span checks, context-window budget, timeout and close/readiness semantics, and server-side operand reconstruction.
- Implement a verify-before/verify-after builder `build_verified_adapter` that verifies the `local-language-release/1` manifest, constructs the provider via a caller-supplied factory, re-verifies the release and closes the provider on mutation or failure.
- Harden `local-language-release/1` verification in `src/vulcan/local_language/release.py` with bounded reads, fixed artifact filenames, artifact path/type/size/digest checks, strict provider-config schema (`local-gpt-span-provider/1`) and evaluation schema checks, and verification of provider tokenizer/weights artifacts before activation.
- Add tokenizer structural validation and exact decoding (`validate_tokenizer_contract`, `decode_generated_suffix`) in `src/vulcan/local_language/tokenizer.py` to require NFC tokens, bijective vocabulary/IDs, required special tokens, and the ability to emit the full proposal grammar.
- Integrate transformer proposal selection into `RuntimeContainer` as an explicit closed mode `transformer_proposal` that requires an absolute approved release path and a safe `provider_factory`; deterministic mode remains default and fallback.
- Preserve privacy and deterministic behavior by hiding request-derived fields from `CognitiveCase` repr and returning strict finalization text from the kernel; add a lightweight `pytest` asyncio shim for dependency-light tests.
- Tests and small helper changes and exports were added; see `tests/security/test_language_contracts.py`, `tests/security/test_local_language_release.py`, and `tests/conftest.py` for contract/fake-provider tests.

### Testing
- Ran focused contract tests: `PYTHONPATH=src pytest tests/security/test_language_contracts.py tests/security/test_local_language_release.py -q` (these passed locally after adjustments).
- Ran extended security suites: `PYTHONPATH=src pytest tests/security/...` covering Graphix ledger, domain registry, audit/alignment, memory and semantic runtime tests; the main security test set completed successfully (79 tests passed in the final verification run).
- Verified diagnostics and packaging checks: compiled modules with `python -m compileall` and `python -O -m compileall`, ran tokenizer/decoder diagnostics and a lightweight dependency-light import check; these succeeded.
- Environment limits: FastAPI/Torch/NumPy were not installed in the test environment so real-model and framework integration tests (Torch safe-load and runtime ASGI endpoints requiring FastAPI) were not executed; no real neural weights or tokenizer binaries are bundled or tested here.
- Outcome: automated contract/security tests for the verified adapter path passed; real-model weight-loading and GPU/torch integration remain out of scope until an approved, non-executable artifact set and a Torch-enabled environment are provided.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b65a62518832f98cd719dff16e581)