### PR TITLE
Implement governed self-improvement transaction

### DIFF
--- a/configs/auto_apply_policy.yaml
+++ b/configs/auto_apply_policy.yaml
@@ -1,8 +1,8 @@
 version: "1"
 auto_apply:
-  enabled: true
+  enabled: false
   # Budget limits for a single auto-apply
-  max_files: 3
+  max_files: 1
   max_total_loc: 100
 
   # Allow/deny patterns (POSIX-style, relative to repo root)
@@ -10,8 +10,6 @@ auto_apply:
     - "src/vulcan/**/*.py"
     - "src/safety/**/*.py"
     - "tests/**/*.py"
-    - "configs/**"
-    - "scripts/**"
     - "!src/**/auth/**"
     - "!src/**/security/**"
     - "!src/**/db/**"

--- a/src/vulcan/world_model/meta_reasoning/governed_transaction.py
+++ b/src/vulcan/world_model/meta_reasoning/governed_transaction.py
@@ -1,0 +1,362 @@
+"""Governed self-improvement transaction.
+
+Dependency-light transaction owner for Phase 8.  All source mutation is CAS,
+policy, approval, audit, and changed-tree verification gated.  The module never
+commits, pushes, evaluates plan callables, or executes model supplied commands.
+"""
+from __future__ import annotations
+
+import ast
+import difflib
+import hashlib
+import json
+import os
+import stat
+import subprocess
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+SCHEMA_VERSION = "vulcan-improvement-proposal/1"
+DISABLED_ENV = "VULCAN_AUTO_APPLY_DISABLED"
+_ALLOWED_PROPOSAL_KEYS = frozenset({
+    "schema_version", "proposal_id", "objective_type", "target_path",
+    "expected_original_sha256", "original_content", "candidate_content",
+    "candidate_sha256", "inspected_source_digest", "generator_identity",
+    "provider_release_digest", "rationale", "expected_policy_digest",
+    "approval_id",
+})
+_DENY_PREFIXES = (
+    ".git", ".venv", "venv", "env", "__pycache__", ".pytest_cache", ".mypy_cache",
+    "data", "audit", "logs", "memory", "models", "weights", "secrets", ".github/workflows",
+)
+_DENY_NAMES = {".env", "auto_apply_policy.yaml"}
+_TERMINAL = {"applied", "rejected", "aborted", "verification_failed"}
+
+class TransactionError(Exception):
+    """Fail-closed transaction validation/application error."""
+
+@dataclass(frozen=True)
+class VerificationGate:
+    identity: str
+    argv: Tuple[str, ...]
+    timeout_s: float = 10.0
+    output_limit: int = 20000
+    env: Mapping[str, str] = field(default_factory=dict)
+
+@dataclass(frozen=True)
+class ImprovementPolicy:
+    schema_version: str
+    enabled: bool
+    repo_root: Path
+    permitted_objectives: Tuple[str, ...]
+    permitted_path_globs: Tuple[str, ...]
+    denied_path_globs: Tuple[str, ...]
+    max_files: int
+    max_candidate_bytes: int
+    max_changed_lines: int
+    approval_required: bool
+    permitted_generators: Mapping[str, Tuple[str, ...]]
+    verification_gates: Tuple[VerificationGate, ...]
+    timeout_s: float
+    output_limit: int
+    audit_required: bool
+    clean_changed_file_set: bool = True
+    allow_hardlinks: bool = False
+    digest: str = ""
+
+@dataclass(frozen=True)
+class InspectionSnapshot:
+    repo_root: Path
+    files: Mapping[str, str]
+    contents: Mapping[str, str]
+    digest: str
+
+@dataclass(frozen=True)
+class ImprovementProposal:
+    schema_version: str
+    proposal_id: str
+    objective_type: str
+    target_path: str
+    expected_original_sha256: str
+    original_content: str
+    candidate_content: str
+    candidate_sha256: str
+    inspected_source_digest: str
+    generator_identity: str
+    provider_release_digest: str
+    rationale: str = ""
+    expected_policy_digest: str = ""
+    approval_id: str = ""
+
+    @classmethod
+    def from_json(cls, text: str) -> "ImprovementProposal":
+        def pairs_hook(pairs: List[Tuple[str, Any]]) -> Dict[str, Any]:
+            out: Dict[str, Any] = {}
+            for k, v in pairs:
+                if k in out:
+                    raise TransactionError(f"duplicate proposal key: {k}")
+                out[k] = v
+            return out
+        obj = json.loads(text, object_pairs_hook=pairs_hook)
+        return cls.from_mapping(obj)
+
+    @classmethod
+    def from_mapping(cls, obj: Mapping[str, Any]) -> "ImprovementProposal":
+        if not isinstance(obj, Mapping):
+            raise TransactionError("proposal must be a mapping")
+        unknown = set(obj) - _ALLOWED_PROPOSAL_KEYS
+        if unknown:
+            raise TransactionError(f"unknown proposal fields: {sorted(unknown)}")
+        required = _ALLOWED_PROPOSAL_KEYS - {"rationale", "approval_id"}
+        missing = [k for k in sorted(required) if k not in obj]
+        if missing:
+            raise TransactionError(f"missing proposal fields: {missing}")
+        vals = {k: obj.get(k, "") for k in _ALLOWED_PROPOSAL_KEYS}
+        if not all(isinstance(v, str) for v in vals.values()):
+            raise TransactionError("proposal fields must be strings")
+        return cls(**{k: vals[k] for k in cls.__dataclass_fields__})
+
+    def digest(self) -> str:
+        data = {k: getattr(self, k) for k in sorted(self.__dataclass_fields__)}
+        return _sha256(json.dumps(data, sort_keys=True, separators=(",", ":")).encode())
+
+@dataclass(frozen=True)
+class ApprovalRecord:
+    approval_id: str
+    proposal_digest: str
+    policy_digest: str
+    original_source_digest: str
+    approver_identity: str
+    approved_at: float
+    expires_at: float
+    state: str = "approved"
+    used: bool = False
+
+@dataclass
+class TransactionResult:
+    status: str
+    state: str
+    proposal_digest: str = ""
+    target_path: str = ""
+    failure_category: str = ""
+    gate_results: List[Dict[str, Any]] = field(default_factory=list)
+    rollback_digest: str = ""
+
+class ApprovalStore:
+    def __init__(self, path: Path):
+        self.path = Path(path)
+    def load(self, approval_id: str) -> ApprovalRecord:
+        try:
+            doc = json.loads(self.path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            raise TransactionError("approval store unavailable or corrupt") from exc
+        rec = doc.get(approval_id)
+        if not isinstance(rec, dict):
+            raise TransactionError("approval not found")
+        return ApprovalRecord(**rec)
+    def mark_used(self, approval_id: str) -> None:
+        doc = json.loads(self.path.read_text(encoding="utf-8"))
+        doc[approval_id]["used"] = True
+        _atomic_write(self.path, json.dumps(doc, sort_keys=True).encode(), 0o600)
+
+def _sha256(b: bytes) -> str:
+    return hashlib.sha256(b).hexdigest()
+
+def _rel_path(path: str) -> Path:
+    if not path or path.startswith("/") or "\\" in path or "\x00" in path:
+        raise TransactionError("invalid target path")
+    if any(ord(c) < 32 for c in path):
+        raise TransactionError("control character in target path")
+    p = Path(path)
+    if p.is_absolute() or any(part in ("", ".", "..") for part in p.parts):
+        raise TransactionError("ambiguous or traversing target path")
+    if p.suffix != ".py":
+        raise TransactionError("target must be an existing Python file")
+    return p
+
+def resolve_repo_root(root: Path) -> Path:
+    root = Path(root)
+    if root.is_symlink():
+        raise TransactionError("repository root symlink rejected")
+    resolved = root.resolve()
+    if str(resolved) in {"/", str(Path.home())} or len(resolved.parts) < 3:
+        raise TransactionError("broad repository root rejected")
+    if not (resolved / ".git").exists():
+        raise TransactionError("repository marker .git missing")
+    return resolved
+
+def resolve_target(repo_root: Path, rel: str) -> Path:
+    rp = _rel_path(rel)
+    cur = repo_root
+    for part in rp.parts:
+        cur = cur / part
+        if cur.is_symlink():
+            raise TransactionError("symlink in target path rejected")
+    target = (repo_root / rp).resolve()
+    if not str(target).startswith(str(repo_root) + os.sep):
+        raise TransactionError("target escapes repository root")
+    return target
+
+def inspect_repository(repo_root: Path, allow_globs: Sequence[str], *, max_files: int = 100, max_file_bytes: int = 200000, max_total_bytes: int = 1000000) -> InspectionSnapshot:
+    root = resolve_repo_root(repo_root)
+    files: Dict[str, str] = {}; contents: Dict[str, str] = {}; total = 0
+    for f in sorted(root.rglob("*.py")):
+        rel = f.relative_to(root).as_posix()
+        if _denied(rel) or not _glob_any(rel, allow_globs) or f.is_symlink() or not f.is_file():
+            continue
+        data = f.read_bytes()
+        if len(data) > max_file_bytes: continue
+        total += len(data)
+        if len(files) >= max_files or total > max_total_bytes: raise TransactionError("inspection bounds exceeded")
+        try: text = data.decode("utf-8")
+        except UnicodeDecodeError: continue
+        digest = _sha256(data); files[rel] = digest; contents[rel] = text
+    snap = json.dumps(files, sort_keys=True, separators=(",", ":")).encode()
+    return InspectionSnapshot(root, files, contents, _sha256(snap))
+
+def _glob_any(path: str, globs: Sequence[str]) -> bool:
+    import fnmatch
+    return any(fnmatch.fnmatch(path, g) for g in globs if _safe_glob(g))
+
+def _safe_glob(g: str) -> bool:
+    return bool(g) and not g.startswith("/") and "\\" not in g and ".." not in Path(g).parts
+
+def _denied(rel: str) -> bool:
+    parts = rel.split("/")
+    return parts[0] in _DENY_PREFIXES or any(rel == p or rel.startswith(p + "/") for p in _DENY_PREFIXES) or parts[-1] in _DENY_NAMES
+
+def load_governed_policy(path: Path) -> ImprovementPolicy:
+    raw = Path(path).read_bytes(); doc = json.loads(raw.decode("utf-8")) if path.suffix == ".json" else __import__("yaml").safe_load(raw)
+    node = doc.get("auto_apply", doc)
+    root = resolve_repo_root(Path(node["repository_root"]))
+    gates = tuple(VerificationGate(str(g["id"]), tuple(g["argv"]), float(g.get("timeout_s", node.get("timeout_s", 10))), int(g.get("output_limit", node.get("output_limit", 20000))), dict(g.get("env", {}))) for g in node.get("verification_gates", []))
+    digest = _sha256(json.dumps(node, sort_keys=True, default=str).encode())
+    return ImprovementPolicy(str(node.get("schema_version", "auto-apply-policy/2")), bool(node.get("enabled", False)), root, tuple(node.get("permitted_objective_types", [])), tuple(node.get("permitted_path_globs", [])), tuple(node.get("denied_path_globs", [])), int(node.get("max_files", 1)), int(node.get("max_candidate_bytes", 50000)), int(node.get("max_changed_lines", 200)), bool(node.get("approval_required", True)), {str(k): tuple(v) for k, v in dict(node.get("permitted_generators", {})).items()}, gates, float(node.get("timeout_s", 10)), int(node.get("output_limit", 20000)), bool(node.get("audit_required", True)), bool(node.get("clean_changed_file_set", True)), bool(node.get("allow_hardlinks", False)), digest)
+
+class GovernedSelfImprovementTransaction:
+    def __init__(self, policy: Optional[ImprovementPolicy], audit_owner: Any, approval_store: Optional[ApprovalStore] = None, gate_runner: Any = None):
+        self.policy = policy; self.audit = audit_owner; self.approval_store = approval_store; self.gate_runner = gate_runner or self._run_gate; self._unresolved = False
+    def readiness(self) -> Tuple[bool, str]:
+        if self._unresolved: return False, "unresolved improvement transaction"
+        if os.environ.get(DISABLED_ENV, "1") != "0": return False, "disabled by default"
+        if not self.policy or not self.policy.enabled: return False, "policy disabled or missing"
+        if not self.audit: return False, "audit owner missing"
+        if not self.policy.verification_gates: return False, "verification gates missing"
+        return True, "ready"
+    def apply(self, proposal: ImprovementProposal, snapshot: InspectionSnapshot, actor: str = "offline-owner") -> TransactionResult:
+        pd = proposal.digest()
+        try:
+            ok, reason = self.readiness()
+            if not ok: raise TransactionError(reason)
+            policy = self.policy; assert policy is not None
+            repo = resolve_repo_root(policy.repo_root); target = resolve_target(repo, proposal.target_path)
+            self._validate(policy, proposal, snapshot, target)
+            self._audit("improvement.proposed", proposal, pd, actor, state="proposed")
+            approval = self._require_approval(policy, proposal, pd)
+            self._audit("improvement.approved", proposal, pd, actor, approver=approval.approver_identity, state="approved")
+            st = target.stat(); original = target.read_bytes(); original_digest = _sha256(original)
+            if original_digest != proposal.expected_original_sha256: raise TransactionError("stale original digest")
+            if not policy.allow_hardlinks and getattr(st, "st_nlink", 1) > 1: raise TransactionError("unexpected hardlink")
+            cand = proposal.candidate_content.encode("utf-8")
+            ast.parse(proposal.candidate_content)
+            self._audit("improvement.apply_prepared", proposal, pd, actor, state="applying")
+            self._unresolved = True
+            safe_mode = stat.S_IMODE(st.st_mode) & 0o777 & ~0o6000
+            _atomic_write(target, cand, safe_mode)
+            installed_digest = _sha256(target.read_bytes())
+            if installed_digest != proposal.candidate_sha256: raise TransactionError("install digest mismatch")
+            self._audit("improvement.candidate_installed", proposal, pd, actor, installed_digest=installed_digest)
+            gate_results = []
+            for gate in policy.verification_gates:
+                gr = self.gate_runner(gate, repo, policy)
+                gate_results.append(gr); self._audit("improvement.gate_completed", proposal, pd, actor, gate=gr)
+                if not gr.get("ok") or _sha256(target.read_bytes()) != proposal.candidate_sha256:
+                    raise GateFailure("gate failed or mutated candidate", gate_results)
+            self._unresolved = False
+            if self.approval_store and proposal.approval_id: self.approval_store.mark_used(proposal.approval_id)
+            self._audit("improvement.applied", proposal, pd, actor, result_digest=proposal.candidate_sha256)
+            return TransactionResult("applied_and_verified", "applied", pd, proposal.target_path, gate_results=gate_results)
+        except GateFailure as exc:
+            return self._rollback(proposal, pd, target, original, safe_mode, exc.gate_results, str(exc))
+        except Exception as exc:
+            try: self._audit("improvement.aborted", proposal, pd, actor, failure_category=str(exc)[:200], state="aborted")
+            except Exception: pass
+            return TransactionResult("rejected_before_installation", "rejected", pd, proposal.target_path, str(exc)[:200])
+    def _validate(self, policy: ImprovementPolicy, p: ImprovementProposal, snapshot: InspectionSnapshot, target: Path) -> None:
+        if p.schema_version != SCHEMA_VERSION: raise TransactionError("bad schema")
+        if p.objective_type not in policy.permitted_objectives: raise TransactionError("unknown objective")
+        rel = p.target_path
+        if rel not in snapshot.files or p.inspected_source_digest != snapshot.digest: raise TransactionError("target was not inspected")
+        if _denied(rel) or _glob_any(rel, policy.denied_path_globs) or not _glob_any(rel, policy.permitted_path_globs): raise TransactionError("protected or unpermitted path")
+        if not target.exists() or not target.is_file(): raise TransactionError("new file or directory rejected")
+        if p.expected_original_sha256 != snapshot.files[rel] or _sha256(p.original_content.encode()) != p.expected_original_sha256: raise TransactionError("missing or mismatched original")
+        cand = p.candidate_content.encode("utf-8")
+        if not cand or len(cand) > policy.max_candidate_bytes or _sha256(cand) != p.candidate_sha256: raise TransactionError("candidate digest/size invalid")
+        if p.candidate_content == p.original_content: raise TransactionError("identical candidate")
+        if "```" in p.candidate_content or "..." in p.candidate_content or "TODO" == p.candidate_content.strip(): raise TransactionError("unbounded model wrapper or placeholder")
+        ast.parse(p.candidate_content)
+        changed = sum(1 for l in difflib.unified_diff(p.original_content.splitlines(), p.candidate_content.splitlines(), lineterm="") if l.startswith(("+", "-")) and not l.startswith(("+++", "---")))
+        if policy.max_files != 1 or changed > policy.max_changed_lines: raise TransactionError("change bounds exceeded")
+        if p.generator_identity not in policy.permitted_generators or p.provider_release_digest not in policy.permitted_generators[p.generator_identity]: raise TransactionError("unknown provider/release")
+        if p.expected_policy_digest != policy.digest: raise TransactionError("policy digest mismatch")
+    def _require_approval(self, policy: ImprovementPolicy, p: ImprovementProposal, pd: str) -> ApprovalRecord:
+        if not policy.approval_required: return ApprovalRecord("not-required", pd, policy.digest, p.expected_original_sha256, "policy", time.time(), time.time()+1)
+        if not self.approval_store or not p.approval_id: raise TransactionError("approval required")
+        rec = self.approval_store.load(p.approval_id)
+        if rec.used or rec.state != "approved" or rec.expires_at < time.time() or rec.proposal_digest != pd or rec.policy_digest != policy.digest or rec.original_source_digest != p.expected_original_sha256:
+            raise TransactionError("approval binding invalid")
+        return rec
+    def _run_gate(self, gate: VerificationGate, repo: Path, policy: ImprovementPolicy) -> Dict[str, Any]:
+        if not gate.argv or gate.argv[0] == "git" and any(a in {"commit", "push"} for a in gate.argv): raise TransactionError("forbidden gate command")
+        start = time.time(); env = {"PATH": os.environ.get("PATH", ""), "PYTHONPATH": str(repo / "src")}; env.update(gate.env)
+        try:
+            proc = subprocess.run(list(gate.argv), cwd=repo, env=env, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=gate.timeout_s, shell=False, check=False)
+            out = (proc.stdout + proc.stderr)[:gate.output_limit]
+            return {"identity": gate.identity, "argv_digest": _sha256(json.dumps(list(gate.argv)).encode()), "exit_status": proc.returncode, "timeout": False, "output_digest": _sha256(out), "started_at": start, "ended_at": time.time(), "ok": proc.returncode == 0}
+        except subprocess.TimeoutExpired as exc:
+            return {"identity": gate.identity, "argv_digest": _sha256(json.dumps(list(gate.argv)).encode()), "exit_status": None, "timeout": True, "output_digest": "", "started_at": start, "ended_at": time.time(), "ok": False}
+    def _rollback(self, p: ImprovementProposal, pd: str, target: Path, original: bytes, mode: int, gate_results: List[Dict[str, Any]], why: str) -> TransactionResult:
+        try:
+            if _sha256(target.read_bytes()) != p.candidate_sha256:
+                self._audit("improvement.manual_recovery_required", p, pd, "system", failure_category="external mutation prevented rollback")
+                self._unresolved = False
+                return TransactionResult("external_mutation_prevented_rollback", "verification_failed", pd, p.target_path, why, gate_results)
+            _atomic_write(target, original, mode)
+            rd = _sha256(target.read_bytes())
+            if rd != p.expected_original_sha256: raise TransactionError("rollback digest mismatch")
+            self._audit("improvement.rollback_completed", p, pd, "system", rollback_digest=rd)
+            self._unresolved = False
+            return TransactionResult("verification_failed_rollback_succeeded", "verification_failed", pd, p.target_path, why, gate_results, rd)
+        except Exception as exc:
+            self._unresolved = False
+            try: self._audit("improvement.manual_recovery_required", p, pd, "system", failure_category=str(exc)[:200])
+            except Exception: pass
+            return TransactionResult("verification_failed_rollback_failed", "verification_failed", pd, p.target_path, str(exc)[:200], gate_results)
+    def _audit(self, event: str, p: ImprovementProposal, pd: str, actor: str, **meta: Any) -> None:
+        if not self.audit: raise TransactionError("audit owner unavailable")
+        payload = {"event": event, "proposal_digest": pd, "policy_digest": self.policy.digest if self.policy else "", "original_digest": p.expected_original_sha256, "candidate_digest": p.candidate_sha256, "target_path": p.target_path, "objective_type": p.objective_type, "actor": actor, "timestamp": time.time()}
+        payload.update(meta)
+        self.audit.record_event(event, payload)
+
+class GateFailure(Exception):
+    def __init__(self, msg: str, gate_results: List[Dict[str, Any]]):
+        super().__init__(msg); self.gate_results = gate_results
+
+def _atomic_write(path: Path, data: bytes, mode: int) -> None:
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    tmp_path = Path(tmp)
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data); f.flush(); os.fsync(f.fileno())
+        os.chmod(tmp_path, mode & 0o777 & ~0o6000)
+        os.replace(tmp_path, path)
+        try:
+            dfd = os.open(str(path.parent), os.O_DIRECTORY); os.fsync(dfd); os.close(dfd)
+        except Exception: pass
+    finally:
+        try:
+            if tmp_path.exists(): tmp_path.unlink()
+        except Exception: pass

--- a/src/vulcan/world_model/self_improvement_apply.py
+++ b/src/vulcan/world_model/self_improvement_apply.py
@@ -9,7 +9,6 @@ Phase 1 of WorldModel decomposition.
 import ast
 import difflib
 import logging
-import subprocess
 import time
 from typing import Any, Dict, Optional, Tuple
 
@@ -48,14 +47,13 @@ def _validate_code_ast(wm, content: str) -> None:
 def _apply_diff_and_commit(
     wm, file_path: str, original_code: str, updated_code: str, commit_message: str
 ) -> Tuple[str, bool]:
-    """
-    Apply diff and commit changes.
-    Returns tuple of (diff_summary, commit_succeeded).
-    """
-    full_path = wm.repo_root / file_path
+    """Deprecated compatibility entry point.
 
-    # 1. Generate Diff
-    diff_lines = list(
+    Phase 8 routes all source mutations through
+    GovernedSelfImprovementTransaction.  This legacy direct-write/Git path now
+    fails closed and never writes, commits, or executes plan-supplied behavior.
+    """
+    diff_summary = "\n".join(
         difflib.unified_diff(
             original_code.splitlines(),
             updated_code.splitlines(),
@@ -64,69 +62,10 @@ def _apply_diff_and_commit(
             lineterm="",
         )
     )
-    diff_summary = "\n".join(diff_lines)
-
-    # 2. Apply Change
-    full_path.parent.mkdir(parents=True, exist_ok=True)
-    with open(full_path, "w", encoding="utf-8") as f:
-        f.write(updated_code)
-
-    # 3. Git Commit
-    try:
-        from vulcan.settings import settings
-        auto_commit_enabled = settings.self_improvement_auto_commit
-    except (ImportError, AttributeError):
-        auto_commit_enabled = False
-
-    if not auto_commit_enabled:
-        logger.info("Self-improvement auto-commit disabled (set VULCAN_SELF_IMPROVEMENT_AUTO_COMMIT=true to enable)")
-        return diff_summary, False
-
-    if not (wm.repo_root / ".git").exists():
-        logger.warning(
-            f"Cannot commit: {wm.repo_root} is not a Git repository. Skipping commit."
-        )
-        return diff_summary, False
-
-    try:
-        subprocess.run(  # nosec B603 B607
-            ["git", "add", file_path],
-            cwd=wm.repo_root,
-            check=True,
-            capture_output=True,
-        )
-
-        commit_result = subprocess.run(  # nosec B603 B607
-            ["git", "commit", "-m", f"vulcan(auto): {commit_message}"],
-            cwd=wm.repo_root,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-
-        hash_result = subprocess.run(  # nosec B603 B607
-            ["git", "rev-parse", "--short", "HEAD"],
-            cwd=wm.repo_root,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
-
-        logger.info(f"Git Commit successful: {hash_result.stdout.strip()}")
-        return diff_summary, True
-
-    except subprocess.CalledProcessError as e:
-        if "nothing to commit" in e.stderr:
-            logger.info(
-                "Commit skipped: No functional changes detected by Git after writing."
-            )
-            return diff_summary, False
-        logger.error(f"Git commit failed for {file_path}: {e.stderr}")
-        raise RuntimeError(f"Git commit failed: {e.stderr}") from e
-    except Exception as e:
-        logger.error(f"Critical error during file application or Git: {e}")
-        raise
-
+    raise RuntimeError(
+        "legacy self-improvement application is disabled; use "
+        "GovernedSelfImprovementTransaction"
+    )
 
 def _execute_improvement(wm, improvement_action: Dict[str, Any]):
     """

--- a/tests/test_governed_self_improvement_transaction.py
+++ b/tests/test_governed_self_improvement_transaction.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import py_compile
+import stat
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+import importlib.util
+
+GT_PATH = Path(__file__).resolve().parents[1] / "src/vulcan/world_model/meta_reasoning/governed_transaction.py"
+spec = importlib.util.spec_from_file_location("governed_transaction", GT_PATH)
+gt = importlib.util.module_from_spec(spec)
+import sys
+sys.modules["governed_transaction"] = gt
+spec.loader.exec_module(gt)
+ApprovalRecord = gt.ApprovalRecord
+ApprovalStore = gt.ApprovalStore
+GovernedSelfImprovementTransaction = gt.GovernedSelfImprovementTransaction
+ImprovementPolicy = gt.ImprovementPolicy
+ImprovementProposal = gt.ImprovementProposal
+VerificationGate = gt.VerificationGate
+inspect_repository = gt.inspect_repository
+
+
+def sha(s: str) -> str:
+    return hashlib.sha256(s.encode()).hexdigest()
+
+
+class Audit:
+    def __init__(self, fail=False):
+        self.events = []
+        self.fail = fail
+    def record_event(self, event, payload):
+        if self.fail:
+            raise RuntimeError("audit down")
+        assert "secret" not in json.dumps(payload).lower()
+        assert "candidate_content" not in payload and "original_content" not in payload
+        self.events.append((event, payload))
+
+
+@pytest.fixture()
+def repo(tmp_path):
+    root = tmp_path / "repo"
+    (root / ".git").mkdir(parents=True)
+    (root / "src/pkg").mkdir(parents=True)
+    target = root / "src/pkg/mod.py"
+    target.write_text("VALUE = 1\n", encoding="utf-8")
+    return root
+
+
+def policy(repo, *, gates=None, approval=False, max_bytes=10000, max_lines=20):
+    return ImprovementPolicy(
+        schema_version="auto-apply-policy/2",
+        enabled=True,
+        repo_root=repo,
+        permitted_objectives=("bugfix",),
+        permitted_path_globs=("src/**/*.py",),
+        denied_path_globs=(".git/**", "configs/auto_apply_policy.yaml"),
+        max_files=1,
+        max_candidate_bytes=max_bytes,
+        max_changed_lines=max_lines,
+        approval_required=approval,
+        permitted_generators={"human": ("release-1",)},
+        verification_gates=tuple(gates if gates is not None else [VerificationGate("compile", ("python", "-m", "py_compile", "src/pkg/mod.py"), 5)]),
+        timeout_s=5,
+        output_limit=2000,
+        audit_required=True,
+        digest="policy-digest",
+    )
+
+
+def proposal(repo, pol, *, path="src/pkg/mod.py", original="VALUE = 1\n", candidate="VALUE = 2\n", approval_id=""):
+    snap = inspect_repository(repo, ("src/**/*.py",))
+    p = ImprovementProposal(
+        schema_version=gt.SCHEMA_VERSION,
+        proposal_id="p1",
+        objective_type="bugfix",
+        target_path=path,
+        expected_original_sha256=sha(original),
+        original_content=original,
+        candidate_content=candidate,
+        candidate_sha256=sha(candidate),
+        inspected_source_digest=snap.digest,
+        generator_identity="human",
+        provider_release_digest="release-1",
+        rationale="bounded metadata only",
+        expected_policy_digest=pol.digest,
+        approval_id=approval_id,
+    )
+    return p, snap
+
+
+def run_tx(repo, pol=None, audit=None, p=None, snap=None, store=None, runner=None):
+    os.environ[gt.DISABLED_ENV] = "0"
+    pol = pol or policy(repo)
+    if p is None:
+        p, snap = proposal(repo, pol)
+    return GovernedSelfImprovementTransaction(pol, audit if audit is not None else Audit(), store, runner).apply(p, snap)
+
+
+def test_disabled_missing_policy_and_audit_reject_before_mutation(repo, monkeypatch):
+    pol = policy(repo); p, snap = proposal(repo, pol)
+    monkeypatch.setenv(gt.DISABLED_ENV, "1")
+    r = GovernedSelfImprovementTransaction(pol, Audit()).apply(p, snap)
+    assert r.status == "rejected_before_installation"
+    monkeypatch.setenv(gt.DISABLED_ENV, "0")
+    assert GovernedSelfImprovementTransaction(None, Audit()).apply(p, snap).status == "rejected_before_installation"
+    assert GovernedSelfImprovementTransaction(pol, None).apply(p, snap).status == "rejected_before_installation"
+    assert (repo / "src/pkg/mod.py").read_text() == "VALUE = 1\n"
+
+
+@pytest.mark.parametrize("bad_path", ["/x.py", "../x.py", "src//x.py", "src\\x.py", "src/pkg/t.txt"])
+def test_path_traversal_absolute_ambiguity_non_python_rejected(repo, bad_path):
+    pol = policy(repo); p, snap = proposal(repo, pol, path=bad_path)
+    r = run_tx(repo, pol, p=p, snap=snap)
+    assert r.status == "rejected_before_installation"
+
+
+def test_root_component_symlink_new_file_and_protected_paths_rejected(repo, tmp_path):
+    linkroot = tmp_path / "linkroot"; linkroot.symlink_to(repo)
+    with pytest.raises(gt.TransactionError): gt.resolve_repo_root(linkroot)
+    (repo / "src/link").symlink_to(repo / "src/pkg")
+    pol = policy(repo); p, snap = proposal(repo, pol, path="src/link/mod.py")
+    assert run_tx(repo, pol, p=p, snap=snap).status == "rejected_before_installation"
+    p2, snap2 = proposal(repo, pol, path="src/pkg/new.py")
+    assert run_tx(repo, pol, p=p2, snap=snap2).status == "rejected_before_installation"
+    (repo / "configs").mkdir(); (repo / "configs/auto_apply_policy.yaml").write_text("x=1\n")
+    p3, snap3 = proposal(repo, pol, path="configs/auto_apply_policy.yaml")
+    assert run_tx(repo, pol, p=p3, snap=snap3).status == "rejected_before_installation"
+
+
+@pytest.mark.parametrize("mut", ["stale", "digest", "noop", "syntax", "oversize", "loc", "objective", "provider", "release", "policy_digest", "uninspected"])
+def test_proposal_policy_bounds_rejections(repo, mut):
+    pol = policy(repo, max_bytes=5 if mut == "oversize" else 10000, max_lines=0 if mut == "loc" else 20)
+    p, snap = proposal(repo, pol, candidate="VALUE = 2\n")
+    if mut == "stale": (repo / "src/pkg/mod.py").write_text("VALUE = 3\n")
+    if mut == "digest": p = ImprovementProposal(**{**p.__dict__, "candidate_sha256": "0" * 64})
+    if mut == "noop": p = ImprovementProposal(**{**p.__dict__, "candidate_content": p.original_content, "candidate_sha256": p.expected_original_sha256})
+    if mut == "syntax": p = ImprovementProposal(**{**p.__dict__, "candidate_content": "def bad(:\n", "candidate_sha256": sha("def bad(:\n")})
+    if mut == "objective": p = ImprovementProposal(**{**p.__dict__, "objective_type": "deploy"})
+    if mut == "provider": p = ImprovementProposal(**{**p.__dict__, "generator_identity": "llm"})
+    if mut == "release": p = ImprovementProposal(**{**p.__dict__, "provider_release_digest": "evil"})
+    if mut == "policy_digest": p = ImprovementProposal(**{**p.__dict__, "expected_policy_digest": "old"})
+    if mut == "uninspected": p = ImprovementProposal(**{**p.__dict__, "target_path": "src/pkg/other.py"})
+    r = run_tx(repo, pol, p=p, snap=snap)
+    assert r.status == "rejected_before_installation"
+
+
+def test_duplicate_unknown_json_and_plan_callable_not_executed(repo):
+    text = '{"schema_version":"x","schema_version":"y"}'
+    with pytest.raises(gt.TransactionError): ImprovementProposal.from_json(text)
+    pol = policy(repo); p, snap = proposal(repo, pol)
+    with pytest.raises(gt.TransactionError): ImprovementProposal.from_mapping({**p.__dict__, "apply": lambda: (_ for _ in ()).throw(AssertionError())})
+    assert run_tx(repo, pol, p=p, snap=snap).status == "applied_and_verified"
+
+
+def test_approval_lifecycle_binds_expires_reuse_and_resumes(repo, tmp_path):
+    pol = policy(repo, approval=True); p, snap = proposal(repo, pol, approval_id="a1")
+    store_path = tmp_path / "approvals.json"
+    rec = ApprovalRecord("a1", p.digest(), pol.digest, p.expected_original_sha256, "alice", time.time(), time.time()+60)
+    store_path.write_text(json.dumps({"a1": rec.__dict__}), encoding="utf-8")
+    assert run_tx(repo, pol, p=p, snap=snap, store=ApprovalStore(store_path)).status == "applied_and_verified"
+    (repo / "src/pkg/mod.py").write_text("VALUE = 1\n")
+    assert run_tx(repo, pol, p=p, snap=snap, store=ApprovalStore(store_path)).status == "rejected_before_installation"
+    rec2 = ApprovalRecord("a2", "bad", pol.digest, p.expected_original_sha256, "alice", time.time(), time.time()+60)
+    store_path.write_text(json.dumps({"a2": rec2.__dict__}), encoding="utf-8")
+    p2 = ImprovementProposal(**{**p.__dict__, "approval_id": "a2"})
+    assert run_tx(repo, pol, p=p2, snap=snap, store=ApprovalStore(store_path)).status == "rejected_before_installation"
+    rec3 = ApprovalRecord("a3", p.digest(), pol.digest, p.expected_original_sha256, "alice", time.time()-100, time.time()-1)
+    store_path.write_text(json.dumps({"a3": rec3.__dict__}), encoding="utf-8")
+    p3 = ImprovementProposal(**{**p.__dict__, "approval_id": "a3"})
+    assert run_tx(repo, pol, p=p3, snap=snap, store=ApprovalStore(store_path)).status == "rejected_before_installation"
+
+
+def test_gate_shell_false_metacharacters_candidate_installed_success_and_compile(repo):
+    seen = {}
+    def runner(gate, root, pol):
+        seen["argv"] = gate.argv; seen["content"] = (root / "src/pkg/mod.py").read_text(); seen["shell"] = False
+        return {"identity": gate.identity, "ok": True, "exit_status": 0, "timeout": False, "argv_digest": sha(json.dumps(gate.argv)), "output_digest": sha("")}
+    pol = policy(repo, gates=[VerificationGate("inert", ("python", "-c", "print('a|b;$(x)')"), 5)])
+    r = run_tx(repo, pol, runner=runner)
+    assert r.status == "applied_and_verified" and seen["content"] == "VALUE = 2\n" and seen["shell"] is False
+    py_compile.compile(str(repo / "src/pkg/mod.py"), doraise=True)
+
+
+def test_failed_gate_timeout_and_gate_mutation_restore_original(repo):
+    pol = policy(repo, gates=[VerificationGate("fail", ("python", "-c", "raise SystemExit(7)"), 5)])
+    assert run_tx(repo, pol).status == "verification_failed_rollback_succeeded"
+    assert (repo / "src/pkg/mod.py").read_text() == "VALUE = 1\n"
+    pol2 = policy(repo, gates=[VerificationGate("timeout", ("python", "-c", "import time; time.sleep(2)"), 0.1)])
+    assert run_tx(repo, pol2).status == "verification_failed_rollback_succeeded"
+    def mutate(gate, root, pol):
+        (root / "src/pkg/mod.py").write_text("VALUE = 99\n")
+        return {"identity": gate.identity, "ok": True, "exit_status": 0, "timeout": False}
+    assert run_tx(repo, policy(repo), runner=mutate).status == "external_mutation_prevented_rollback"
+    assert (repo / "src/pkg/mod.py").read_text() == "VALUE = 99\n"
+
+
+def test_rollback_failure_manual_recovery_and_mode_safe(repo, monkeypatch):
+    os.chmod(repo / "src/pkg/mod.py", 0o6755)
+    pol = policy(repo)
+    calls = {"n": 0}; real = gt._atomic_write
+    def flaky(path, data, mode):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise OSError("disk")
+        return real(path, data, mode)
+    monkeypatch.setattr(gt, "_atomic_write", flaky)
+    r = run_tx(repo, pol, runner=lambda g, r, p: {"identity": "fail", "ok": False})
+    assert r.status == "verification_failed_rollback_failed"
+    monkeypatch.setattr(gt, "_atomic_write", real)
+    (repo / "src/pkg/mod.py").write_text("VALUE = 1\n")
+    r2 = run_tx(repo, pol)
+    assert r2.status == "applied_and_verified"
+    assert stat.S_IMODE((repo / "src/pkg/mod.py").stat().st_mode) & 0o6000 == 0
+
+
+def test_audit_unavailable_before_install_no_mutation_and_readiness_unresolved(repo):
+    pol = policy(repo); p, snap = proposal(repo, pol)
+    r = GovernedSelfImprovementTransaction(pol, Audit(fail=True)).apply(p, snap)
+    assert r.status == "rejected_before_installation"
+    assert (repo / "src/pkg/mod.py").read_text() == "VALUE = 1\n"
+    tx = GovernedSelfImprovementTransaction(pol, Audit()); os.environ[gt.DISABLED_ENV] = "0"; tx._unresolved = True
+    assert tx.readiness()[0] is False
+
+
+def test_legacy_direct_write_and_static_reachability_fail_closed(repo):
+    app_path = Path(__file__).resolve().parents[1] / "src/vulcan/world_model/self_improvement_apply.py"
+    assert "legacy self-improvement application is disabled" in app_path.read_text()
+    app = app_path.read_text()
+    tree = __import__("ast").parse(app)
+    calls = [n for n in __import__("ast").walk(tree) if isinstance(n, __import__("ast").Call)]
+    forbidden = []
+    for c in calls:
+        f = c.func
+        if isinstance(f, __import__("ast").Subscript): forbidden.append("subscript-call")
+        if isinstance(f, __import__("ast").Attribute) and f.attr in {"commit", "push"}: forbidden.append(f.attr)
+    assert forbidden == []
+    governed = (Path(__file__).resolve().parents[1] / "src/vulcan/world_model/meta_reasoning/governed_transaction.py").read_text()
+    assert "shell=False" in governed
+    gtree = __import__("ast").parse(governed)
+    for node in __import__("ast").walk(gtree):
+        if isinstance(node, __import__("ast").Call) and isinstance(node.func, __import__("ast").Attribute):
+            assert node.func.attr not in {"commit", "push"}
+        if isinstance(node, __import__("ast").Call) and isinstance(node.func, __import__("ast").Subscript):
+            raise AssertionError("plan-supplied callable call is reachable")
+
+
+def test_success_leaves_git_worktree_uncommitted(repo):
+    subprocess.run(["git", "init"], cwd=repo, check=True, stdout=subprocess.PIPE)
+    subprocess.run(["git", "config", "user.email", "a@b.c"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "a"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo, check=True, stdout=subprocess.PIPE)
+    assert run_tx(repo).status == "applied_and_verified"
+    status = subprocess.run(["git", "status", "--short"], cwd=repo, text=True, stdout=subprocess.PIPE, check=True).stdout
+    assert "src/pkg/mod.py" in status


### PR DESCRIPTION
### Motivation

- Consolidate and harden all source-mutation paths behind a single governed transaction that enforces policy, approval, audit, CAS installation, verification gates, and byte-identical rollback. 
- Fail-closed legacy direct-write/auto-commit behavior so no hidden path can write/commit/push or execute plan-supplied callables. 
- Default to deny and minimize the auto-apply surface by disabling auto-apply and narrowing default file budgets and allowlists. 

### Description

- Add a dependency-light transaction module `meta_reasoning/governed_transaction.py` implementing a typed `vulcan-improvement-proposal/1` schema, duplicate-key detection, proposal/policy/inspected-source binding, repository-root and path symlink/ traversal rejection, UTF-8-only inspection snapshot, candidate AST validation, deterministic change-size bounds, approval binding, and audit event emission. 
- Implement atomic CAS installation with exclusive temporary file creation, flush/fsync, safe permission handling, `os.replace`, directory fsync when available, installed-digest recording, and strict rollback semantics that restore the original only when the installed candidate digest still matches. 
- Add shell-free verification gates executed as bounded argv arrays with timeouts, captured output limits, per-gate recording, gate mutation detection, and forbidden gate commands (no `commit`/`push`); gate failures trigger rollback and detailed result states. 
- Fail-closed legacy compatibility: replace the old `_apply_diff_and_commit` helper so it no longer writes, stages, or commits changes and instead raises a clear runtime error directing callers to the governed transaction. 
- Harden defaults and configuration by disabling auto-apply in `configs/auto_apply_policy.yaml`, reducing the default file budget to one, and narrowing the default allowlist. 
- Add focused regression/unit tests `tests/test_governed_self_improvement_transaction.py` that exercise disabled-by-default behavior, path/policy/approval/proposal validations, shell=False gates, changed-tree verification, rollback/manual-recovery outcomes, static reachability checks for forbidden Git publish and plan-callable execution, and that successful application leaves the worktree uncommitted. 

### Testing

- Ran focused unit tests `tests/test_governed_self_improvement_transaction.py` and all included cases passed (26 tests passed). 
- Verified module compilation with normal and optimized byte-compilation (`py_compile` and `compileall`) for the new transaction and related modules; compilation succeeded. 
- Executed dependency-light static and runtime checks embedded in the tests (gate argv/shell checks, AST-based search for forbidden commit/push/plan-callable calls, and repository integrity checks); those checks passed. 
- Repository-level verification (whitespace/diff checks and other local integrity assertions exercised by the test harness) completed with no reported errors. 
- Note: running the broader existing self-improvement test file set in `src/vulcan/tests` could not be completed in this environment because those tests import unavailable optional native dependencies (for example `numpy`), so those integration tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b6b95b020832f94ef73706abf4da2)