### PR TITLE
Make CSIU governed improvement path executable

### DIFF
--- a/src/vulcan/world_model/meta_reasoning/csiu_enforcement.py
+++ b/src/vulcan/world_model/meta_reasoning/csiu_enforcement.py
@@ -135,9 +135,11 @@ class CSIUDecision:
 
 @dataclass(frozen=True)
 class CSIUInfluenceRecord:
-    decision_id: str; policy_digest: str; plan_digest: str; reserved_influence: float; actual_influence: float; applied: bool; state: str; enforcer_id: str; timestamp: str=field(default_factory=lambda:_ts(_now())); schema_version: str=SCHEMA_RECORD; previous_record_digest: str="0"*64; record_id: str=""; record_digest: str=""
+    decision_id: str; policy_digest: str; plan_digest: str; reserved_influence: float; actual_influence: float; applied: bool; state: str; enforcer_id: str; charged_influence: float=0.0; timestamp: str=field(default_factory=lambda:_ts(_now())); schema_version: str=SCHEMA_RECORD; previous_record_digest: str="0"*64; record_id: str=""; record_digest: str=""
     def __post_init__(self):
-        _num(self.reserved_influence,"reserved_influence"); _num(self.actual_influence,"actual_influence"); _parse_ts(self.timestamp)
+        _num(self.reserved_influence,"reserved_influence"); _num(self.actual_influence,"actual_influence"); _num(self.charged_influence,"charged_influence"); _parse_ts(self.timestamp)
+        if self.charged_influence == 0.0:
+            object.__setattr__(self,"charged_influence",max(abs(self.reserved_influence),abs(self.actual_influence)))
         if self.state not in {"prepared","committed","aborted","blocked"}: raise CSIUValidationError("bad state")
         if not isinstance(self.enforcer_id,str) or not self.enforcer_id: raise CSIUValidationError("missing enforcer id")
         if not isinstance(self.previous_record_digest,str) or not re_full_hash(self.previous_record_digest): raise CSIUValidationError("bad previous digest")
@@ -149,7 +151,7 @@ class CSIUInfluenceRecord:
     @property
     def actual_effect(self): return self.actual_influence
     def to_dict(self, include_digest=True):
-        d={"schema_version":self.schema_version,"enforcer_id":self.enforcer_id,"decision_id":self.decision_id,"policy_digest":self.policy_digest,"plan_digest":self.plan_digest,"timestamp":self.timestamp,"reserved_influence":self.reserved_influence,"actual_influence":self.actual_influence,"applied":self.applied,"state":self.state,"previous_record_digest":self.previous_record_digest,"record_id":self.record_id}
+        d={"schema_version":self.schema_version,"enforcer_id":self.enforcer_id,"decision_id":self.decision_id,"policy_digest":self.policy_digest,"plan_digest":self.plan_digest,"timestamp":self.timestamp,"reserved_influence":self.reserved_influence,"actual_influence":self.actual_influence,"charged_influence":self.charged_influence,"applied":self.applied,"state":self.state,"previous_record_digest":self.previous_record_digest,"record_id":self.record_id}
         if include_digest: d["record_digest"]=self.record_digest
         return dict(sorted(d.items()))
 
@@ -182,7 +184,7 @@ class CSIUEnforcement(SerializationMixin):
     _unpickleable_attrs=["_lock","_clock"]
     def __init__(self, config: Optional[CSIUEnforcementConfig]=None, policy: Optional[CSIUPolicy]=None):
         self.config=config or CSIUEnforcementConfig(); self.policy=policy or CSIUPolicy(max_single_influence=self.config.max_single_influence,max_cumulative_influence_window=self.config.max_cumulative_influence_window,cumulative_window_seconds=self.config.cumulative_window_seconds)
-        self._lock=threading.RLock(); self._clock=self.config.clock or _now; self.enforcer_id=f"csiu:{self.policy.policy_id}:{self.policy.policy_digest}"; self._durable_ready=False; self._durable_prev="0"*64; self._durable_fd=None; self._influence_history=[]; self._audit_trail=[]; self._last_decision=None; self._last_snapshot=None; self._total_applications=0; self._total_blocked=0; self._total_capped=0; self._max_influence_seen=0.0; self._load_durable()
+        self._lock=threading.RLock(); self._clock=self.config.clock or _now; self.enforcer_id=f"csiu:{self.policy.policy_id}:{self.policy.policy_digest}"; self._durable_ready=False; self._durable_prev="0"*64; self._durable_fd=None; self._influence_history=[]; self._audit_trail=[]; self._last_decision=None; self._last_snapshot=None; self._closed=False; self._seen_snapshot_digests=set(); self._total_applications=0; self._total_blocked=0; self._total_capped=0; self._max_influence_seen=0.0; self._load_durable()
     def _restore_unpickleable_attrs(self): self._lock=threading.RLock(); self._clock=_now
     def _emit(self,event, data):
         rec={"event":event,"timestamp":_ts(self._clock()),"data":_clean(data)}
@@ -215,7 +217,7 @@ class CSIUEnforcement(SerializationMixin):
         prev="0"*64; seen=set(); retained=[]; cutoff=self._clock()-timedelta(seconds=self.config.cumulative_window_seconds)
         for line in raw.splitlines():
             d=self._load_json_line(line)
-            allowed={"schema_version","enforcer_id","decision_id","policy_digest","plan_digest","timestamp","reserved_influence","actual_influence","applied","state","previous_record_digest","record_id","record_digest"}
+            allowed={"schema_version","enforcer_id","decision_id","policy_digest","plan_digest","timestamp","reserved_influence","actual_influence","charged_influence","applied","state","previous_record_digest","record_id","record_digest"}
             if set(d)!=allowed: raise CSIUValidationError("unknown durable fields")
             r=CSIUInfluenceRecord(**d)
             if r.record_id in seen: raise CSIUValidationError("duplicate durable record")
@@ -227,12 +229,14 @@ class CSIUEnforcement(SerializationMixin):
             prev=r.record_digest
         self._influence_history=retained; self._durable_prev=prev; self._durable_ready=True
     def readiness(self):
+        if self._closed: raise CSIUValidationError("csiu enforcer closed")
         if self.config.durable_accounting_required and not self._durable_ready: raise CSIUValidationError("durable accounting unavailable")
         return True
     def close(self):
         if self._durable_fd is not None:
             try: fcntl.flock(self._durable_fd, fcntl.LOCK_UN); os.close(self._durable_fd)
             finally: self._durable_fd=None
+        self._durable_ready=False; self._closed=True
     def _persist(self,r):
         p=self.config.durable_store_path
         if p:
@@ -244,11 +248,19 @@ class CSIUEnforcement(SerializationMixin):
             self._durable_prev=r.record_digest
     def is_enabled(self): return self.config.global_enabled and not self.config.emergency_stop
     def validate_snapshot(self, snapshot: CSIUMetricSnapshot)->Tuple[bool,str]:
+        if self._closed: return False,"enforcer_closed"
         if snapshot.policy_digest!=self.policy.policy_digest: return False,"policy_digest_mismatch"
         if snapshot.metric_definition_version!=self.policy.metric_definition_version: return False,"metric_definition_mismatch"
         if snapshot.sample_count<self.policy.min_sample_count: return False,"insufficient_sample_count"
-        age=(self._clock()-_parse_ts(snapshot.window_end)).total_seconds()
+        ws=_parse_ts(snapshot.window_start); we=_parse_ts(snapshot.window_end)
+        age=(self._clock()-we).total_seconds()
         if age<0 or age>self.policy.max_snapshot_age_seconds: return False,"stale_snapshot"
+        if self._last_snapshot is not None:
+            last_end=_parse_ts(self._last_snapshot.window_end)
+            if ws < last_end: return False,"overlapping_or_reordered_window"
+            if snapshot.provider_id!=self._last_snapshot.provider_id or snapshot.provenance_digest==self._last_snapshot.provenance_digest or snapshot.privacy_cohort!=self._last_snapshot.privacy_cohort:
+                return False,"provider_or_provenance_incompatible"
+        if snapshot.snapshot_digest in self._seen_snapshot_digests: return False,"replayed_snapshot"
         return True,"ok"
     def compute_utility(self, prev: CSIUMetricSnapshot, cur: CSIUMetricSnapshot)->float:
         total=sum(abs(self.policy.weights[k]) for k in METRIC_ORDER)
@@ -264,7 +276,7 @@ class CSIUEnforcement(SerializationMixin):
         return max(-self.config.max_single_influence,min(self.config.max_single_influence,p))
     def check_cumulative_influence(self):
         with self._lock:
-            self._prune_locked(); cum=sum(abs(r.actual_influence) for r in self._influence_history if r.state=="committed")
+            self._prune_locked(); cum=sum(abs(r.charged_influence) for r in self._influence_history if r.state=="committed")
             return {"cumulative_influence":cum,"count":len(self._influence_history),"window_seconds":self.config.cumulative_window_seconds,"max_allowed":self.config.max_cumulative_influence_window,"remaining":max(0.0,self.config.max_cumulative_influence_window-cum),"exceeds_cap":cum>self.config.max_cumulative_influence_window}
     def _prune_locked(self):
         cutoff=self._clock()-timedelta(seconds=self.config.cumulative_window_seconds)
@@ -276,32 +288,82 @@ class CSIUEnforcement(SerializationMixin):
     def _reserve_locked(self, decision: CSIUDecision)->Tuple[bool,str]:
         self._prune_locked()
         if len(self._influence_history)>=self.config.history_capacity: return False,"history_capacity_exhausted"
-        cur=sum(abs(r.actual_influence) for r in self._influence_history if r.state=="committed")
+        cur=sum(abs(r.charged_influence) for r in self._influence_history if r.state=="committed")
         need=max(abs(decision.actual_effect),abs(decision.pressure))
         if need>self.config.max_single_influence+1e-12: return False,"single_cap_exceeded"
         if cur+need>self.config.max_cumulative_influence_window+1e-12: return False,"cumulative_cap_exceeded"
         return True,"ok"
     def apply_regularization_with_enforcement(self, plan: Dict[str,Any], pressure: float, metrics: Mapping[str,float], plan_id="unknown", action_type="improvement", snapshot: Optional[CSIUMetricSnapshot]=None)->Tuple[Dict[str,Any],CSIUDecision]:
-        original=copy.deepcopy(plan or {}); pd=canonical_digest({"plan":original})
+        if self._closed: return copy.deepcopy(plan or {}), self._decision(canonical_digest({"plan":copy.deepcopy(plan or {})}),"enforcer_closed",0,0,0,True,False,snapshot)
+        original=copy.deepcopy(plan or {}); input_digest=canonical_digest({"plan":plan or {}}); pd=canonical_digest({"plan":original})
         if not self.is_enabled() or not self.config.regularization_enabled:
             return original,self._decision(pd,"disabled",0,0,0,True,False,snapshot)
         try: pressure=self.enforce_pressure_cap(pressure)
         except Exception: return original,self._decision(pd,"invalid_pressure",0,0,0,True,False,snapshot)
         if pressure==0: return original,self._decision(pd,"zero_pressure",0,0,0,True,False,snapshot)
+        if input_digest != pd: return original,self._decision(pd,"original_mutated_before_regularization",0,0,0,True,False,snapshot)
         proposed=copy.deepcopy(original); effect=0.0
         ow=proposed.get("objective_weights")
         if isinstance(ow,dict):
-            proposed["objective_weights"]={str(k):_num(v)*(1.0-0.03*pressure) for k,v in ow.items() if not isinstance(v,bool)}; effect=max(effect,abs(0.03*pressure))
+            if any(isinstance(v,bool) for v in ow.values()): return original,self._decision(pd,"invalid_objective_weight",0,0,0,True,False,snapshot)
+            proposed["objective_weights"]={str(k):_num(v)*(1.0-0.03*pressure) for k,v in ow.items()}; effect=max(effect,abs(0.03*pressure))
+            if set(proposed["objective_weights"]) != set(ow): return original,self._decision(pd,"objective_weight_removed",0,0,0,True,False,snapshot)
         proposed.setdefault("csiu_regularization",{})["route_penalty"]={"kind":"entropy","value":0.03*pressure}; effect=max(effect,abs(0.03*pressure))
         proposed.setdefault("csiu_regularization",{})["explainability_preference"]={"value":0.02*pressure}; effect=max(effect,abs(0.02*pressure))
-        effect=abs(pressure)
+        effect=self._measure_plan_effect(original, proposed)
+        if effect>self.config.max_single_influence+1e-12: return original,self._decision(pd,"single_effect_exceeded",0,0,pressure,True,False,snapshot,effect)
+        if not self._diff_allowed(original, proposed): return original,self._decision(pd,"closed_path_violation",0,0,pressure,True,False,snapshot,effect)
         dec=self._decision(pd,"applied",0,0,pressure,False,True,snapshot,effect)
         with self._lock:
             ok,reason=self._reserve_locked(dec)
             if not ok:
                 self._total_blocked+=1; b=CSIUDecision(dec.decision_id,self.policy.policy_digest,pd,reason,dec.utility,dec.ewma_utility,0.0,0.0,False,True,dec.snapshot_id,dec.snapshot_digest); self._emit("csiu.influence_blocked",b.to_dict()); return original,b
-            r=CSIUInfluenceRecord(dec.decision_id,self.policy.policy_digest,pd,pressure,max(abs(effect),abs(pressure)),True,"committed",self.enforcer_id,timestamp=_ts(self._clock()), previous_record_digest=self._durable_prev); self._persist(r); self._influence_history.append(r); self._total_applications+=1; self._last_decision=dec; self._emit("csiu.influence_applied",{"decision":dec.to_dict(),"record":r.to_dict(),"budget":self.check_cumulative_influence()})
+            r=CSIUInfluenceRecord(dec.decision_id,self.policy.policy_digest,pd,pressure,effect,True,"committed",self.enforcer_id,charged_influence=max(abs(effect),abs(pressure)),timestamp=_ts(self._clock()), previous_record_digest=self._durable_prev); self._persist(r); self._influence_history.append(r); self._total_applications+=1; self._last_decision=dec; self._emit("csiu.influence_applied",{"decision":dec.to_dict(),"record":r.to_dict(),"budget":self.check_cumulative_influence()})
+        if snapshot is not None:
+            self._last_snapshot=snapshot; self._seen_snapshot_digests.add(snapshot.snapshot_digest)
         return proposed,dec
+    def apply_regularization_from_snapshots(self, plan: Dict[str,Any], previous: Optional[CSIUMetricSnapshot], current: Optional[CSIUMetricSnapshot], plan_id="unknown", action_type="improvement"):
+        original=copy.deepcopy(plan or {})
+        if previous is None or current is None:
+            if current is not None:
+                ok,reason=self.validate_snapshot(current)
+                if ok:
+                    self._last_snapshot=current; self._seen_snapshot_digests.add(current.snapshot_digest)
+                    reason="baseline_established"
+                return original,self._decision(canonical_digest({"plan":original}),reason,0,0,0,True,False,current)
+            return original,self._decision(canonical_digest({"plan":original}),"missing_snapshot",0,0,0,True,False,current)
+        for snap in (previous,current):
+            ok,reason=self.validate_snapshot(snap)
+            if not ok: return original,self._decision(canonical_digest({"plan":original}),reason,0,0,0,True,False,current)
+        if _parse_ts(previous.window_end)>_parse_ts(current.window_start): return original,self._decision(canonical_digest({"plan":original}),"overlapping_or_reordered_window",0,0,0,True,False,current)
+        if previous.provider_id!=current.provider_id or previous.privacy_cohort!=current.privacy_cohort: return original,self._decision(canonical_digest({"plan":original}),"provider_or_provenance_incompatible",0,0,0,True,False,current)
+        u=self.compute_utility(previous,current); ew=self.policy.ewma_alpha*u + (1-self.policy.ewma_alpha)*0.0; pressure=self.pressure_from_utility(ew)
+        proposed,dec=self.apply_regularization_with_enforcement(original, pressure, current.metrics, plan_id, action_type, current)
+        dec=replace(dec, utility=u, ewma_utility=ew)
+        self._last_decision=dec
+        return proposed,dec
+    def _measure_plan_effect(self, before, after):
+        vals=[]
+        ow1=before.get("objective_weights") if isinstance(before,dict) else None; ow2=after.get("objective_weights") if isinstance(after,dict) else None
+        if isinstance(ow1,dict) and isinstance(ow2,dict):
+            for k,v in ow1.items():
+                if k not in ow2: raise CSIUValidationError("objective weight removed")
+                vals.append(abs(_num(ow2[k])- _num(v))/max(1.0,abs(_num(v))))
+        reg=after.get("csiu_regularization",{}) if isinstance(after,dict) else {}
+        if isinstance(reg,dict):
+            for entry in reg.values():
+                if isinstance(entry,dict) and "value" in entry: vals.append(abs(_num(entry["value"])))
+        return max(vals or [0.0])
+    def _diff_allowed(self,before,after):
+        allowed={('objective_weights',),('csiu_regularization',)}
+        return all((path[:1] in allowed) for path in self._changed_paths(before,after))
+    def _changed_paths(self,a,b,p=()):
+        if type(a)!=type(b): return [p]
+        if isinstance(a,dict):
+            out=[]
+            for k in set(a)|set(b): out += self._changed_paths(a.get(k), b.get(k), p+(k,))
+            return out
+        return [] if a==b else [p]
     def _decision(self,pd,reason,u,ew,p,blocked,applied,snapshot=None,effect=0.0):
         body={"policy_digest":self.policy.policy_digest,"plan_digest":pd,"reason":reason,"snapshot":getattr(snapshot,"snapshot_digest","")}; did=_id("csiu-decision",body)
         return CSIUDecision(did,self.policy.policy_digest,pd,reason,u,ew,p,effect,applied,blocked,getattr(snapshot,"snapshot_id",''),getattr(snapshot,"snapshot_digest",''))
@@ -353,4 +415,5 @@ def reset_csiu_enforcer(test_only: bool=True):
     global _csiu_enforcer
     with _enforcer_lock:
         if _csiu_enforcer and not test_only and _csiu_enforcer._influence_history: raise CSIUValidationError("cannot reset live CSIU singleton")
+        if _csiu_enforcer: _csiu_enforcer.close()
         _csiu_enforcer=None

--- a/src/vulcan/world_model/meta_reasoning/governed_transaction.py
+++ b/src/vulcan/world_model/meta_reasoning/governed_transaction.py
@@ -16,6 +16,7 @@ import subprocess
 import tempfile
 import time
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
@@ -34,6 +35,22 @@ _DENY_PREFIXES = (
 )
 _DENY_NAMES = {".env", "auto_apply_policy.yaml"}
 _TERMINAL = {"applied", "rejected", "aborted", "verification_failed"}
+
+class TransactionStatus(str, Enum):
+    APPLIED_AND_VERIFIED = "applied_and_verified"
+    REJECTED_BEFORE_INSTALLATION = "rejected_before_installation"
+    VERIFICATION_FAILED_ROLLBACK_SUCCEEDED = "verification_failed_rollback_succeeded"
+    VERIFICATION_FAILED_ROLLBACK_FAILED = "verification_failed_rollback_failed"
+    EXTERNAL_MUTATION_PREVENTED_ROLLBACK = "external_mutation_prevented_rollback"
+
+    @property
+    def verified_success(self) -> bool:
+        return self is TransactionStatus.APPLIED_AND_VERIFIED
+
+    @property
+    def rollback_succeeded(self) -> bool:
+        return self is TransactionStatus.VERIFICATION_FAILED_ROLLBACK_SUCCEEDED
+
 
 class TransactionError(Exception):
     """Fail-closed transaction validation/application error."""
@@ -137,13 +154,25 @@ class ApprovalRecord:
 
 @dataclass
 class TransactionResult:
-    status: str
+    status: TransactionStatus | str
     state: str
     proposal_digest: str = ""
     target_path: str = ""
     failure_category: str = ""
     gate_results: List[Dict[str, Any]] = field(default_factory=list)
     rollback_digest: str = ""
+
+    def __post_init__(self) -> None:
+        if isinstance(self.status, str):
+            self.status = TransactionStatus(self.status)
+
+    @property
+    def verified_success(self) -> bool:
+        return self.status.verified_success
+
+    @property
+    def status_code(self) -> str:
+        return self.status.value
 
 class ApprovalStore:
     def __init__(self, path: Path):
@@ -157,6 +186,15 @@ class ApprovalStore:
         if not isinstance(rec, dict):
             raise TransactionError("approval not found")
         return ApprovalRecord(**rec)
+    def save(self, record: ApprovalRecord) -> None:
+        try:
+            doc = json.loads(self.path.read_text(encoding="utf-8")) if self.path.exists() else {}
+        except Exception as exc:
+            raise TransactionError("approval store unavailable or corrupt") from exc
+        if record.approval_id in doc:
+            raise TransactionError("approval already exists")
+        doc[record.approval_id] = record.__dict__.copy()
+        _atomic_write(self.path, json.dumps(doc, sort_keys=True).encode(), 0o600)
     def mark_used(self, approval_id: str) -> None:
         doc = json.loads(self.path.read_text(encoding="utf-8"))
         doc[approval_id]["used"] = True
@@ -278,13 +316,13 @@ class GovernedSelfImprovementTransaction:
             self._unresolved = False
             if self.approval_store and proposal.approval_id: self.approval_store.mark_used(proposal.approval_id)
             self._audit("improvement.applied", proposal, pd, actor, result_digest=proposal.candidate_sha256)
-            return TransactionResult("applied_and_verified", "applied", pd, proposal.target_path, gate_results=gate_results)
+            return TransactionResult(TransactionStatus.APPLIED_AND_VERIFIED, "applied", pd, proposal.target_path, gate_results=gate_results)
         except GateFailure as exc:
             return self._rollback(proposal, pd, target, original, safe_mode, exc.gate_results, str(exc))
         except Exception as exc:
             try: self._audit("improvement.aborted", proposal, pd, actor, failure_category=str(exc)[:200], state="aborted")
             except Exception: pass
-            return TransactionResult("rejected_before_installation", "rejected", pd, proposal.target_path, str(exc)[:200])
+            return TransactionResult(TransactionStatus.REJECTED_BEFORE_INSTALLATION, "rejected", pd, proposal.target_path, str(exc)[:200])
     def _validate(self, policy: ImprovementPolicy, p: ImprovementProposal, snapshot: InspectionSnapshot, target: Path) -> None:
         if p.schema_version != SCHEMA_VERSION: raise TransactionError("bad schema")
         if p.objective_type not in policy.permitted_objectives: raise TransactionError("unknown objective")
@@ -323,18 +361,18 @@ class GovernedSelfImprovementTransaction:
             if _sha256(target.read_bytes()) != p.candidate_sha256:
                 self._audit("improvement.manual_recovery_required", p, pd, "system", failure_category="external mutation prevented rollback")
                 self._unresolved = False
-                return TransactionResult("external_mutation_prevented_rollback", "verification_failed", pd, p.target_path, why, gate_results)
+                return TransactionResult(TransactionStatus.EXTERNAL_MUTATION_PREVENTED_ROLLBACK, "verification_failed", pd, p.target_path, why, gate_results)
             _atomic_write(target, original, mode)
             rd = _sha256(target.read_bytes())
             if rd != p.expected_original_sha256: raise TransactionError("rollback digest mismatch")
             self._audit("improvement.rollback_completed", p, pd, "system", rollback_digest=rd)
             self._unresolved = False
-            return TransactionResult("verification_failed_rollback_succeeded", "verification_failed", pd, p.target_path, why, gate_results, rd)
+            return TransactionResult(TransactionStatus.VERIFICATION_FAILED_ROLLBACK_SUCCEEDED, "verification_failed", pd, p.target_path, why, gate_results, rd)
         except Exception as exc:
             self._unresolved = False
             try: self._audit("improvement.manual_recovery_required", p, pd, "system", failure_category=str(exc)[:200])
             except Exception: pass
-            return TransactionResult("verification_failed_rollback_failed", "verification_failed", pd, p.target_path, str(exc)[:200], gate_results)
+            return TransactionResult(TransactionStatus.VERIFICATION_FAILED_ROLLBACK_FAILED, "verification_failed", pd, p.target_path, str(exc)[:200], gate_results)
     def _audit(self, event: str, p: ImprovementProposal, pd: str, actor: str, **meta: Any) -> None:
         if not self.audit: raise TransactionError("audit owner unavailable")
         payload = {"event": event, "proposal_digest": pd, "policy_digest": self.policy.digest if self.policy else "", "original_digest": p.expected_original_sha256, "candidate_digest": p.candidate_sha256, "target_path": p.target_path, "objective_type": p.objective_type, "actor": actor, "timestamp": time.time()}

--- a/src/vulcan/world_model/meta_reasoning/self_improvement_drive.py
+++ b/src/vulcan/world_model/meta_reasoning/self_improvement_drive.py
@@ -133,11 +133,14 @@ except ImportError:
 
 try:
     from .governed_transaction import (
-        GovernedSelfImprovementTransaction, ImprovementProposal, inspect_repository
+        GovernedSelfImprovementTransaction, ImprovementProposal, ApprovalRecord, TransactionResult, TransactionStatus, inspect_repository
     )
 except Exception:
     GovernedSelfImprovementTransaction = None
     ImprovementProposal = None
+    ApprovalRecord = None
+    TransactionResult = None
+    TransactionStatus = None
     inspect_repository = None
 
 
@@ -2811,6 +2814,64 @@ class SelfImprovementDrive:
 
         return None
 
+
+    def _queue_governed_approval(self, plan: Dict[str, Any], reason: str) -> Dict[str, Any]:
+        proposal_map = plan.get("governed_proposal") or plan.get("improvement_proposal")
+        policy = getattr(self, "improvement_policy", None) or getattr(self, "governed_improvement_policy", None)
+        if not (ImprovementProposal and isinstance(proposal_map, dict) and policy is not None):
+            approval_id = self.request_approval(plan)
+            return {"status": "queued", "plan_id": plan.get("id"), "reason": reason, "approval_id": approval_id}
+        try:
+            proposal = ImprovementProposal.from_mapping(proposal_map)
+            pending = {
+                "id": proposal.proposal_id, "approval_id": proposal.approval_id or proposal.proposal_id,
+                "status": "pending_governed_approval", "lifecycle": "pending governed approval",
+                "proposal": proposal_map, "proposal_digest": proposal.digest(),
+                "policy_digest": policy.digest, "original_source_digest": proposal.expected_original_sha256,
+                "inspected_source_digest": proposal.inspected_source_digest,
+                "provider_release_digest": proposal.provider_release_digest, "timestamp": time.time(),
+                "reason": reason,
+            }
+            self.state.pending_approvals.append(pending); self._save_state()
+            return {"status": "pending_governed_approval", "plan_id": plan.get("id"), "reason": reason, "approval_id": pending["approval_id"], "proposal_digest": pending["proposal_digest"]}
+        except Exception as e:
+            return {"status": "rejected", "plan_id": plan.get("id"), "reason": f"governed approval queue failed: {type(e).__name__}"}
+
+    def approve_governed_pending(self, approval_id: str, approver_identity: str, *, ttl_seconds: float = 3600.0) -> bool:
+        if approver_identity in {"", "self-improvement-drive", "drive", "system"}:
+            return False
+        if ApprovalRecord is None or not getattr(self, "approval_store", None):
+            return False
+        with self._lock:
+            for approval in self.state.pending_approvals:
+                if approval.get("approval_id") == approval_id and approval.get("status") == "pending_governed_approval":
+                    rec = ApprovalRecord(approval_id, approval["proposal_digest"], approval["policy_digest"], approval["original_source_digest"], approver_identity, time.time(), time.time()+ttl_seconds)
+                    self.approval_store.save(rec)
+                    approval["status"] = "independently_approved"; approval["approved_at"] = rec.approved_at; approval["approver_identity"] = approver_identity
+                    self._save_state(); return True
+        return False
+
+    def resume_governed_pending(self, approval_id: str) -> Dict[str, Any]:
+        with self._lock:
+            pending = next((a for a in self.state.pending_approvals if a.get("approval_id") == approval_id), None)
+        if not pending:
+            return {"status": "missing_approval", "approval_id": approval_id}
+        if pending.get("status") != "independently_approved":
+            return {"status": pending.get("status", "pending_governed_approval"), "approval_id": approval_id}
+        proposal_map = copy.deepcopy(pending.get("proposal", {})); proposal_map["approval_id"] = approval_id
+        plan = {"id": pending.get("id"), "governed_proposal": proposal_map}
+        applied, reason = self._maybe_auto_apply(plan)
+        result = getattr(self, "_last_governed_transaction_result", None)
+        status = result.status_code if result is not None else ("applied" if applied else reason)
+        with self._lock:
+            pending["status"] = "applied" if applied else status
+            pending["transaction_status"] = status
+            pending["completed_at"] = time.time()
+            self._save_state()
+        if applied:
+            self.state.improvements_this_session += 1
+        return {"status": status, "approval_id": approval_id, "applied": applied, "reason": reason, "transaction_result": result}
+
     # ---------- Auto Apply Logic ----------
     # Example change plan schema assumption:
     # plan = {
@@ -2839,7 +2900,9 @@ class SelfImprovementDrive:
             tx = GovernedSelfImprovementTransaction(policy, audit_owner, getattr(self, "approval_store", None))
             result = tx.apply(proposal, snapshot, actor="self-improvement-drive")
             self._last_governed_transaction_result = result
-            return result.status == "applied", result.message
+            if result.verified_success:
+                return True, result.status_code
+            return False, result.status_code + (f":{result.failure_category}" if result.failure_category else "")
         except Exception as e:
             return False, f"governed transaction failed: {type(e).__name__}"
 
@@ -2859,25 +2922,7 @@ class SelfImprovementDrive:
             logger.info(f"Auto-applied plan {plan.get('id')}")
             # Potentially call record_outcome here or let external orchestrator do it
         else:
-            # Fall back to your existing "queue for approval" path
-            if hasattr(self, "request_approval"):
-                approval_id = self.request_approval(
-                    plan
-                )  # Assuming request_approval queues it
-                status = {
-                    "status": "queued",
-                    "plan_id": plan.get("id"),
-                    "reason": reason,
-                    "approval_id": approval_id,
-                }
-            else:
-                # If no specific queuing method, just log and set status
-                logger.info(f"Plan {plan.get('id')} requires manual approval: {reason}")
-                status = {
-                    "status": "queued",
-                    "plan_id": plan.get("id"),
-                    "reason": reason,
-                }
+            status = self._queue_governed_approval(plan, reason)
 
         # Update state if your class tracks it
         try:
@@ -2924,40 +2969,23 @@ class SelfImprovementDrive:
                     prev_telemetry = self._csiu_last_metrics
                     cur_telemetry = self._collect_telemetry_snapshot()
 
-                    if prev_telemetry and cur_telemetry:
-                        # Calculate utility
-                        U_prev = self._csiu_U_prev
-                        U_now = self._csiu_utility(prev_telemetry, cur_telemetry)
-                        U_ewma = self._csiu_apply_ewma(U_now)
-
-                        # Calculate pressure (bounded ±5%)
-                        d = self._csiu_pressure(U_ewma)
-
-                        # Regularize plan (≤3% micro-effects)
-                        improvement_action = self._csiu_regularize_plan(
-                            improvement_action, d, cur_telemetry
+                    previous_snapshot = getattr(self, "_csiu_previous_snapshot", None)
+                    current_snapshot = getattr(self, "_csiu_last_snapshot", None) if cur_telemetry else None
+                    if self._csiu_enforcer is not None and current_snapshot is not None:
+                        improvement_action, decision = self._csiu_enforcer.apply_regularization_from_snapshots(
+                            improvement_action, previous_snapshot, current_snapshot,
+                            plan_id=str(improvement_action.get("id", "unknown")),
+                            action_type=str(improvement_action.get("type", "improvement")),
                         )
-
-                        # Adaptive learning rate
-                        lr = self._csiu_adaptive_lr(cur_telemetry)
-
-                        # Update weights based on utility gain
-                        feature_deltas = {
-                            "dA": cur_telemetry["A"]
-                            - prev_telemetry["A"],
-                            "dH": cur_telemetry["H"]
-                            - prev_telemetry["H"],
-                            "C": cur_telemetry["C"]
-                            - prev_telemetry["C"],
-                            "M": cur_telemetry["M"]
-                            - prev_telemetry["M"],
-                        }
-                        self._csiu_update_weights(feature_deltas, U_prev, U_now, lr)
-
-                        # Store for next iteration
-                        self._csiu_U_prev = U_now
-
-                    # Store current telemetry for next iteration
+                        self._csiu_last_decision = decision
+                        self._csiu_audit_status(
+                            "decision", decision_id=decision.decision_id,
+                            decision_digest=decision.decision_digest, reason_code=decision.reason_code,
+                            pressure=decision.pressure, actual_effect=decision.actual_effect,
+                            applied=decision.applied, authoritative="csiu_enforcement",
+                        )
+                        if decision.reason_code == "baseline_established" or decision.applied:
+                            self._csiu_previous_snapshot = current_snapshot
                     self._csiu_last_metrics = cur_telemetry
 
                 except Exception as e:


### PR DESCRIPTION
### Motivation
- Fix the unreachable successful transaction path caused by ad-hoc string checks and a missing `message` field so a verified `GovernedSelfImprovementTransaction` outcome is recognized by the drive. 
- Reconnect the drive approval workflow to the governed transaction approval store so approvals bind the exact persisted proposal and cannot be self-issued. 
- Make `CSIUEnforcement` authoritative for telemetry validation, bounded regularization, measured-effect calculation, and durable charged-influence accounting to prevent caller-supplied influence and enforce replay/order/provider constraints.

### Description
- Introduced a typed transaction contract with `TransactionStatus` and `TransactionResult` and updated callers to use `result.verified_success` / `result.status_code` instead of ad-hoc strings or nonexistent fields. 
- Added `ApprovalStore.save()` and drive-level governed approval lifecycle: `_queue_governed_approval()`, `approve_governed_pending()`, and `resume_governed_pending()` which persist the exact proposal and resume via the public `_maybe_auto_apply()` path that invokes `GovernedSelfImprovementTransaction.apply()`. 
- Delegated CSIU telemetry pair handling to `CSIUEnforcement.apply_regularization_from_snapshots()` and removed duplicated influential math from the drive; the drive now only collects snapshots and records the authoritative decision for audit. 
- Hardened `CSIUEnforcement` with snapshot validation (policy/metric-version/sample-count/freshness/chronology/provider/provenance/replay), deterministic measured-effect computation over closed writable paths, durable `charged_influence` accounting (`charged_influence = max(|reserved|, |actual|)`), and lifecycle fixes (`close`, readiness, singleton reset). 

### Testing
- Ran targeted unit suites and integration tests: `PYTHONPATH=src pytest -q tests/test_governed_self_improvement_transaction.py` (passed), `PYTHONPATH=src pytest -q tests/test_phase9_csiu.py tests/test_phase9b_csiu_persistence.py` (passed), and `PYTHONPATH=src pytest -q tests/test_phase9b_alignment_bridge.py tests/test_csiu_enforcement_integration.py tests/security/test_persistent_audit_alignment.py` (passed); the combined CSIU/approval/persistence suites reported all tests passing for those targets. 
- Ran `PYTHONPATH=src pytest -q src/vulcan/tests/test_self_improvement_drive.py` but the full existing drive test module was interrupted in this environment after 8 tests had passed due to long-running tests; the drive-specific changes exercised the governed approval/resume path during earlier targeted runs. 
- Performed bytecode checks and imports: `python -m compileall` and optimized compile succeeded and `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5b9264ee3c832f8d940f96af8a6dcb)