### PR TITLE
Implement authenticated canonical API

### DIFF
--- a/src/vulcan/memory/governed.py
+++ b/src/vulcan/memory/governed.py
@@ -185,6 +185,7 @@ class SQLiteMemoryRepository:
             CREATE TABLE IF NOT EXISTS memory_heads(record_id TEXT PRIMARY KEY,tenant_id TEXT NOT NULL,subject_id TEXT NOT NULL,purpose TEXT NOT NULL,namespace TEXT NOT NULL,key_name TEXT NOT NULL,current_revision INTEGER NOT NULL,current_lifecycle TEXT NOT NULL CHECK(current_lifecycle IN ('active','tombstoned','purged')),deletion_epoch INTEGER NOT NULL,UNIQUE(tenant_id,subject_id,purpose,namespace,key_name),FOREIGN KEY(record_id,current_revision) REFERENCES memory_revisions(record_id,revision));
             CREATE TABLE IF NOT EXISTS memory_idempotency(tenant_id TEXT NOT NULL,subject_id TEXT NOT NULL,idempotency_key TEXT NOT NULL,operation TEXT NOT NULL,request_digest TEXT NOT NULL,record_id TEXT,PRIMARY KEY(tenant_id,subject_id,idempotency_key));
             CREATE TABLE IF NOT EXISTS memory_journal(sequence INTEGER PRIMARY KEY AUTOINCREMENT,operation TEXT NOT NULL,record_id TEXT NOT NULL,revision INTEGER NOT NULL,tenant_id TEXT NOT NULL,subject_id TEXT NOT NULL,request_digest TEXT NOT NULL,committed_at TEXT NOT NULL);
+            CREATE TABLE IF NOT EXISTS memory_audit_outbox(operation_id TEXT PRIMARY KEY,event_type TEXT NOT NULL,operation TEXT NOT NULL,record_id TEXT NOT NULL,revision INTEGER NOT NULL,tenant_id TEXT NOT NULL,subject_id TEXT NOT NULL,purpose TEXT NOT NULL,namespace TEXT NOT NULL,key_name TEXT NOT NULL,prior_record_digest TEXT,new_record_digest TEXT NOT NULL,deletion_epoch INTEGER NOT NULL,request_digest TEXT NOT NULL,audit_complete INTEGER NOT NULL DEFAULT 0);
             """)
             versions=self._db.execute("SELECT version FROM memory_schema").fetchall()
             if not versions: self._db.execute("INSERT INTO memory_schema VALUES(?)",(SCHEMA_VERSION,))
@@ -199,6 +200,7 @@ class SQLiteMemoryRepository:
                 "memory_heads":{"record_id","tenant_id","subject_id","purpose","namespace","key_name","current_revision","current_lifecycle","deletion_epoch"},
                 "memory_idempotency":{"tenant_id","subject_id","idempotency_key","operation","request_digest","record_id"},
                 "memory_journal":{"sequence","operation","record_id","revision","tenant_id","subject_id","request_digest","committed_at"},
+                "memory_audit_outbox":{"operation_id","event_type","operation","record_id","revision","tenant_id","subject_id","purpose","namespace","key_name","prior_record_digest","new_record_digest","deletion_epoch","request_digest","audit_complete"},
             }
             tables={r[0] for r in self._db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'")}
             if tables != set(expected): raise RuntimeError("memory schema table verification failed")
@@ -232,7 +234,7 @@ class SQLiteMemoryRepository:
                     if r[14]==prev_epoch+1 and r[10] not in (MemoryLifecycle.TOMBSTONED.value, MemoryLifecycle.PURGED.value): raise RuntimeError("memory deletion epoch changed outside deletion")
                     prev_epoch=r[14]
             heads=self._db.execute("SELECT record_id,tenant_id,subject_id,purpose,namespace,key_name,current_revision,current_lifecycle,deletion_epoch FROM memory_heads").fetchall()
-            if len(heads)!=len(groups): raise RuntimeError("memory head/history mismatch fails closed")
+            if len(heads)>len(groups): raise RuntimeError("memory head/history mismatch fails closed")
             for h in heads:
                 rs=groups.get(h[0]);
                 if not rs: raise RuntimeError("memory head orphan fails closed")
@@ -241,6 +243,9 @@ class SQLiteMemoryRepository:
                 if (h[1],h[2],h[3],h[4],h[6],h[7],h[8]) != (last[2],last[3],last[5],last[6],last[1],last[10],last[14]) or not head_key_ok: raise RuntimeError("memory head not latest fails closed")
             bad=self._db.execute("SELECT 1 FROM memory_idempotency i LEFT JOIN memory_revisions r ON i.record_id=r.record_id WHERE i.record_id IS NOT NULL AND r.record_id IS NULL LIMIT 1").fetchone()
             if bad: raise RuntimeError("memory idempotency orphan fails closed")
+            pending=self._db.execute("SELECT COUNT(*) FROM memory_audit_outbox WHERE audit_complete=0").fetchone()[0]
+            if pending and self._audit is None: raise RuntimeError("memory audit outbox pending without audit owner")
+            if pending: self.flush_outbox()
     def _record(self,row):
         data=list(row); data[9]=MemoryKind(data[9]); data[10]=MemoryLifecycle(data[10]); return MemoryRecord(*data)
     def _decision(self,op,actor,proposal=None): return self._policy.decide(op,actor,proposal)
@@ -249,6 +254,8 @@ class SQLiteMemoryRepository:
         row=self._db.execute("SELECT operation,request_digest,record_id FROM memory_idempotency WHERE tenant_id=? AND subject_id=? AND idempotency_key=?",(actor.tenant_id,actor.subject_id,key)).fetchone()
         if not row:return None
         if row[0]!=op.value or row[1]!=digest:return MemoryCommitResult(MemoryReason.IDEMPOTENCY_CONFLICT)
+        pending=self._db.execute("SELECT 1 FROM memory_audit_outbox WHERE operation_id=? AND audit_complete=0",(digest,)).fetchone()
+        if pending: self._db.execute("COMMIT"); self.flush_outbox(); self._db.execute("BEGIN IMMEDIATE")
         return self._current(actor,row[2]) if row[2] else MemoryCommitResult(MemoryReason.COMMITTED)
     def _current(self,actor,record_id):
         row=self._db.execute("SELECT r.record_id,r.revision,r.tenant_id,r.subject_id,r.actor_id,r.purpose,r.namespace,r.key_name,r.value,r.kind,r.lifecycle,r.policy_version,r.created_at,r.expires_at,r.deletion_epoch,r.digest,r.supersedes FROM memory_heads h JOIN memory_revisions r ON r.record_id=h.record_id AND r.revision=h.current_revision WHERE h.record_id=? AND h.tenant_id=? AND h.subject_id=? AND h.purpose=?",(record_id,actor.tenant_id,actor.subject_id,actor.purpose)).fetchone()
@@ -256,11 +263,32 @@ class SQLiteMemoryRepository:
     def _insert_revision(self,data):
         self._db.execute("INSERT INTO memory_revisions VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",tuple(data[k] for k in ("record_id","revision","tenant_id","subject_id","actor_id","purpose","namespace","key","value","kind","lifecycle","policy_version","created_at","expires_at","deletion_epoch","digest","supersedes")))
     def _journal(self,op,data,digest): self._db.execute("INSERT INTO memory_journal(operation,record_id,revision,tenant_id,subject_id,request_digest,committed_at) VALUES(?,?,?,?,?,?,?)",(op.value,data["record_id"],data["revision"],data["tenant_id"],data["subject_id"],digest,_time(self._clock)))
-    def _audit_event(self,event_type,actor,op,proposal=None,record=None,prior_digest=None,new_digest=None,deletion_epoch=0):
-        if not self._audit: return
+    def _audit_payload(self,event_type,op,row):
         h=lambda x: hashlib.sha256(str(x).encode()).hexdigest()[:32]
-        payload={"operation_type":op.value,"tenant_digest":h(actor.tenant_id),"subject_digest":h(actor.subject_id),"purpose":actor.purpose,"namespace":proposal.namespace if proposal else (record.namespace if record else "profile"),"key":proposal.key if proposal else (record.key if record else "unknown"),"record_id":record.record_id if record else "pending","revision":record.revision if record else 0,"prior_record_digest":prior_digest,"new_record_digest":new_digest,"policy_identity":self._policy.version,"policy_revision":self._policy.version,"deletion_epoch":deletion_epoch,"result_category":event_type.rsplit("_",1)[-1]}
-        self._audit.append(event_type,payload)
+        return {"operation_id":row[0],"operation_type":op,"tenant_digest":h(row[5]),"subject_digest":h(row[6]),"purpose":row[7],"namespace":row[8],"key":row[9],"record_id":row[3],"revision":row[4],"prior_record_digest":row[10],"new_record_digest":row[11],"policy_identity":self._policy.version,"policy_revision":self._policy.version,"deletion_epoch":row[12],"result_category":event_type.rsplit("_",1)[-1]}
+    def _audit_event(self,*a,**k): return None
+    def _outbox(self,event_type,op,data,digest,prior=None):
+        self._db.execute("INSERT OR IGNORE INTO memory_audit_outbox VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,0)",(digest,event_type,op.value,data["record_id"],data["revision"],data["tenant_id"],data["subject_id"],data["purpose"],data["namespace"],data["key"],prior,data["digest"],data["deletion_epoch"],digest))
+    def flush_outbox(self):
+        with self._lock:
+            rows=self._db.execute("SELECT operation_id,event_type,operation,record_id,revision,tenant_id,subject_id,purpose,namespace,key_name,prior_record_digest,new_record_digest,deletion_epoch,request_digest,audit_complete FROM memory_audit_outbox WHERE audit_complete=0 ORDER BY rowid").fetchall()
+            for row in rows:
+                if self._audit is not None:
+                    payload=self._audit_payload(row[1], row[2], row)
+                    self._audit.append('memory.write_prepared', {**payload, 'result_category':'prepared'})
+                    self._audit.append(row[1], payload)
+                self._db.execute("BEGIN IMMEDIATE")
+                try:
+                    if row[2]=='create':
+                        exists=self._db.execute("SELECT 1 FROM memory_heads WHERE record_id=?",(row[3],)).fetchone()
+                        if not exists: self._db.execute("INSERT INTO memory_heads SELECT record_id,tenant_id,subject_id,purpose,namespace,key_name,revision,lifecycle,deletion_epoch FROM memory_revisions WHERE record_id=? AND revision=?",(row[3],row[4]))
+                    else:
+                        self._db.execute("UPDATE memory_heads SET current_revision=?,current_lifecycle=(SELECT lifecycle FROM memory_revisions WHERE record_id=? AND revision=?),deletion_epoch=? WHERE record_id=?",(row[4],row[3],row[4],row[12],row[3]))
+                    self._db.execute("UPDATE memory_audit_outbox SET audit_complete=1 WHERE operation_id=?",(row[0],)); self._db.execute("COMMIT")
+                except Exception:
+                    try: self._db.execute("ROLLBACK")
+                    except Exception: pass
+                    raise
     def commit(self,actor,proposal):
         if self._decision(MemoryOperation.CREATE,actor,proposal).decision is PolicyDecision.REJECT:return MemoryCommitResult(MemoryReason.POLICY_REJECTED)
         digest=self._envelope(MemoryOperation.CREATE,actor,f"{proposal.namespace}:{proposal.key}",proposal)
@@ -274,7 +302,7 @@ class SQLiteMemoryRepository:
                 if exists and exists[1] in ("tombstoned","purged"):
                     self._db.execute("UPDATE memory_heads SET key_name=? WHERE record_id=?",(proposal.key+"#deleted"+str(exists[2]), exists[0]))
                 self._audit_event("memory.write_prepared", actor, MemoryOperation.CREATE, proposal, new_digest=digest)
-                now=_time(self._clock); rid="mem-"+uuid4().hex; data={"record_id":rid,"revision":1,"tenant_id":actor.tenant_id,"subject_id":actor.subject_id,"actor_id":actor.actor_id,"purpose":actor.purpose,"namespace":proposal.namespace,"key":proposal.key,"value":proposal.value,"kind":proposal.kind.value,"lifecycle":"active","policy_version":self._policy.version,"created_at":now,"expires_at":(datetime.fromisoformat(now.replace("Z","+00:00"))+self._policy.retention(actor,proposal)).isoformat().replace("+00:00","Z"),"deletion_epoch":0,"supersedes":None};data["digest"]=_digest(data);self._insert_revision(data);self._db.execute("INSERT INTO memory_heads VALUES(?,?,?,?,?,?,?,?,?)",(rid,actor.tenant_id,actor.subject_id,actor.purpose,proposal.namespace,proposal.key,1,"active",0));self._db.execute("INSERT INTO memory_idempotency VALUES(?,?,?,?,?,?)",(actor.tenant_id,actor.subject_id,proposal.idempotency_key,"create",digest,rid));self._journal(MemoryOperation.CREATE,data,digest);self._db.execute("COMMIT");rec=self._record(tuple(data[k] for k in ("record_id","revision","tenant_id","subject_id","actor_id","purpose","namespace","key","value","kind","lifecycle","policy_version","created_at","expires_at","deletion_epoch","digest","supersedes")));self._audit_event("memory.write_committed", actor, MemoryOperation.CREATE, proposal, rec, new_digest=rec.digest);return MemoryCommitResult(MemoryReason.COMMITTED,rec)
+                now=_time(self._clock); rid="mem-"+uuid4().hex; data={"record_id":rid,"revision":1,"tenant_id":actor.tenant_id,"subject_id":actor.subject_id,"actor_id":actor.actor_id,"purpose":actor.purpose,"namespace":proposal.namespace,"key":proposal.key,"value":proposal.value,"kind":proposal.kind.value,"lifecycle":"active","policy_version":self._policy.version,"created_at":now,"expires_at":(datetime.fromisoformat(now.replace("Z","+00:00"))+self._policy.retention(actor,proposal)).isoformat().replace("+00:00","Z"),"deletion_epoch":0,"supersedes":None};data["digest"]=_digest(data);self._insert_revision(data);self._outbox("memory.write_committed", MemoryOperation.CREATE, data, digest);self._db.execute("INSERT INTO memory_idempotency VALUES(?,?,?,?,?,?)",(actor.tenant_id,actor.subject_id,proposal.idempotency_key,"create",digest,rid));self._journal(MemoryOperation.CREATE,data,digest);self._db.execute("COMMIT");self.flush_outbox();rec=self._record(tuple(data[k] for k in ("record_id","revision","tenant_id","subject_id","actor_id","purpose","namespace","key","value","kind","lifecycle","policy_version","created_at","expires_at","deletion_epoch","digest","supersedes")));return MemoryCommitResult(MemoryReason.COMMITTED,rec)
             except Exception:
                 try: self._db.execute("ROLLBACK")
                 except Exception: pass
@@ -309,10 +337,9 @@ class SQLiteMemoryRepository:
                         rd={"record_id":rr[0],"revision":rr[1],"tenant_id":rr[2],"subject_id":rr[3],"actor_id":rr[4],"purpose":rr[5],"namespace":rr[6],"key":rr[7],"value":rr[8],"kind":rr[9],"lifecycle":rr[10],"policy_version":rr[11],"created_at":rr[12],"expires_at":rr[13],"deletion_epoch":rr[14],"supersedes":rr[15]}
                         self._db.execute("UPDATE memory_revisions SET digest=? WHERE record_id=? AND revision=?",(_digest(rd),rid,rr[1]))
                     data["value"]=None; data["digest"]=_digest(data)
-                self._db.execute("UPDATE memory_heads SET current_revision=?,current_lifecycle=?,deletion_epoch=? WHERE record_id=?",(base+1,lifecycle,deletion,rid));self._db.execute("INSERT INTO memory_idempotency VALUES(?,?,?,?,?,?)",(actor.tenant_id,actor.subject_id,key,op.value,digest,rid));self._journal(op,data,digest);self._db.execute("COMMIT")
+                self._outbox("memory.write_committed", op, data, digest, old.digest);self._db.execute("INSERT INTO memory_idempotency VALUES(?,?,?,?,?,?)",(actor.tenant_id,actor.subject_id,key,op.value,digest,rid));self._journal(op,data,digest);self._db.execute("COMMIT"); self.flush_outbox()
                 rec=self._record(tuple(data[k] for k in ("record_id","revision","tenant_id","subject_id","actor_id","purpose","namespace","key","value","kind","lifecycle","policy_version","created_at","expires_at","deletion_epoch","digest","supersedes")))
                 receipt=None if op is not MemoryOperation.FORGET else DeletionReceipt("del-"+uuid4().hex,DeletionState.COMPLETED,rid,base+1,deletion,self._policy.version,("sqlite_payloads","canonical_head"),("sqlite_payloads","canonical_head"))
-                self._audit_event("memory.write_committed", actor, op, proposal, rec, prior_digest=old.digest, new_digest=rec.digest, deletion_epoch=deletion)
                 return MemoryCommitResult(MemoryReason.COMMITTED,rec,False,receipt)
             except Exception:
                 try: self._db.execute("ROLLBACK")

--- a/src/vulcan/runtime/app.py
+++ b/src/vulcan/runtime/app.py
@@ -1,154 +1,180 @@
-"""Canonical statically-composed ASGI application selected by Docker."""
-
+"""Canonical statically-composed authenticated ASGI application."""
 from __future__ import annotations
-
-import asyncio
+import asyncio, json, os
 from contextlib import asynccontextmanager
 from uuid import uuid4
-
-from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import JSONResponse
-from starlette.middleware.base import BaseHTTPMiddleware
-import os
-import base64
-import hashlib
-import hmac
-import json
-import time
-from vulcan.api.models import UnifiedChatRequest
-
+try:
+    from fastapi import FastAPI, HTTPException, Request
+    from fastapi.responses import JSONResponse
+except Exception:  # dependency-light route-manifest diagnostics
+    class HTTPException(Exception):
+        def __init__(self, status_code:int, detail:str='', headers=None): self.status_code=status_code; self.detail=detail; self.headers=headers or {}; super().__init__(detail)
+    class JSONResponse(dict):
+        def __init__(self, status_code:int=200, content=None, headers=None): super().__init__(content or {}); self.status_code=status_code; self.headers=headers or {}
+    class Request: pass
+    class _State: pass
+    class _Route:
+        def __init__(self,path,endpoint): self.path=path; self.endpoint=endpoint
+    class FastAPI:
+        def __init__(self, *a, **k): self.routes=[]; self.state=_State()
+        def get(self,path):
+            def deco(fn): self.routes.append(_Route(path,fn)); return fn
+            return deco
+        def post(self,path):
+            def deco(fn): self.routes.append(_Route(path,fn)); return fn
+            return deco
+        def patch(self,path):
+            def deco(fn): self.routes.append(_Route(path,fn)); return fn
+            return deco
+        def delete(self,path):
+            def deco(fn): self.routes.append(_Route(path,fn)); return fn
+            return deco
+        def middleware(self, _kind):
+            def deco(fn): return fn
+            return deco
+try:
+    from pydantic import BaseModel, ConfigDict, Field, StrictStr, StrictInt
+except Exception:  # pragma: no cover
+    BaseModel=object; ConfigDict=dict; Field=lambda *a,**k: None; StrictStr=str; StrictInt=int
+from .auth import AuthConfig, AuthError, AuthorizationError, authenticate_bearer
 from .case import CognitiveCase
 from .composition import compose_runtime
 from .kernel import KernelRequest
 from .semantic import Utterance
+from vulcan.memory.governed import MemoryActorContext, MemoryKind, MemoryReadRequest, MemoryWriteProposal, MemoryReason
 
+MAX_BODY=16_384
+ABSENT_ETAG='"absent"'
 
-def _runtime(request: Request):
-    runtime = getattr(request.app.state, "runtime", None)
-    if runtime is None or runtime.closed:
-        raise HTTPException(status_code=503, detail="Cognitive runtime is not ready")
-    return runtime
-
+def _auth_config_from_env()->AuthConfig:
+    return AuthConfig(secret=os.getenv('VULCAN_JWT_SECRET') or os.getenv('GRAPHIX_JWT_SECRET') or os.getenv('JWT_SECRET') or '', issuer=os.getenv('VULCAN_JWT_ISSUER','vulcan'), audience=os.getenv('VULCAN_JWT_AUDIENCE','vulcan-runtime'))
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Routes are registered below, before this point.  Readiness is not set
-    # until all required services form one RuntimeContainer.
-    app.state.ready = False
-    app.state.runtime = None
-    runtime = None
+    app.state.ready=False; app.state.runtime=None; app.state.auth_config=None; runtime=None
     try:
-        runtime = await asyncio.to_thread(compose_runtime)
-        await runtime.readiness()
-        app.state.runtime = runtime
-        app.state.ready = True
+        app.state.auth_config=_auth_config_from_env()
+        runtime=await asyncio.to_thread(compose_runtime)
+        await runtime.readiness(); app.state.runtime=runtime; app.state.ready=True
         yield
     except BaseException:
-        # Composition can succeed while a subsequent graph health check fails.
-        # Do not leak that partially composed owner graph or publish readiness.
+        app.state.ready=False; app.state.runtime=None
         if runtime is not None:
-            try:
-                await runtime.close()
-            except BaseException:
-                pass
-        app.state.runtime = None
+            try: await runtime.close()
+            except BaseException: pass
         raise
     finally:
-        app.state.ready = False
-        active_runtime = getattr(app.state, "runtime", None)
-        if active_runtime is not None:
-            await active_runtime.close()
-        app.state.runtime = None
+        app.state.ready=False
+        active=getattr(app.state,'runtime',None); app.state.runtime=None
+        if active is not None: await active.close()
 
+def _json_loads_no_dupes(raw:bytes):
+    def pairs(p):
+        d={}
+        for k,v in p:
+            if k in d: raise ValueError('duplicate JSON key')
+            d[k]=v
+        return d
+    return json.loads(raw.decode('utf-8'), object_pairs_hook=pairs, parse_constant=lambda x: (_ for _ in()).throw(ValueError('non-finite')))
+async def _body(request:Request):
+    ct=request.headers.get('content-type','').split(';',1)[0].strip().lower()
+    if ct!='application/json': raise HTTPException(415, 'unsupported content type')
+    raw=bytearray()
+    async for chunk in request.stream():
+        raw.extend(chunk)
+        if len(raw)>MAX_BODY: raise HTTPException(413, 'request body too large')
+    try: return _json_loads_no_dupes(bytes(raw))
+    except Exception: raise HTTPException(400, 'malformed JSON') from None
 
-def _jwt_secret() -> str | None:
-    return os.getenv("GRAPHIX_JWT_SECRET") or os.getenv("JWT_SECRET_KEY") or os.getenv("JWT_SECRET")
-
-def _decode_segment(segment: str) -> dict[str, object]:
-    padding = "=" * (-len(segment) % 4)
-    decoded = base64.urlsafe_b64decode((segment + padding).encode("ascii"))
-    value = json.loads(decoded.decode("utf-8"))
-    if not isinstance(value, dict):
-        raise ValueError("JWT segment is not an object")
-    return value
-
-def _authenticate_bearer(value: str) -> bool:
-    """Verify only configured HS256 bearer tokens; never treat presence as auth."""
-    secret = _jwt_secret()
-    if not secret or not value.startswith("Bearer "):
-        return False
-    parts = value[7:].split(".")
-    if len(parts) != 3:
-        return False
+def _principal(request:Request, scope:str):
     try:
-        header, payload = _decode_segment(parts[0]), _decode_segment(parts[1])
-        if header.get("alg") != "HS256" or not isinstance(payload.get("sub"), str):
-            return False
-        expected = base64.urlsafe_b64encode(hmac.new(secret.encode("utf-8"), f"{parts[0]}.{parts[1]}".encode("ascii"), hashlib.sha256).digest()).rstrip(b"=").decode("ascii")
-        if not hmac.compare_digest(expected, parts[2]):
-            return False
-        expiry = payload.get("exp")
-        return isinstance(expiry, (int, float)) and not isinstance(expiry, bool) and expiry > time.time()
-    except (UnicodeError, ValueError, json.JSONDecodeError):
-        return False
+        p=authenticate_bearer(request.headers.get('authorization'), request.app.state.auth_config)
+        p.require(scope); return p
+    except AuthorizationError: raise HTTPException(403,'forbidden') from None
+    except AuthError: raise HTTPException(401,'authentication required', headers={'WWW-Authenticate':'Bearer'}) from None
+async def _runtime(request:Request):
+    rt=getattr(request.app.state,'runtime',None)
+    if not getattr(request.app.state,'ready',False) or rt is None or rt.closed: raise HTTPException(503,'runtime not ready')
+    try: await rt.readiness()
+    except Exception:
+        request.app.state.ready=False; raise HTTPException(503,'runtime not ready') from None
+    return rt
 
-class ServingBoundaryMiddleware(BaseHTTPMiddleware):
-    """Canonical transport policy: health is public; chat is authenticated and bounded."""
-    max_body_bytes = 16_384
-    async def dispatch(self, request: Request, call_next):
-        if request.url.path not in {"/health/live", "/health/ready"}:
-            length = request.headers.get("content-length")
-            # Chunked bodies are rejected here; deployments must enforce the same
-            # bound upstream before forwarding a request without Content-Length.
-            if length is None or not length.isdigit() or int(length) > self.max_body_bytes:
-                return JSONResponse(status_code=413, content={"detail": "request body exceeds canonical bound"})
-            if not _authenticate_bearer(request.headers.get("authorization", "")):
-                return JSONResponse(status_code=401, content={"detail": "authentication required"}, headers={"WWW-Authenticate": "Bearer"})
-        response = await call_next(request)
-        response.headers.setdefault("X-Content-Type-Options", "nosniff")
-        response.headers.setdefault("X-Frame-Options", "DENY")
-        response.headers.setdefault("Cache-Control", "no-store")
-        return response
+def _actor(p, request_id): return MemoryActorContext(p.tenant,p.subject,p.subject,request_id=request_id)
 
-def generate_route_manifest() -> tuple[dict[str, object], ...]:
-    return tuple({"path": path, "method": method, "classification": "public" if path.startswith("/health/") else "protected", "authentication_required": not path.startswith("/health/"), "authorization": "none" if path.startswith("/health/") else "authenticated"} for path, method in (("/health/live", "GET"), ("/health/ready", "GET"), ("/v1/chat", "POST"), ("/v1/chat/orchestrated", "POST"), ("/vulcan/v1/chat", "POST")))
+class ReasonRequest(BaseModel):
+    message: StrictStr = Field(..., min_length=1, max_length=2048)
+    conversation_id: StrictStr|None = Field(default=None, max_length=128)
+    model_config=ConfigDict(extra='forbid', strict=True)
+class MemoryWriteBody(BaseModel):
+    key: StrictStr=Field(..., min_length=1, max_length=64); value: StrictStr=Field(..., min_length=1, max_length=64); idempotency_key: StrictStr=Field(..., min_length=1, max_length=128)
+    model_config=ConfigDict(extra='forbid', strict=True)
+class MemoryCorrectBody(MemoryWriteBody):
+    base_revision: StrictInt=Field(..., ge=1, le=1_000_000)
+class BundleBody(BaseModel):
+    bundle: dict
+    model_config=ConfigDict(extra='forbid', strict=True)
 
-def create_app() -> FastAPI:
-    app = FastAPI(title="VULCAN canonical runtime", version="4.0", lifespan=lifespan)
-    app.add_middleware(ServingBoundaryMiddleware)
-    app.state.route_manifest = generate_route_manifest()
+def generate_route_manifest():
+    return tuple({'path':p,'method':m,'classification':'public' if p.startswith('/health/') else 'protected'} for p,m in [('/health/live','GET'),('/health/ready','GET'),('/v1/chat','POST'),('/v1/admin/domains','POST'),('/v1/admin/alignment','POST'),('/v1/audit/cases/{case_id}','GET'),('/v1/memory/preferences','POST'),('/v1/memory/preferences/{key}','GET'),('/v1/memory/preferences/{record_id}','PATCH'),('/v1/memory/preferences/{record_id}','DELETE')])
 
-    @app.get("/health/live")
-    async def live() -> dict[str, str]:
-        return {"status": "alive"}
-
-    @app.get("/health/ready")
-    async def ready(request: Request):
-        runtime = getattr(request.app.state, "runtime", None)
-        if not getattr(request.app.state, "ready", False) or runtime is None:
-            return JSONResponse(status_code=503, content={"status": "not_ready"})
-        try:
-            await runtime.readiness()
-            capabilities = runtime.capabilities()
-        except Exception:
-            app = request.app
-            app.state.ready = False
-            return JSONResponse(status_code=503, content={"status": "not_ready"})
-        return {"status": "ready", "runtime_id": runtime.runtime_id, "capabilities": list(capabilities)}
-
-    async def chat_handler(request: Request, body: UnifiedChatRequest):
-        runtime = _runtime(request)
-        if body.history or body.enable_reasoning or body.enable_memory or body.enable_planning or body.enable_causal:
-            raise HTTPException(status_code=422, detail="history, memory, planning, causal, and general reasoning are unavailable on the canonical runtime")
-        utterance = Utterance.from_text(body.message)
-        case = CognitiveCase.create(request_id=request.headers.get("X-Request-ID", str(uuid4())), conversation_id=body.conversation_id, input_digest=utterance.digest)
-        result = await runtime.kernel.handle(KernelRequest(utterance, body.conversation_id), case)
-        return result.transport(case_id=case.case_id, runtime_id=runtime.runtime_id, snapshot_id=case.state_snapshot_id)
-
-    app.post("/v1/chat", response_model=None)(chat_handler)
-    app.post("/v1/chat/orchestrated", response_model=None)(chat_handler)
-    app.post("/vulcan/v1/chat", response_model=None)(chat_handler)
+def create_app()->FastAPI:
+    app=FastAPI(title='VULCAN canonical runtime', version='7.0', lifespan=lifespan)
+    app.state.route_manifest=generate_route_manifest(); app.state.ready=False; app.state.runtime=None
+    @app.middleware('http')
+    async def bounds(request, call_next):
+        resp=await call_next(request); resp.headers.setdefault('Cache-Control','no-store'); resp.headers.setdefault('X-Content-Type-Options','nosniff'); return resp
+    @app.get('/health/live')
+    async def live(): return {'status':'alive'}
+    @app.get('/health/ready')
+    async def ready(request:Request):
+        try: rt=await _runtime(request); return {'status':'ready','runtime_id':rt.runtime_id,'capabilities':list(rt.capabilities())}
+        except HTTPException: return JSONResponse(status_code=503, content={'status':'not_ready'})
+    async def chat(request:Request):
+        _principal(request,'reason:write'); rt=await _runtime(request); data=await _body(request); body=ReasonRequest.model_validate(data)
+        utterance=Utterance.from_text(body.message); case=CognitiveCase.create(request_id='req-'+uuid4().hex, conversation_id=body.conversation_id, input_digest=utterance.digest)
+        result=await rt.kernel.handle(KernelRequest(utterance, body.conversation_id), case); out=result.transport(case_id=case.case_id,runtime_id=rt.runtime_id,snapshot_id=case.state_snapshot_id); out['status']=result.status.value; return out
+    for _p in ('/v1/chat','/v1/chat/orchestrated','/vulcan/v1/chat'):
+        app.post(_p)(chat)
+    @app.post('/v1/admin/domains')
+    async def domains(request:Request):
+        p=_principal(request,'domains:write'); rt=await _runtime(request); etag=request.headers.get('if-match')
+        if etag is None: raise HTTPException(412,'If-Match required')
+        data=await _body(request); body=BundleBody.model_validate(data); snap=await asyncio.to_thread(rt.domain_registry.load_bundle, json.dumps(body.bundle).encode(), expected_previous_digest=None if etag==ABSENT_ETAG else etag.strip('"'))
+        return {'committed_snapshot_id':snap,'committed_audit_identity':'domain.activation_committed','actor':p.subject}
+    @app.post('/v1/admin/alignment')
+    async def alignment(request:Request):
+        p=_principal(request,'alignment:write'); rt=await _runtime(request); etag=request.headers.get('if-match')
+        if etag is None: raise HTTPException(412,'If-Match required')
+        data=await _body(request); pol=await asyncio.to_thread(rt.alignment.update, data, expected_previous_digest=etag.strip('"'), actor_id=p.subject)
+        return {'policy_id':pol.policy_id,'revision':pol.revision,'policy_digest':pol.policy_digest,'committed_audit_identity':'alignment.activation_committed'}
+    @app.get('/v1/audit/cases/{case_id}')
+    async def audit_case(case_id:str, request:Request):
+        _principal(request,'audit:read'); rt=await _runtime(request)
+        if not case_id.startswith('case-') or len(case_id)>128: raise HTTPException(404,'case not found')
+        rows=rt.audit.case_events(case_id) if hasattr(rt.audit,'case_events') else []
+        return {'case_id':case_id,'events':rows[:64]}
+    @app.post('/v1/memory/preferences')
+    async def mem_create(request:Request):
+        p=_principal(request,'memory:write'); rt=await _runtime(request); body=MemoryWriteBody.model_validate(await _body(request)); res=await asyncio.to_thread(rt.memory.remember,_actor(p,'req-'+uuid4().hex),MemoryWriteProposal(MemoryKind.EXPLICIT_PREFERENCE,'profile',body.key,body.value,body.idempotency_key))
+        if res.reason is not MemoryReason.COMMITTED: raise HTTPException(409,res.reason.value)
+        return {'record_id':res.record.record_id,'revision':res.record.revision,'key':res.record.key,'value':res.record.value}
+    @app.get('/v1/memory/preferences/{key}')
+    async def mem_read(key:str, request:Request):
+        p=_principal(request,'memory:read'); rt=await _runtime(request); rows=await asyncio.to_thread(rt.memory.retrieve,MemoryReadRequest(_actor(p,'req-'+uuid4().hex),'profile',key,1))
+        if not rows: raise HTTPException(404,'memory not found')
+        r=rows[0]; return {'record_id':r.record_id,'revision':r.revision,'key':r.key,'value':r.value}
+    @app.patch('/v1/memory/preferences/{record_id}')
+    async def mem_correct(record_id:str, request:Request):
+        p=_principal(request,'memory:write'); rt=await _runtime(request); body=MemoryCorrectBody.model_validate(await _body(request)); res=await asyncio.to_thread(rt.memory.correct,_actor(p,'req-'+uuid4().hex),record_id,body.base_revision,MemoryWriteProposal(MemoryKind.EXPLICIT_PREFERENCE,'profile',body.key,body.value,body.idempotency_key))
+        if res.reason is not MemoryReason.COMMITTED: raise HTTPException(409,res.reason.value)
+        return {'record_id':res.record.record_id,'revision':res.record.revision,'key':res.record.key,'value':res.record.value}
+    @app.delete('/v1/memory/preferences/{record_id}')
+    async def mem_forget(record_id:str, request:Request):
+        p=_principal(request,'memory:forget'); rt=await _runtime(request); rev=int(request.headers.get('if-match','0').strip('"') or '0')
+        if rev<1: raise HTTPException(412,'If-Match required')
+        res=await asyncio.to_thread(rt.memory.forget,_actor(p,'req-'+uuid4().hex),record_id,rev,request.headers.get('idempotency-key') or 'forget-'+uuid4().hex)
+        if res.reason is not MemoryReason.COMMITTED: raise HTTPException(409,res.reason.value)
+        return {'record_id':record_id,'revision':res.record.revision,'state':'forgotten'}
     return app
-
-
-app = create_app()
+app=create_app()

--- a/src/vulcan/runtime/auth.py
+++ b/src/vulcan/runtime/auth.py
@@ -1,0 +1,96 @@
+"""Dependency-light strict HS256 bearer authentication for canonical runtime."""
+from __future__ import annotations
+import base64, binascii, hashlib, hmac, json, math, re, time, unicodedata
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+_B64=re.compile(r"^[A-Za-z0-9_-]+$")
+_CTL=re.compile(r"[\x00-\x1f\x7f]")
+KEY_FIELDS={"jku","jwk","kid","x5u","x5c","x5t","x5t#S256","crit"}
+MAX_HEADER=8192; MAX_JWT=6144; MAX_SEG=2048; MAX_JSON=4096; MAX_CLAIMS=32; MAX_LIST=16; MAX_TEXT=256
+class AuthError(ValueError): pass
+class AuthorizationError(AuthError): pass
+@dataclass(frozen=True)
+class AuthConfig:
+    secret: str; issuer: str; audience: str; skew_seconds:int=60; require_typ:bool=True; tenant_claim:str="tenant"
+    def __post_init__(self):
+        if len(self.secret.encode('utf-8'))<32: raise AuthError("strong JWT secret required")
+        for v in (self.issuer,self.audience,self.tenant_claim): _text(v,MAX_TEXT,"config")
+        if not (0<=self.skew_seconds<=300): raise AuthError("invalid auth skew")
+@dataclass(frozen=True)
+class AuthenticatedPrincipal:
+    subject:str; tenant:str; issuer:str; audience:tuple[str,...]; scopes:frozenset[str]
+    def require(self, scope:str)->None:
+        if scope not in self.scopes: raise AuthorizationError("missing required scope")
+
+def _text(v,max_len,name):
+    if not isinstance(v,str) or not v or len(v)>max_len: raise AuthError(f"invalid {name}")
+    n=unicodedata.normalize('NFC',v)
+    if n!=v or _CTL.search(n) or any(0xD800<=ord(c)<=0xDFFF for c in n): raise AuthError(f"invalid {name}")
+    return n
+
+def _b64(seg):
+    if not isinstance(seg,str) or not seg or len(seg)>MAX_SEG or '=' in seg or not _B64.fullmatch(seg): raise AuthError("invalid JWT encoding")
+    try: raw=base64.urlsafe_b64decode(seg+'='*((4-len(seg)%4)%4))
+    except (binascii.Error, ValueError): raise AuthError("invalid JWT encoding") from None
+    if not raw or len(raw)>MAX_JSON: raise AuthError("decoded JWT segment too large")
+    if base64.urlsafe_b64encode(raw).rstrip(b'=').decode('ascii')!=seg: raise AuthError("noncanonical JWT encoding")
+    return raw
+
+def _loads(raw):
+    def pairs(p):
+        if len(p)>MAX_CLAIMS: raise AuthError("too many claims")
+        d={}
+        for k,v in p:
+            _text(k,64,"claim name")
+            if k in d: raise AuthError("duplicate JSON key")
+            d[k]=v
+        return d
+    try: obj=json.loads(raw.decode('utf-8'), object_pairs_hook=pairs, parse_constant=lambda x: (_ for _ in ()).throw(AuthError("non-finite number")))
+    except (UnicodeDecodeError,json.JSONDecodeError) as e: raise AuthError("invalid JWT JSON") from e
+    if not isinstance(obj,dict): raise AuthError("JWT object required")
+    return obj
+
+def _finite_time(o,name):
+    if type(o) not in (int,float) or not math.isfinite(o): raise AuthError(f"invalid {name}")
+    return float(o)
+
+def _aud(v):
+    if isinstance(v,str): return (_text(v,MAX_TEXT,"audience"),)
+    if isinstance(v,list) and 1<=len(v)<=MAX_LIST:
+        vals=tuple(_text(x,MAX_TEXT,"audience") for x in v)
+        if len(set(vals))!=len(vals): raise AuthError("duplicate audience")
+        return vals
+    raise AuthError("invalid audience")
+
+def _scopes(v):
+    if isinstance(v,str): vals=tuple(x for x in v.split(' ') if x)
+    elif isinstance(v,list): vals=tuple(v)
+    else: raise AuthError("invalid scopes")
+    if not vals or len(vals)>MAX_LIST: raise AuthError("invalid scopes")
+    vals=tuple(_text(x,64,"scope") for x in vals)
+    if len(set(vals))!=len(vals): raise AuthError("duplicate scopes")
+    return frozenset(vals)
+
+def authenticate_bearer(header:str|None, config:AuthConfig, *, clock:Callable[[],float]|None=None)->AuthenticatedPrincipal:
+    if not isinstance(header,str) or not header.startswith('Bearer ') or len(header)>MAX_HEADER: raise AuthError("missing bearer token")
+    token=header[7:]
+    if len(token)>MAX_JWT or token.count('.')!=2: raise AuthError("malformed JWT")
+    hseg,pseg,sseg=token.split('.')
+    header_obj,payload=_loads(_b64(hseg)),_loads(_b64(pseg))
+    if set(header_obj)&KEY_FIELDS: raise AuthError("JWT key selection is forbidden")
+    if header_obj.get('alg')!='HS256': raise AuthError("unsupported JWT algorithm")
+    if config.require_typ and header_obj.get('typ')!='JWT': raise AuthError("invalid JWT typ")
+    if set(header_obj)-{'alg','typ'}: raise AuthError("unsupported JWT header")
+    expected=base64.urlsafe_b64encode(hmac.new(config.secret.encode(), f'{hseg}.{pseg}'.encode('ascii'), hashlib.sha256).digest()).rstrip(b'=').decode('ascii')
+    if not hmac.compare_digest(expected,sseg): raise AuthError("invalid JWT signature")
+    now=(clock or time.time)(); exp=_finite_time(payload.get('exp'), 'exp')
+    if exp<=now: raise AuthError("expired JWT")
+    if 'nbf' in payload and _finite_time(payload['nbf'],'nbf')>now+config.skew_seconds: raise AuthError("JWT not yet valid")
+    if 'iat' in payload and _finite_time(payload['iat'],'iat')>now+config.skew_seconds: raise AuthError("JWT issued in future")
+    sub=_text(payload.get('sub'),128,'subject'); tenant=_text(payload.get(config.tenant_claim),128,'tenant')
+    if payload.get('iss')!=config.issuer: raise AuthError("issuer mismatch")
+    audiences=_aud(payload.get('aud'))
+    if config.audience not in audiences: raise AuthError("audience mismatch")
+    scopes=_scopes(payload.get('scope', payload.get('scopes')))
+    return AuthenticatedPrincipal(sub, tenant, config.issuer, audiences, scopes)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -534,13 +534,21 @@ def pytest_sessionfinish(session, exitstatus):
 
     print(f"[conftest] Test session finished with exit status {exitstatus}")
 
-# Dependency-light asyncio marker support when pytest-asyncio is unavailable.
+# Dependency-light asyncio marker support when pytest-asyncio/AnyIO is unavailable.
+def _compatible_async_plugin_present(config):
+    pm=config.pluginmanager
+    return any(pm.hasplugin(name) for name in ("asyncio", "pytest_asyncio", "anyio"))
+
 def pytest_pyfunc_call(pyfuncitem):
-    if pyfuncitem.get_closest_marker("asyncio") is not None:
-        import asyncio, inspect
-        testfunction = pyfuncitem.obj
-        if inspect.iscoroutinefunction(testfunction):
-            kwargs = {name: pyfuncitem.funcargs[name] for name in pyfuncitem._fixtureinfo.argnames}
-            asyncio.run(testfunction(**kwargs))
-            return True
+    marker=pyfuncitem.get_closest_marker("asyncio")
+    if marker is None or _compatible_async_plugin_present(pyfuncitem.config):
+        return None
+    import asyncio, inspect, pytest
+    testfunction=pyfuncitem.obj
+    if inspect.isasyncgenfunction(testfunction):
+        raise pytest.UsageError("async generator tests require a real async pytest plugin")
+    if inspect.iscoroutinefunction(testfunction):
+        kwargs={name: pyfuncitem.funcargs[name] for name in pyfuncitem._fixtureinfo.argnames}
+        asyncio.run(testfunction(**kwargs))
+        return True
     return None

--- a/tests/security/test_phase7_auth_outbox.py
+++ b/tests/security/test_phase7_auth_outbox.py
@@ -1,0 +1,92 @@
+import base64, hashlib, hmac, json, time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from vulcan.runtime.auth import AuthConfig, AuthError, AuthorizationError, authenticate_bearer
+from vulcan.memory.governed import SQLiteMemoryRepository, MemoryActorContext, MemoryWriteProposal, MemoryKind, MemoryReadRequest, MemoryReason
+
+SECRET='s'*32
+
+def b64(o):
+    raw=json.dumps(o, separators=(',', ':'), allow_nan=False).encode()
+    return base64.urlsafe_b64encode(raw).rstrip(b'=').decode()
+def tok(payload, header=None, secret=SECRET):
+    h=b64(header or {'alg':'HS256','typ':'JWT'}); p=b64(payload); sig=base64.urlsafe_b64encode(hmac.new(secret.encode(),f'{h}.{p}'.encode(),hashlib.sha256).digest()).rstrip(b'=').decode(); return f'Bearer {h}.{p}.{sig}'
+def cfg(): return AuthConfig(SECRET,'iss','aud')
+def good(**kw):
+    p={'sub':'u1','tenant':'t1','iss':'iss','aud':'aud','scope':'reason:write memory:read','exp':2000,'iat':900,'nbf':900}; p.update(kw); return p
+
+def test_auth_valid_and_principal_has_no_raw_token():
+    p=authenticate_bearer(tok(good()), cfg(), clock=lambda:1000)
+    assert (p.subject,p.tenant)==('u1','t1') and 'reason:write' in p.scopes and not hasattr(p,'token')
+
+def test_auth_rejects_weak_secret_missing_bearer_structure_padding_and_bad_sig():
+    with pytest.raises(AuthError): AuthConfig('short','iss','aud')
+    with pytest.raises(AuthError): authenticate_bearer(tok(good())[7:], cfg(), clock=lambda:1000)
+    with pytest.raises(AuthError): authenticate_bearer('Bearer a.b', cfg(), clock=lambda:1000)
+    bad=tok(good()).replace('.', '=.', 1)
+    with pytest.raises(AuthError): authenticate_bearer(bad, cfg(), clock=lambda:1000)
+    with pytest.raises(AuthError): authenticate_bearer(tok(good(), secret='x'*32), cfg(), clock=lambda:1000)
+
+def test_auth_rejects_duplicate_keys_algorithms_key_selection_times_and_mismatch():
+    h='eyJhbGciOiJIUzI1NiIsImFsZyI6IkhTMjU2IiwidHlwIjoiSldUIn0'; p=b64(good()); sig=base64.urlsafe_b64encode(hmac.new(SECRET.encode(),f'{h}.{p}'.encode(),hashlib.sha256).digest()).rstrip(b'=').decode()
+    with pytest.raises(AuthError): authenticate_bearer(f'Bearer {h}.{p}.{sig}', cfg(), clock=lambda:1000)
+    for header in ({'alg':'none','typ':'JWT'},{'alg':'RS256','typ':'JWT'},{'alg':'HS256','typ':'JWT','kid':'k'}):
+        with pytest.raises(AuthError): authenticate_bearer(tok(good(), header), cfg(), clock=lambda:1000)
+    for pl in (good(exp=999), good(exp=True), good(nbf=2000), good(iat=2000), good(iss='bad'), good(aud='bad'), good(sub=''), good(tenant=''), good(scope=['a','a'])):
+        with pytest.raises(AuthError): authenticate_bearer(tok(pl), cfg(), clock=lambda:1000)
+    raw='eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.'+base64.urlsafe_b64encode(b'{"sub":"u1","tenant":"t1","iss":"iss","aud":"aud","scope":"reason:write","exp":NaN}').rstrip(b'=').decode()
+    sig=base64.urlsafe_b64encode(hmac.new(SECRET.encode(), raw[7:].encode() if raw.startswith('Bearer ') else raw.encode(), hashlib.sha256).digest()).rstrip(b'=').decode()
+    with pytest.raises(AuthError): authenticate_bearer('Bearer '+raw+'.'+sig, cfg(), clock=lambda:1000)
+    p=authenticate_bearer(tok(good(nbf=1050, iat=1050)), cfg(), clock=lambda:1000); assert p.subject=='u1'
+    with pytest.raises(AuthorizationError): p.require('domains:write')
+
+class FailingAudit:
+    def __init__(self): self.events=[]; self.fail=False; self.fail_after=False
+    def append(self, et, payload):
+        if self.fail: raise RuntimeError('audit down')
+        self.events.append((et,payload['operation_id']))
+        if self.fail_after: raise RuntimeError('ack failed')
+
+def actor(): return MemoryActorContext('tenant','subject','subject',request_id='req')
+def proposal(k='idem'): return MemoryWriteProposal(MemoryKind.EXPLICIT_PREFERENCE,'profile','response_style','concise',k)
+
+def test_outbox_pending_excluded_retry_reopen_and_no_duplicate_event(tmp_path):
+    audit=FailingAudit(); db=tmp_path/'m.db'; repo=SQLiteMemoryRepository(str(db), durable_root=str(tmp_path), audit=audit)
+    audit.fail=True
+    with pytest.raises(RuntimeError): repo.commit(actor(), proposal('same'))
+    assert repo.read(MemoryReadRequest(actor(),'profile','response_style',1)) == ()
+    assert repo._db.execute('select count(*) from memory_revisions').fetchone()[0] == 1
+    assert repo._db.execute('select count(*) from memory_audit_outbox where audit_complete=0').fetchone()[0] == 1
+    audit.fail=False
+    res=repo.commit(actor(), proposal('same'))
+    assert res.reason is MemoryReason.COMMITTED and res.record.revision == 1
+    assert [e[0] for e in audit.events].count('memory.write_committed') == 1
+    repo.close()
+    repo2=SQLiteMemoryRepository(str(db), durable_root=str(tmp_path), audit=audit)
+    assert len(repo2.read(MemoryReadRequest(actor(),'profile','response_style',1))) == 1
+    assert repo2._db.execute('select count(*) from memory_revisions').fetchone()[0] == 1
+    repo2.close()
+
+def test_outbox_audit_success_ack_failure_is_idempotent(tmp_path):
+    audit=FailingAudit(); audit.fail_after=True; db=tmp_path/'m.db'; repo=SQLiteMemoryRepository(str(db), durable_root=str(tmp_path), audit=audit)
+    with pytest.raises(RuntimeError): repo.commit(actor(), proposal('ack'))
+    assert repo.read(MemoryReadRequest(actor(),'profile','response_style',1)) == ()
+    audit.fail_after=False
+    res=repo.commit(actor(), proposal('ack'))
+    assert res.reason is MemoryReason.COMMITTED
+    assert repo._db.execute('select count(*) from memory_revisions').fetchone()[0] == 1
+    assert [e[0] for e in audit.events].count('memory.write_committed') == 1
+    repo.close()
+
+def test_asyncio_fallback_plugin_paths_are_mutually_exclusive(pytestconfig):
+    import tests.conftest as c
+    class PM:
+        def __init__(self, present): self.present=present
+        def hasplugin(self, name): return self.present and name == 'asyncio'
+    class Cfg:
+        def __init__(self, present): self.pluginmanager=PM(present)
+    assert c._compatible_async_plugin_present(Cfg(True)) is True
+    assert c._compatible_async_plugin_present(Cfg(False)) is False


### PR DESCRIPTION
### Motivation

- Provide a single canonical ASGI runtime with strict HS256 bearer authentication and no unauthenticated fallback. 
- Prevent memory writes from becoming visible before their required audit append is durably acknowledged and make idempotent retries resume pending operations. 
- Ensure test harness behaves deterministically for async tests by avoiding a dependency-light fallback when a real async plugin is present and by rejecting unsupported async generator tests.

### Description

- Add a dependency-light, strict JWT module at `src/vulcan/runtime/auth.py` that enforces HS256, canonical base64url parsing, duplicate-key/non-finite JSON rejection, issuer/audience/time/tenant/scopes validation, injected clock support, and an immutable `AuthenticatedPrincipal` API. 
- Rework the canonical application in `src/vulcan/runtime/app.py` to use a single lifespan-owned `RuntimeContainer`, validate auth config at startup, enforce bounded JSON body parsing, validate/require scopes, publish readiness only after full readiness checks, and expose the narrow HTTP surface (health, chat, admin domain/alignment, audit case retrieval, governed-memory CRUD). 
- Implement a transactional SQLite outbox and reconciliation in `src/vulcan/memory/governed.py` so revision + idempotency + a bounded pending audit record are created atomically, outbox rows are flushed synchronously before a write is reported effective, pending outbox entries are reconciled at startup/readiness, retries resume pending operations, and duplicate semantic events are avoided. 
- Harden pytest async fallback in `tests/conftest.py` so it runs only when no compatible async plugin is present, preserves fixtures and exception propagation, and rejects async-generator tests instead of silently passing them. 
- Add focused tests in `tests/security/test_phase7_auth_outbox.py` that exercise auth adversarial cases and the outbox/failure-recovery/idempotency behaviors.

### Testing

- Ran focused dependency-light/auth and outbox tests: `pytest -q tests/security/test_phase7_auth_outbox.py` — passed. 
- Ran the broader security-focused suite exercised during development, including governed memory, persistent audit/alignment/domain registries and runtime convergence diagnostics: the dependency-light suite ran successfully (72 tests passed). 
- Static/optimized compile checks: `python -m compileall` and `python -O -m compileall` over modified modules succeeded. 
- Adversarial diagnostic verifying weak secret rejection succeeded via `AuthConfig` checks. 
- Environment note: FastAPI is not installed in this container, so live ASGI/TestClient-based HTTP surface verification could not be executed here (framework-dependent tests were skipped or exercised via dependency-light route-manifest diagnostics). 

Commit SHA: `0e7f7b7a0a317cb5770e73673071186ced015ea4`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b68f3e4e0832f82ea81e8b306519a)