### PR TITLE
Complete final CSIU acceptance gates

### DIFF
--- a/src/vulcan/runtime/audit.py
+++ b/src/vulcan/runtime/audit.py
@@ -1,6 +1,6 @@
 """Dependency-light append-only canonical audit owner (vulcan-audit/1)."""
 from __future__ import annotations
-import copy, fcntl, hashlib, json, os, re, threading, unicodedata
+import copy, fcntl, hashlib, json, math, os, re, threading, unicodedata
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -33,7 +33,9 @@ def _bound(v, depth=0):
         if len(n)>MAX_STRING or any(ord(c)<32 for c in n): raise AuditError("invalid string")
         return n
     if type(v) in (int,bool) or v is None: return v
-    if isinstance(v,float): raise AuditError("non-finite number")
+    if isinstance(v,float):
+        if not math.isfinite(v): raise AuditError("non-finite number")
+        return v
     if isinstance(v,dict):
         if len(v)>MAX_ITEMS: raise AuditError("object bound")
         return { _bound(str(k),depth+1): _bound(val,depth+1) for k,val in sorted(v.items()) }

--- a/src/vulcan/world_model/meta_reasoning/csiu_enforcement.py
+++ b/src/vulcan/world_model/meta_reasoning/csiu_enforcement.py
@@ -358,6 +358,52 @@ class CSIUEnforcement(SerializationMixin):
             r=self._record_for_decision(dec,state,previous_snapshot_digest,dec.actual_effect,0.0 if not dec.applied else max(abs(dec.actual_effect),abs(dec.pressure)))
             self._persist(r)
 
+    def observe_telemetry_snapshots(self, previous: Optional[CSIUMetricSnapshot], current: Optional[CSIUMetricSnapshot], *, observation_id: str = "telemetry-observation") -> CSIUDecision:
+        """Accept typed telemetry for accounting/cursor state without plan influence.
+
+        This public operation is intentionally evaluation-only: it never builds a
+        regularized plan, never reserves or charges influence capacity, and never
+        increments applied-influence counters or emits ``csiu.influence_applied``.
+        """
+        if self._closed:
+            raise CSIUValidationError("csiu enforcer closed")
+        plan_digest=canonical_digest({"telemetry_observation": str(observation_id)})
+        if current is None:
+            return self._decision(plan_digest,"missing_snapshot",0,0,0,True,False,None)
+        if previous is None:
+            ok,reason=self.validate_snapshot(current)
+            if not ok:
+                return self._decision(plan_digest,reason,0,0,0,True,False,current)
+            dec=self._decision(plan_digest,"baseline_established",0,self._last_ewma,0,True,False,current)
+            with self._lock:
+                self._persist_terminal_decision(dec,"","telemetry")
+                self._last_snapshot=current; self._last_snapshot_digest=current.snapshot_digest
+                self._seen_snapshot_digests.add(current.snapshot_digest); self._last_decision=dec
+            return dec
+        expected=getattr(self,"_last_snapshot_digest",getattr(self._last_snapshot,"snapshot_digest",None))
+        if expected and previous.snapshot_digest!=expected:
+            return self._decision(plan_digest,"previous_snapshot_digest_mismatch",0,self._last_ewma,0,True,False,current)
+        if previous.policy_digest!=self.policy.policy_digest or current.policy_digest!=self.policy.policy_digest:
+            return self._decision(plan_digest,"policy_digest_mismatch",0,self._last_ewma,0,True,False,current)
+        if current.snapshot_digest in self._seen_snapshot_digests:
+            return self._decision(plan_digest,"replayed_snapshot",0,self._last_ewma,0,True,False,current)
+        ok,reason=self.validate_snapshot(current)
+        if not ok:
+            return self._decision(plan_digest,reason,0,self._last_ewma,0,True,False,current)
+        if _parse_ts(previous.window_end)>_parse_ts(current.window_start):
+            return self._decision(plan_digest,"overlapping_or_reordered_window",0,self._last_ewma,0,True,False,current)
+        if previous.provider_id!=current.provider_id or previous.privacy_cohort!=current.privacy_cohort:
+            return self._decision(plan_digest,"provider_or_provenance_incompatible",0,self._last_ewma,0,True,False,current)
+        u=self.compute_utility(previous,current)
+        ew=self.policy.ewma_alpha*u + (1-self.policy.ewma_alpha)*self._last_ewma
+        reason="zero_pressure" if self.pressure_from_utility(ew)==0 else "telemetry_observed"
+        dec=self._decision(plan_digest,reason,u,ew,0,True,False,current)
+        with self._lock:
+            self._persist_terminal_decision(dec, previous.snapshot_digest, "telemetry")
+            self._last_snapshot=current; self._last_snapshot_digest=current.snapshot_digest
+            self._seen_snapshot_digests.add(current.snapshot_digest); self._last_ewma=ew; self._last_decision=dec
+        return dec
+
     def _apply_regularization_with_enforcement(self, plan: Dict[str,Any], pressure: float, metrics: Mapping[str,float], plan_id="unknown", action_type="improvement", snapshot: Optional[CSIUMetricSnapshot]=None, *, _utility: float=0.0, _ewma: float=0.0, _previous_snapshot_digest: str="")->Tuple[Dict[str,Any],CSIUDecision]:
         if snapshot is None:
             raise CSIUValidationError("typed snapshot decision required")
@@ -449,6 +495,30 @@ class CSIUEnforcement(SerializationMixin):
         return {"schema_version":"vulcan-csiu-weight-proposal/1","active_policy_digest":self.policy.policy_digest,"proposed_weights":dict(self.policy.weights),"supporting_snapshot_digests":[s.snapshot_digest for s in snapshots],"approval_state":"pending_review","proposal_digest":canonical_digest({"active_policy_digest":self.policy.policy_digest,"weights":dict(self.policy.weights)})}
     def propose_alignment_policy(self, active_policy: Any, snapshots: List[CSIUMetricSnapshot])->CSIUAlignmentProposal:
         dig=getattr(active_policy,"policy_digest",""); rev=int(getattr(active_policy,"revision",0)); pid=getattr(active_policy,"policy_id","vulcan-alignment/1")
+        if not (dig and rev >= 1):
+            raise CSIUValidationError("active alignment policy required")
+        if len(snapshots) < 4:
+            raise CSIUValidationError("insufficient alignment evidence")
+        ordered=sorted(snapshots, key=lambda s: _parse_ts(s.window_start))
+        if list(snapshots) != ordered or len({s.snapshot_digest for s in snapshots}) != len(snapshots):
+            raise CSIUValidationError("alignment evidence windows must be ordered and unique")
+        provider=snapshots[0].provider_id; cohort=snapshots[0].privacy_cohort; last_end=None
+        for s in snapshots:
+            ok,reason=self.validate_snapshot(s) if s.snapshot_digest not in self._seen_snapshot_digests else (s.policy_digest==self.policy.policy_digest and s.metric_definition_version==self.policy.metric_definition_version and s.sample_count>=self.policy.min_sample_count, "ok")
+            if not ok:
+                raise CSIUValidationError(f"invalid alignment evidence: {reason}")
+            if s.policy_digest != self.policy.policy_digest:
+                raise CSIUValidationError("mixed CSIU policy evidence")
+            if s.provider_id != provider or s.privacy_cohort != cohort:
+                raise CSIUValidationError("mixed provider or cohort evidence")
+            ws,we=_parse_ts(s.window_start),_parse_ts(s.window_end)
+            if last_end is not None and ws < last_end:
+                raise CSIUValidationError("overlapping alignment evidence")
+            last_end=we
+        evidence=tuple(s.snapshot_digest for s in snapshots[-4:])
+        evidence_id=canonical_digest({"active_alignment_digest":dig,"active_alignment_revision":rev,"csiu_policy_digest":self.policy.policy_digest,"evidence":list(evidence)})
+        if getattr(self,"_alignment_cooldown_evidence_id",None)==evidence_id and self._clock() < getattr(self,"_alignment_cooldown_until",datetime.min.replace(tzinfo=UTC)):
+            raise CSIUValidationError("alignment evidence cooldown")
         trend={k:0.0 for k in METRIC_ORDER}
         if len(snapshots)>=2:
             a,b=snapshots[-2],snapshots[-1]; trend={k:(b.metrics[k]-a.metrics[k])*DIRECTIONS[k] for k in METRIC_ORDER}
@@ -463,14 +533,17 @@ class CSIUEnforcement(SerializationMixin):
         # AlignmentRegistry.activate/update with exact CAS against this digest.
         if len(snapshots)>=4:
             sustained=[]
-            for k in ("C","M"):
+            for k in ("G","M"):
                 vals=[(snapshots[i].metrics[k]-snapshots[i-1].metrics[k])*DIRECTIONS[k] for i in range(1,len(snapshots))]
                 if len(vals)>=3 and all(v<=-0.02 for v in vals[-3:]): sustained.append(k)
             if sustained:
                 current=int(getattr(active_policy,"max_claims_per_response",8))
                 delta={"max_claims_per_response":max(1,current-1),"explicit_unknown_behavior":"abstain","require_citations":True,"require_verified_integrity":True,"require_temporal_validity":True}
                 reasons=tuple(sorted(set(reasons+tuple(sustained)+("conservative_alignment_tightening",))))
-        return CSIUAlignmentProposal(pid,rev,dig,self.policy.policy_digest,tuple(s.snapshot_digest for s in snapshots[-4:]),trend,reasons,"review human-understanding and safety thresholds; proposed deltas only tighten controls","authorized governance review plus ordinary alignment CAS activation",_ts(self._clock()+timedelta(hours=24)),delta)
+        prop=CSIUAlignmentProposal(pid,rev,dig,self.policy.policy_digest,evidence,trend,reasons,"review human-understanding and safety thresholds; proposed deltas only tighten controls","authorized governance review plus ordinary alignment CAS activation",_ts(self._clock()+timedelta(hours=24)),delta)
+        if delta:
+            self._alignment_cooldown_evidence_id=evidence_id; self._alignment_cooldown_until=self._clock()+timedelta(hours=1)
+        return prop
     def get_statistics(self):
         c=self.check_cumulative_influence(); return {"enabled":self.is_enabled(),"policy_digest":self.policy.policy_digest,"metric_definition_version":self.policy.metric_definition_version,"last_valid_snapshot_digest":getattr(self._last_snapshot,"snapshot_digest",None),"last_decision_digest":getattr(self._last_decision,"decision_digest",None),"total_applications":self._total_applications,"total_blocked":self._total_blocked,"total_capped":self._total_capped,"max_influence_seen":self._max_influence_seen,"cumulative_stats":c,"kill_switches":{"global_enabled":self.config.global_enabled,"calculation_enabled":self.config.calculation_enabled,"regularization_enabled":self.config.regularization_enabled,"proposal_generation_enabled":self.config.proposal_generation_enabled,"history_display_enabled":self.config.history_tracking_enabled,"emergency_stop":self.config.emergency_stop}}
     def export_audit_trail(self,path: Optional[Path]=None):

--- a/src/vulcan/world_model/meta_reasoning/governed_transaction.py
+++ b/src/vulcan/world_model/meta_reasoning/governed_transaction.py
@@ -152,27 +152,36 @@ class TrustedApprovalPrincipal:
     principal_id: str
     scopes: Tuple[str, ...]
     expires_at: float
+    approval_id: str = ""
+    proposal_digest: str = ""
+    policy_digest: str = ""
+    original_source_digest: str = ""
 
-class ApprovalAuthorityPort:
+class ApprovalVerifierPort:
     def is_authorized(self, principal: TrustedApprovalPrincipal, bindings: Mapping[str, str]) -> bool:
         raise NotImplementedError
 
-class ClosedApprovalAuthority(ApprovalAuthorityPort):
-    def __init__(self, principals: Mapping[str, TrustedApprovalPrincipal] = None):
-        self._principals = dict(principals or {})
-    def issue_principal(self, principal_id: str, scopes: Sequence[str], ttl_seconds: float = 3600.0) -> TrustedApprovalPrincipal:
+class ApprovalIssuer:
+    def issue_principal(self, principal_id: str, scopes: Sequence[str], *, bindings: Mapping[str, str], ttl_seconds: float = 3600.0) -> TrustedApprovalPrincipal:
         if not isinstance(principal_id, str) or not principal_id or len(principal_id) > 128:
             raise TransactionError("bad principal")
-        p = TrustedApprovalPrincipal(principal_id, tuple(str(s) for s in scopes), time.time()+float(ttl_seconds))
-        self._principals[principal_id] = p
-        return p
+        required=("approval_id","proposal_digest","policy_digest","original_source_digest")
+        if any(not isinstance(bindings.get(k), str) or not bindings.get(k) for k in required):
+            raise TransactionError("bad approval bindings")
+        return TrustedApprovalPrincipal(principal_id, tuple(str(s) for s in scopes), time.time()+float(ttl_seconds), *(str(bindings[k]) for k in required))
+
+class ClosedApprovalVerifier(ApprovalVerifierPort):
+    def __init__(self, principals: Mapping[str, TrustedApprovalPrincipal] = None):
+        self._principals = dict(principals or {})
     def is_authorized(self, principal: TrustedApprovalPrincipal, bindings: Mapping[str, str]) -> bool:
         if not isinstance(principal, TrustedApprovalPrincipal): return False
         stored = self._principals.get(principal.principal_id)
         if stored != principal or principal.expires_at < time.time(): return False
         required = str(bindings.get("required_scope", "self_improvement.approve"))
         if required not in principal.scopes: return False
-        return all(isinstance(bindings.get(k), str) and bindings.get(k) for k in ("approval_id","proposal_digest","policy_digest","original_source_digest"))
+        return all(getattr(principal,k)==bindings.get(k) for k in ("approval_id","proposal_digest","policy_digest","original_source_digest"))
+
+ClosedApprovalAuthority = ClosedApprovalVerifier
 
 @dataclass(frozen=True)
 class ApprovalRecord:
@@ -221,62 +230,102 @@ class TransactionResult:
 class ApprovalStore:
     def __init__(self, path: Path):
         self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
     def _check_paths(self) -> None:
         lock = self.path.with_suffix(self.path.suffix + ".lock")
         if self.path.is_symlink() or lock.is_symlink(): raise TransactionError("symlinked approval store or lock")
-
-    def load(self, approval_id: str) -> ApprovalRecord:
-        self._check_paths()
-        try:
-            doc = json.loads(self.path.read_text(encoding="utf-8"))
-        except Exception as exc:
-            raise TransactionError("approval store unavailable or corrupt") from exc
-        rec = doc.get(approval_id)
-        if not isinstance(rec, dict):
-            raise TransactionError("approval not found")
-        return ApprovalRecord(**rec)
-    def _strict_record(self, record: ApprovalRecord) -> None:
-        import re
-        for n in ("proposal_digest","policy_digest","original_source_digest"):
-            if not re.fullmatch(r"[0-9a-f]{64}", getattr(record,n)): raise TransactionError("bad approval digest")
-
-    def save(self, record: ApprovalRecord) -> None:
-        self._check_paths(); self._strict_record(record)
-        try:
-            doc = json.loads(self.path.read_text(encoding="utf-8")) if self.path.exists() else {}
-        except Exception as exc:
-            raise TransactionError("approval store unavailable or corrupt") from exc
-        if record.approval_id in doc:
-            raise TransactionError("approval already exists")
-        doc[record.approval_id] = record.__dict__.copy()
-        _atomic_write(self.path, json.dumps(doc, sort_keys=True).encode(), 0o600)
-    def claim(self, approval_id: str, proposal_digest: str) -> ApprovalRecord:
-        self.path.parent.mkdir(parents=True, exist_ok=True)
+    def _lock_fd(self):
         self._check_paths()
         lock = self.path.with_suffix(self.path.suffix + ".lock")
         fd = os.open(lock, os.O_CREAT|os.O_RDWR, 0o600)
+        self._check_paths()
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        self._check_paths()
+        return fd
+    @staticmethod
+    def _loads(text: str) -> Dict[str, Any]:
+        def pairs_hook(pairs: List[Tuple[str, Any]]) -> Dict[str, Any]:
+            out: Dict[str, Any] = {}
+            for k,v in pairs:
+                if k in out: raise TransactionError("duplicate approval store key")
+                out[k]=v
+            return out
         try:
-            fcntl.flock(fd, fcntl.LOCK_EX)
-            doc = json.loads(self.path.read_text(encoding="utf-8")) if self.path.exists() else {}
+            doc=json.loads(text, object_pairs_hook=pairs_hook, parse_constant=lambda x: (_ for _ in ()).throw(TransactionError("non-finite approval store number")))
+        except TransactionError:
+            raise
+        except Exception as exc:
+            raise TransactionError("approval store unavailable or corrupt") from exc
+        if not isinstance(doc, dict): raise TransactionError("approval store schema invalid")
+        for k,v in doc.items():
+            if not isinstance(k,str) or not isinstance(v,dict): raise TransactionError("approval store schema invalid")
+            rec=ApprovalRecord(**v); ApprovalStore._strict_record_static(rec)
+        return doc
+    @staticmethod
+    def _strict_record_static(record: ApprovalRecord) -> None:
+        import re
+        for n in ("proposal_digest","policy_digest","original_source_digest"):
+            if not re.fullmatch(r"[0-9a-f]{64}", getattr(record,n)): raise TransactionError("bad approval digest")
+        if record.state in {"approved","claimed"} and record.expires_at < time.time(): raise TransactionError("approval expired")
+    def _read_doc_locked(self) -> Dict[str, Any]:
+        self._check_paths()
+        if not self.path.exists(): return {}
+        return self._loads(self.path.read_text(encoding="utf-8"))
+    def _write_doc_locked(self, doc: Dict[str, Any]) -> None:
+        self._check_paths()
+        _atomic_write(self.path, json.dumps(doc, sort_keys=True, allow_nan=False, separators=(",", ":")).encode(), 0o600)
+        self._check_paths()
+
+    def load(self, approval_id: str) -> ApprovalRecord:
+        fd=self._lock_fd()
+        try:
+            doc=self._read_doc_locked(); rec=doc.get(approval_id)
+            if not isinstance(rec, dict): raise TransactionError("approval not found")
+            return ApprovalRecord(**rec)
+        finally:
+            try: fcntl.flock(fd, fcntl.LOCK_UN)
+            finally: os.close(fd)
+    def _strict_record(self, record: ApprovalRecord) -> None:
+        self._strict_record_static(record)
+
+    def save(self, record: ApprovalRecord) -> None:
+        self._strict_record(record); fd=self._lock_fd()
+        try:
+            doc=self._read_doc_locked()
+            if record.approval_id in doc: raise TransactionError("approval already exists")
+            doc[record.approval_id]=record.__dict__.copy(); self._write_doc_locked(doc)
+        finally:
+            try: fcntl.flock(fd, fcntl.LOCK_UN)
+            finally: os.close(fd)
+    def claim(self, approval_id: str, proposal_digest: str) -> ApprovalRecord:
+        fd = self._lock_fd()
+        try:
+            doc = self._read_doc_locked()
             recd = doc.get(approval_id)
             if not isinstance(recd, dict): raise TransactionError("approval not found")
             rec = ApprovalRecord(**recd)
-            if rec.used or rec.state != "approved" or rec.proposal_digest != proposal_digest: raise TransactionError("approval already consumed or not claimable")
+            self._strict_record(rec)
+            if rec.used or rec.state != "approved" or rec.proposal_digest != proposal_digest or rec.expires_at < time.time(): raise TransactionError("approval already consumed or not claimable")
             recd["state"] = "claimed"; doc[approval_id] = recd
-            _atomic_write(self.path, json.dumps(doc, sort_keys=True).encode(), 0o600)
+            self._write_doc_locked(doc)
             return ApprovalRecord(**recd)
         finally:
             try: fcntl.flock(fd, fcntl.LOCK_UN)
             finally: os.close(fd)
     def terminalize(self, approval_id: str, state: str) -> None:
-        self._check_paths()
         if state not in {"consumed","rejected","expired","verification_failed","aborted","manual_recovery_required"}:
             raise TransactionError("bad terminal approval state")
-        doc = json.loads(self.path.read_text(encoding="utf-8")) if self.path.exists() else {}
-        if approval_id not in doc: raise TransactionError("approval not found")
-        if doc[approval_id].get("state") in {"consumed","rejected","expired","verification_failed","aborted"}: raise TransactionError("approval already terminal")
-        doc[approval_id]["used"] = True; doc[approval_id]["state"] = state
-        _atomic_write(self.path, json.dumps(doc, sort_keys=True).encode(), 0o600)
+        fd=self._lock_fd()
+        try:
+            doc=self._read_doc_locked()
+            if approval_id not in doc: raise TransactionError("approval not found")
+            rec=ApprovalRecord(**doc[approval_id]); self._strict_record(rec)
+            if rec.state in {"consumed","rejected","expired","verification_failed","aborted","manual_recovery_required"}: raise TransactionError("approval already terminal")
+            doc[approval_id]["used"] = True; doc[approval_id]["state"] = state
+            self._write_doc_locked(doc)
+        finally:
+            try: fcntl.flock(fd, fcntl.LOCK_UN)
+            finally: os.close(fd)
     def mark_used(self, approval_id: str) -> None:
         self.terminalize(approval_id, "consumed")
 

--- a/src/vulcan/world_model/meta_reasoning/self_improvement_drive.py
+++ b/src/vulcan/world_model/meta_reasoning/self_improvement_drive.py
@@ -61,6 +61,16 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 # Initialize logger early - before it's used in import blocks
 logger = logging.getLogger(__name__)
 
+@dataclass(frozen=True)
+class AutoApplyResult:
+    applied: bool
+    status: str
+    reason: str
+    approval_required: bool
+    terminal: bool
+    rollback_succeeded: bool = False
+    manual_recovery_required: bool = False
+
 # ==========================================================================
 # CONSTANTS
 # ==========================================================================
@@ -1721,9 +1731,13 @@ class SelfImprovementDrive:
         if not self._csiu_enforcer or snap is None:
             return getattr(self, "_csiu_last_decision", None)
         prev = getattr(self, "_csiu_previous_snapshot", None)
-        _, decision = self._csiu_enforcer.apply_regularization_from_snapshots({}, prev, snap, plan_id="telemetry-observation", action_type="telemetry")
+        decision = self._csiu_enforcer.observe_telemetry_snapshots(prev, snap, observation_id="drive-telemetry")
         self._csiu_last_decision = decision
-        if decision.reason_code == "baseline_established" or decision.applied or decision.reason_code in {"zero_pressure","disabled"}:
+        terminal_acceptance = {
+            "baseline_established", "telemetry_observed", "zero_pressure",
+            "disabled", "cumulative_cap_exceeded",
+        }
+        if decision.reason_code in terminal_acceptance or decision.applied:
             self._csiu_previous_snapshot = snap
         self._csiu_audit_status("telemetry_observed", decision_id=decision.decision_id, decision_digest=decision.decision_digest, reason_code=decision.reason_code, applied=decision.applied)
         return decision
@@ -1804,6 +1818,8 @@ class SelfImprovementDrive:
             )
             self._csiu_last_decision = decision
             self._csiu_audit_status("decision", decision_id=decision.decision_id, decision_digest=decision.decision_digest, reason_code=decision.reason_code, pressure=decision.pressure, actual_effect=decision.actual_effect, applied=decision.applied)
+            if decision.reason_code in {"applied","zero_pressure","disabled","cumulative_cap_exceeded"}:
+                self._csiu_previous_snapshot = snapshot
             return regularized if decision.applied else original
         except Exception as e:
             self._csiu_audit_status("decision_aborted", reason_code=type(e).__name__)
@@ -2858,13 +2874,15 @@ class SelfImprovementDrive:
             return {"status": "rejected", "plan_id": plan.get("id"), "reason": f"governed approval queue failed: {type(e).__name__}"}
 
     def approve_governed_pending(self, approval_id: str, principal: Any, *, ttl_seconds: float = 3600.0) -> bool:
-        authority = getattr(self, "approval_authority", None)
-        if authority is None or principal is None:
+        from .governed_transaction import TrustedApprovalPrincipal, ApprovalVerifierPort
+        verifier = getattr(self, "approval_verifier", None) or getattr(self, "approval_authority", None)
+        if verifier is None or not isinstance(principal, TrustedApprovalPrincipal):
             return False
-        legacy_string = isinstance(principal, str) and hasattr(authority, "is_authorized") and not authority.__class__.__module__.startswith("vulcan")
-        if isinstance(principal, (str, bytes)) and not legacy_string:
+        if not isinstance(verifier, ApprovalVerifierPort):
             return False
-        if not hasattr(authority, "is_authorized"):
+        if any(hasattr(verifier, name) for name in ("issue_principal","register_principal")):
+            return False
+        if not hasattr(verifier, "is_authorized"):
             return False
         if ApprovalRecord is None or not getattr(self, "approval_store", None):
             return False
@@ -2872,14 +2890,9 @@ class SelfImprovementDrive:
             for approval in self.state.pending_approvals:
                 if approval.get("approval_id") == approval_id and approval.get("status") == "pending_governed_approval":
                     bindings = {"approval_id": approval_id, "proposal_digest": approval["proposal_digest"], "policy_digest": approval["policy_digest"], "original_source_digest": approval["original_source_digest"], "required_scope": "self_improvement.approve"}
-                    if legacy_string:
-                        if not authority.is_authorized(principal, approval_id):
-                            return False
-                        pid = principal
-                    else:
-                        if not authority.is_authorized(principal, bindings):
-                            return False
-                        pid = getattr(principal, "principal_id", "")
+                    if not verifier.is_authorized(principal, bindings):
+                        return False
+                    pid = principal.principal_id
                     rec = ApprovalRecord(approval_id, approval["proposal_digest"], approval["policy_digest"], approval["original_source_digest"], pid, time.time(), time.time()+ttl_seconds)
                     self.approval_store.save(rec)
                     approval["status"] = "independently_approved"; approval["approved_at"] = rec.approved_at; approval["approver_identity"] = pid
@@ -2895,7 +2908,8 @@ class SelfImprovementDrive:
             return {"status": pending.get("status", "pending_governed_approval"), "approval_id": approval_id, "applied": False}
         proposal_map = copy.deepcopy(pending.get("proposal", {})); proposal_map["approval_id"] = approval_id
         plan = {"id": pending.get("id"), "governed_proposal": proposal_map}
-        applied, reason = self._maybe_auto_apply(plan)
+        auto_result = self._maybe_auto_apply(plan)
+        applied, reason = auto_result.applied, auto_result.reason
         result = getattr(self, "_last_governed_transaction_result", None)
         status = result.status_code if result is not None else ("applied" if applied else reason)
         with self._lock:
@@ -2920,19 +2934,19 @@ class SelfImprovementDrive:
     #   "diff_loc": 12,
     #   "apply": callable_that_performs_change_or_patch
     # }
-    def _maybe_auto_apply(self, plan: Dict[str, Any]) -> Tuple[bool, str]:
+    def _maybe_auto_apply(self, plan: Dict[str, Any]) -> AutoApplyResult:
         """Auto-apply only through GovernedSelfImprovementTransaction."""
         if not self._auto_apply_enabled:
-            return False, "auto-apply disabled"
+            return AutoApplyResult(False,"not_attempted","auto-apply disabled",True,False)
         if GovernedSelfImprovementTransaction is None or ImprovementProposal is None or inspect_repository is None:
-            return False, "governed transaction unavailable"
+            return AutoApplyResult(False,"unavailable","governed transaction unavailable",True,False)
         proposal_map = plan.get("governed_proposal") or plan.get("improvement_proposal")
         policy = getattr(self, "improvement_policy", None) or getattr(self, "governed_improvement_policy", None)
         audit_owner = getattr(self, "audit_owner", None) or getattr(self, "audit", None)
         if not isinstance(proposal_map, dict):
-            return False, "missing governed improvement proposal"
+            return AutoApplyResult(False,"missing_governed_proposal","missing governed improvement proposal",True,False)
         if policy is None or audit_owner is None:
-            return False, "governed transaction policy or audit owner missing"
+            return AutoApplyResult(False,"configuration_missing","governed transaction policy or audit owner missing",True,False)
         try:
             proposal = ImprovementProposal.from_mapping(proposal_map)
             snapshot = inspect_repository(policy.repo_root, policy.permitted_path_globs, max_files=policy.max_files)
@@ -2940,10 +2954,13 @@ class SelfImprovementDrive:
             result = tx.apply(proposal, snapshot, actor="self-improvement-drive")
             self._last_governed_transaction_result = result
             if result.verified_success:
-                return True, result.status_code
-            return False, result.status_code + (f":{result.failure_category}" if result.failure_category else "")
+                return AutoApplyResult(True,result.status_code,result.status_code,False,True)
+            if result.status_code == "rejected_before_installation" and result.failure_category == "approval required":
+                return AutoApplyResult(False,result.status_code,result.failure_category,True,False)
+            manual = result.status_code in {"external_mutation_prevented_rollback","verification_failed_rollback_failed"}
+            return AutoApplyResult(False,result.status_code,result.failure_category or result.status_code,False,True,result.status_code=="verification_failed_rollback_succeeded",manual)
         except Exception as e:
-            return False, f"governed transaction failed: {type(e).__name__}"
+            return AutoApplyResult(False,"governed_exception",f"governed transaction failed: {type(e).__name__}",False,True)
 
     # Where improvements are processed, insert a call to _maybe_auto_apply before queueing/approval
     def process_plan(self, plan: Dict[str, Any]) -> Dict[str, Any]:
@@ -2951,21 +2968,21 @@ class SelfImprovementDrive:
         Process a single improvement plan. Auto-apply if policy allows, otherwise queue for approval.
         """
         # ... any existing validation ...
-        applied = False
-        reason = "queued"
+        result = AutoApplyResult(False,"queued","queued",True,False)
         if self._auto_apply_enabled:
-            applied, reason = self._maybe_auto_apply(plan)
+            result = self._maybe_auto_apply(plan)
 
-        if applied:
-            status = {"status": "applied", "plan_id": plan.get("id"), "reason": reason}
+        if result.applied:
+            status = {"status": "applied", "plan_id": plan.get("id"), "reason": result.reason, "transaction_status": result.status}
             logger.info(f"Auto-applied plan {plan.get('id')}")
             # Potentially call record_outcome here or let external orchestrator do it
         else:
-            terminal_markers = ("malformed", "stale", "policy mismatch", "policy_digest", "expired", "consumed", "audit", "gate", "rollback", "external", "manual_recovery", "verification_failed", "external_mutation")
-            if self._auto_apply_enabled and any(m in str(reason) for m in terminal_markers):
-                status = {"status": "terminal", "plan_id": plan.get("id"), "reason": reason}
+            if self._auto_apply_enabled and result.terminal:
+                status = {"status": result.status, "plan_id": plan.get("id"), "reason": result.reason, "terminal": True, "rollback_succeeded": result.rollback_succeeded, "manual_recovery_required": result.manual_recovery_required}
+            elif result.approval_required:
+                status = self._queue_governed_approval(plan, result.reason)
             else:
-                status = self._queue_governed_approval(plan, reason)
+                status = {"status": result.status, "plan_id": plan.get("id"), "reason": result.reason}
 
         # Update state if your class tracks it
         try:

--- a/tests/test_phase9_csiu.py
+++ b/tests/test_phase9_csiu.py
@@ -82,7 +82,9 @@ def test_no_mutation_and_alignment_proposal_no_activation():
     assert d.applied and new != plan
     class Pol:
         policy_digest='b'*64; revision=3; policy_id='canonical-evidence-bound'
-    prop = e.propose_alignment_policy(Pol(), [snap(BASE, e.policy), snap(BAD, e.policy)])
+    e2 = c.CSIUEnforcement()
+    ats=[snap({**BASE,"G":0.20+i*0.03}, e2.policy, end=t+timedelta(minutes=i*6), prov=str(i)) for i in range(4)]
+    prop = e2.propose_alignment_policy(Pol(), ats)
     assert prop.active_alignment_digest == 'b'*64
     assert prop.approval_state == 'pending_review'
 

--- a/tests/test_phase9b_alignment_bridge.py
+++ b/tests/test_phase9b_alignment_bridge.py
@@ -9,15 +9,15 @@ def digest(d):
     x=dict(d); x.pop('policy_digest',None)
     return hashlib.sha256(json.dumps(x,ensure_ascii=False,sort_keys=True,separators=(',',':'),allow_nan=False).encode()).hexdigest()
 
-def snap(enf, t, c, m):
-    metrics={k:0.5 for k in ('A','H','C','V','D','G','E','U','M')}; metrics['C']=c; metrics['M']=m
-    return CSIUMetricSnapshot(metrics=metrics, window_start=(t-timedelta(minutes=5)).isoformat().replace('+00:00','Z'), window_end=t.isoformat().replace('+00:00','Z'), sample_count=30, aggregation_method='privacy_aggregate', metric_definition_version=enf.policy.metric_definition_version, provider_id='test', provenance_digest='a'*64, policy_digest=enf.policy.policy_digest)
+def snap(enf, t, g, m, i):
+    metrics={k:0.5 for k in ('A','H','C','V','D','G','E','U','M')}; metrics['G']=g; metrics['M']=m
+    return CSIUMetricSnapshot(metrics=metrics, window_start=(t-timedelta(minutes=5)).isoformat().replace('+00:00','Z'), window_end=t.isoformat().replace('+00:00','Z'), sample_count=30, aggregation_method='privacy_aggregate', metric_definition_version=enf.policy.metric_definition_version, provider_id='test', provenance_digest=format(i,'x')*64, policy_digest=enf.policy.policy_digest)
 
 def test_reviewed_alignment_proposal_cas_and_stable_lease(tmp_path):
     audit=CanonicalAudit(tmp_path/'a.jsonl'); reg=AlignmentRegistry(tmp_path/'p.json', audit=audit)
     active=reg.active(); lease=reg.lease(); enf=CSIUEnforcement()
-    base=datetime(2026,1,1,tzinfo=timezone.utc)
-    snaps=[snap(enf,base+timedelta(minutes=i*10),0.8-i*0.03,0.2+i*0.03) for i in range(4)]
+    base=datetime.now(timezone.utc)-timedelta(minutes=40)
+    snaps=[snap(enf,base+timedelta(minutes=i*10),0.2+i*0.03,0.2+i*0.03,i) for i in range(4)]
     prop=enf.propose_alignment_policy(active, snaps)
     assert prop.schema_version=='vulcan-csiu-alignment-proposal/1'
     assert prop.active_alignment_revision==1 and prop.active_alignment_digest==active.policy_digest

--- a/tests/test_phase9b_csiu_persistence.py
+++ b/tests/test_phase9b_csiu_persistence.py
@@ -10,9 +10,9 @@ class Clock:
     def __call__(self): return self.t
     def advance(self, seconds): self.t += timedelta(seconds=seconds)
 
-def cfg(path, clock, hist=True):
+def cfg(path, clock, hist=True, cap=0.10, single=0.05):
     Path(path).touch()
-    return CSIUEnforcementConfig(durable_store_path=str(path), durable_accounting_required=True, clock=clock, history_tracking_enabled=hist)
+    return CSIUEnforcementConfig(durable_store_path=str(path), durable_accounting_required=True, clock=clock, history_tracking_enabled=hist, max_cumulative_influence_window=cap, max_single_influence=single)
 
 def plan(): return {"objective_weights":{"a":1.0},"id":"p"}
 
@@ -41,6 +41,25 @@ def test_restart_spanning_budget_and_history_display_off(tmp_path):
     c.advance(3601); assert e2.check_cumulative_influence()['cumulative_influence']==0
     apply(e2); assert e2.check_cumulative_influence()['cumulative_influence'] == pytest.approx(0.05, abs=0.05)
 
+def test_observe_telemetry_is_evaluation_only_and_persistent(tmp_path):
+    c=Clock(); store=tmp_path/'obs.jsonl'; e=CSIUEnforcement(cfg(store,c))
+    s1=snap(e); d1=e.observe_telemetry_snapshots(None,s1); assert d1.reason_code=="baseline_established"
+    assert e.check_cumulative_influence()["cumulative_influence"]==0 and e.get_statistics()["total_applications"]==0
+    c.advance(360); s2=snap(e,{k:.6 if k in ("A","C","E","U") else .4 for k in METRIC_ORDER})
+    d2=e.observe_telemetry_snapshots(s1,s2); assert d2.reason_code in {"telemetry_observed","zero_pressure"}
+    assert e.check_cumulative_influence()["cumulative_influence"]==0 and e.get_statistics()["total_applications"]==0
+    pol=e.policy; e.close(); e2=CSIUEnforcement(cfg(store,c), policy=pol)
+    assert e2.check_cumulative_influence()["cumulative_influence"]==0
+    cur=s2
+    for i in range(10):
+        c.advance(360); nxt=snap(e2,{k:.6+(i+1)*.001 if k in ("A","C","E","U") else .4-(i+1)*.001 for k in METRIC_ORDER})
+        e2.observe_telemetry_snapshots(cur,nxt); cur=nxt
+    assert e2.check_cumulative_influence()["cumulative_influence"]==0 and e2.get_statistics()["total_applications"]==0
+    assert e2.observe_telemetry_snapshots(cur,cur).reason_code=="replayed_snapshot"
+    c.advance(360); real=snap(e2,{k:.8 if k in ("A","C","E","U") else .3 for k in METRIC_ORDER})
+    _,dec=e2.apply_regularization_from_snapshots(plan(),cur,real,plan_id="real")
+    assert dec.applied and e2.check_cumulative_influence()["cumulative_influence"]>0
+
 def test_corruption_symlink_and_second_writer_rejected(tmp_path):
     c=Clock(); store=tmp_path/'c.jsonl'; e=CSIUEnforcement(cfg(store,c)); apply(e)
     with pytest.raises(CSIUValidationError): CSIUEnforcement(cfg(store,c), policy=e.policy)
@@ -50,20 +69,40 @@ def test_corruption_symlink_and_second_writer_rejected(tmp_path):
     with pytest.raises(CSIUValidationError): CSIUEnforcement(cfg(bad,c))
 
 def test_concurrent_remaining_budget_race(tmp_path):
-    c=Clock(); store=tmp_path/'c.jsonl'; e=CSIUEnforcement(cfg(store,c)); apply(e)
+    c=Clock(); store=tmp_path/'c.jsonl'
+    e=CSIUEnforcement(cfg(store,c,cap=0.05,single=0.05))
+    prev=snap(e,{k:(0.0 if k in ("A","C","E","U") else 1.0) for k in METRIC_ORDER})
+    e.observe_telemetry_snapshots(None,prev); c.advance(360)
+    cur=prev
+    for i in range(20):
+        c.advance(360)
+        high = (i % 2 == 0)
+        nxt=snap(e,{k:((1.0 if high else 0.0) if k in ("A","C","E","U") else (0.0 if high else 1.0)) for k in METRIC_ORDER})
+        _,d0=e.apply_regularization_from_snapshots(plan(),cur,nxt,plan_id=f"p{i}")
+        if not d0.applied: break
+        cur=nxt
+        rem=e.check_cumulative_influence()["remaining"]
+        if 0.012 < rem < 0.014: break
     first=e.check_cumulative_influence()['cumulative_influence']
-    object.__setattr__(e.config, 'max_cumulative_influence_window', first * 2.1)
     c.advance(360)
+    base=e._last_snapshot
     barrier=threading.Barrier(2); results=[]
     def worker():
-        barrier.wait(); results.append(apply(e))
+        barrier.wait()
+        now=e._clock(); tag=format(threading.get_ident() % 16, "x")
+        to_high = base.metrics["A"] < 0.5
+        nxt=CSIUMetricSnapshot(metrics={k:((1.0 if to_high else 0.0) if k in ("A","C","E","U") else (0.0 if to_high else 1.0)) for k in METRIC_ORDER}, window_start=(now-timedelta(minutes=5)).isoformat().replace("+00:00","Z"), window_end=now.isoformat().replace("+00:00","Z"), sample_count=30, aggregation_method="mean", metric_definition_version=e.policy.metric_definition_version, provider_id="p", provenance_digest=tag*64, policy_digest=e.policy.policy_digest)
+        results.append(e.apply_regularization_from_snapshots(plan(),base,nxt,plan_id="p"))
     ts=[threading.Thread(target=worker) for _ in range(2)]
     [t.start() for t in ts]; [t.join() for t in ts]
     applied=sum(1 for _,d in results if d.applied); blocked=sum(1 for _,d in results if d.blocked)
     assert applied == 1
     assert blocked == 1
+    assert [d.reason_code for _,d in results if d.blocked] == ["cumulative_cap_exceeded"]
     expected = first + abs(results[0][1].pressure or results[1][1].pressure)
-    assert e.check_cumulative_influence()['cumulative_influence'] == pytest.approx(expected)
+    assert e.check_cumulative_influence()['cumulative_influence'] == pytest.approx(expected, abs=1e-12)
+    pol=e.policy; e.close(); e2=CSIUEnforcement(cfg(store,c,cap=0.05,single=0.05), policy=pol)
+    assert e2.check_cumulative_influence()['cumulative_influence'] == pytest.approx(expected, abs=1e-12)
 
 def test_actual_effect_over_pressure_rejected(tmp_path):
     c=Clock(); store=tmp_path/'c.jsonl'; e=CSIUEnforcement(cfg(store,c))

--- a/tests/test_phase9d_alignment_review.py
+++ b/tests/test_phase9d_alignment_review.py
@@ -1,13 +1,25 @@
 from datetime import datetime, timezone, timedelta
 from vulcan.world_model.meta_reasoning.csiu_enforcement import *
+from vulcan.runtime.alignment import default_policy, validate_policy
+import pytest, hashlib, json
 BASE=dict(A=.5,H=.5,C=.5,V=.5,D=.5,G=.5,E=.5,U=.5,M=.5)
 def snap(vals, pol, i):
     t=datetime.now(timezone.utc)-timedelta(minutes=60-i*5)
     return CSIUMetricSnapshot(metrics=vals, window_start=t.isoformat().replace('+00:00','Z'), window_end=(t+timedelta(minutes=5)).isoformat().replace('+00:00','Z'), sample_count=30, aggregation_method='mean', metric_definition_version=pol.metric_definition_version, provider_id='p', provenance_digest=hex(i)[2:]*64, policy_digest=pol.policy_digest)
-class Pol: policy_digest='b'*64; revision=7; policy_id='align'; max_claims_per_response=8
+def digest(d):
+    x=dict(d); x.pop("policy_digest",None)
+    return hashlib.sha256(json.dumps(x,ensure_ascii=False,sort_keys=True,separators=(",",":"),allow_nan=False).encode()).hexdigest()
+class Pol: policy_digest='b'*64; revision=7; policy_id='canonical-evidence-bound'; max_claims_per_response=8
 def test_alignment_proposal_review_only_valid_delta():
     e=CSIUEnforcement(); snaps=[snap({**BASE,'G':.5+.03*i,'M':.5+.03*i},e.policy,i) for i in range(4)]
     prop=e.propose_alignment_policy(Pol(),snaps)
     assert prop.active_alignment_revision==7 and prop.active_alignment_digest=='b'*64
     assert prop.approval_state=='pending_review'
     assert 'mapping' not in prop.proposed_policy_delta
+    assert 'G' in prop.reason_codes and 'calibration' not in prop.expected_effect.lower()
+    candidate=default_policy().__dict__.copy()
+    candidate["permitted_epistemic_statuses"]=list(candidate["permitted_epistemic_statuses"])
+    candidate.update(prop.proposed_policy_delta); candidate["revision"]=2; candidate["policy_digest"]=""; candidate["policy_digest"]=digest(candidate)
+    assert validate_policy(candidate).revision==2
+    with pytest.raises(CSIUValidationError):
+        e.propose_alignment_policy(Pol(),snaps)

--- a/tests/test_phase9d_approval_atomicity.py
+++ b/tests/test_phase9d_approval_atomicity.py
@@ -1,6 +1,7 @@
 import hashlib,json,os,time,threading
 from pathlib import Path
 from vulcan.world_model.meta_reasoning.governed_transaction import *
+from vulcan.world_model.meta_reasoning.self_improvement_drive import SelfImprovementDrive
 
 def sha(s): return hashlib.sha256(s.encode()).hexdigest()
 class Audit:
@@ -36,3 +37,34 @@ def test_concurrent_claim_exactly_one(tmp_path, monkeypatch):
     ts=[threading.Thread(target=worker) for _ in range(2)]
     [t.start() for t in ts]; [t.join() for t in ts]
     assert res.count(TransactionStatus.APPLIED_AND_VERIFIED)==1
+
+def test_trusted_approval_principal_only_and_bound(tmp_path):
+    d=SelfImprovementDrive(config_path={"drives":{"self_improvement":{"enabled":True,"objectives":[{"type":"bugfix","weight":1.0}],"constraints":{},"triggers":[],"resource_limits":{}}}}, state_path=str(tmp_path/"s.json"))
+    d.approval_store=ApprovalStore(tmp_path/"approvals.json")
+    p_digest=sha("proposal"); pol_digest=sha("policy"); src_digest=sha("source"); aid="a"
+    d.state.pending_approvals.append({"approval_id":aid,"status":"pending_governed_approval","proposal_digest":p_digest,"policy_digest":pol_digest,"original_source_digest":src_digest})
+    bindings={"approval_id":aid,"proposal_digest":p_digest,"policy_digest":pol_digest,"original_source_digest":src_digest,"required_scope":"self_improvement.approve"}
+    issuer=ApprovalIssuer()
+    good=issuer.issue_principal("reviewer",("self_improvement.approve",),bindings=bindings,ttl_seconds=60)
+    d.approval_verifier=ClosedApprovalVerifier({good.principal_id:good})
+    assert not d.approve_governed_pending(aid,"reviewer")
+    assert not d.approve_governed_pending(aid,b"reviewer")
+    assert not d.approve_governed_pending(aid,{"principal_id":"reviewer"})
+    class Duck:
+        principal_id="reviewer"; scopes=("self_improvement.approve",); expires_at=time.time()+60
+    assert not d.approve_governed_pending(aid,Duck())
+    class Attacker:
+        def is_authorized(self,*a): return True
+    d.approval_verifier=Attacker()
+    assert not d.approve_governed_pending(aid,good)
+    d.approval_verifier=ClosedApprovalVerifier({good.principal_id:good})
+    wrong_scope=issuer.issue_principal("wrong",("other",),bindings=bindings,ttl_seconds=60)
+    d.approval_verifier=ClosedApprovalVerifier({"wrong":wrong_scope}); assert not d.approve_governed_pending(aid,wrong_scope)
+    expired=issuer.issue_principal("expired",("self_improvement.approve",),bindings=bindings,ttl_seconds=-1)
+    d.approval_verifier=ClosedApprovalVerifier({"expired":expired}); assert not d.approve_governed_pending(aid,expired)
+    altered=issuer.issue_principal("altered",("self_improvement.approve",),bindings={**bindings,"proposal_digest":sha("altered")},ttl_seconds=60)
+    d.approval_verifier=ClosedApprovalVerifier({"altered":altered}); assert not d.approve_governed_pending(aid,altered)
+    d.approval_verifier=ClosedApprovalVerifier({good.principal_id:good})
+    assert not any(hasattr(d.approval_verifier,n) for n in ("issue_principal","register_principal"))
+    assert not any(hasattr(d,n) for n in ("issue_principal","register_principal"))
+    assert d.approve_governed_pending(aid,good)

--- a/tests/test_phase9d_governed_drive_e2e.py
+++ b/tests/test_phase9d_governed_drive_e2e.py
@@ -1,27 +1,17 @@
 import hashlib, os, time
 from datetime import datetime, timezone, timedelta
 
-import json
 from vulcan.world_model.meta_reasoning.self_improvement_drive import SelfImprovementDrive
 from vulcan.world_model.meta_reasoning.csiu_enforcement import METRIC_ORDER, CSIUMetricSnapshot, reset_csiu_enforcer
 from vulcan.world_model.meta_reasoning.governed_transaction import (
     ApprovalStore, ImprovementPolicy, ImprovementProposal, VerificationGate,
     SCHEMA_VERSION, DISABLED_ENV, inspect_repository, TransactionStatus,
+    ApprovalIssuer, ClosedApprovalVerifier,
 )
+from vulcan.runtime.audit import CanonicalAudit
 
 
 def sha(s): return hashlib.sha256(s.encode()).hexdigest()
-
-class TrustedAuthority:
-    def is_authorized(self, principal, approval_id):
-        return principal == "independent-reviewer" and bool(approval_id)
-
-class AuditAdapter:
-    def __init__(self, path):
-        self.path=path; self.owner_id=f"runtime-audit-adapter:{path}"; path.write_text("")
-    def record_event(self, event, payload):
-        self.path.write_text(self.path.read_text()+json.dumps({"event":event,"payload":payload},sort_keys=True,default=str)+"\n")
-    def close(self): pass
 
 def cfg():
     return {"drives":{"self_improvement":{"enabled":True,"priority":1,"objectives":[{"type":"bugfix","weight":1.0}],"constraints":{"require_human_approval":True,"max_changes_per_session":5},"triggers":[],"resource_limits":{}}}}
@@ -33,25 +23,39 @@ def mk_drive(tmp_path, gate):
     snap=inspect_repository(repo,('src/*.py',))
     prop=ImprovementProposal(SCHEMA_VERSION,'prop-1','bugfix','src/t.py',sha('X=1\n'),'X=1\n','X=2\n',sha('X=2\n'),snap.digest,'deterministic','rel','proof',pol.digest,'')
     drive=SelfImprovementDrive(config_path=cfg(), state_path=str(tmp_path/'state.json'))
-    drive.improvement_policy=pol; drive.approval_store=ApprovalStore(tmp_path/'approvals.json'); drive.approval_authority=TrustedAuthority(); drive.audit_owner=AuditAdapter(tmp_path/'audit.jsonl'); drive._auto_apply_enabled=True
+    drive.improvement_policy=pol; drive.approval_store=ApprovalStore(tmp_path/'approvals.json'); drive.audit_owner=CanonicalAudit(tmp_path/'audit.jsonl'); drive._auto_apply_enabled=True
     obj=drive.objectives[0]
     drive.should_trigger=lambda ctx: True
     drive.select_objective=lambda: obj
     drive.generate_improvement_action=lambda objective: {'id':'drive-plan','type':'improvement','governed_proposal':prop.__dict__.copy(),'objective_weights':{'bugfix':1.0}}
     base=datetime.now(timezone.utc)-timedelta(minutes=20); calls={'n':0}
-    drive._csiu_previous_snapshot = CSIUMetricSnapshot(metrics={k:0.5 for k in METRIC_ORDER}, window_start=(base-timedelta(minutes=5)).isoformat().replace('+00:00','Z'), window_end=base.isoformat().replace('+00:00','Z'), sample_count=30, aggregation_method='mean', metric_definition_version=drive._csiu_enforcer.policy.metric_definition_version, provider_id='typed-provider', provenance_digest='a'*64, policy_digest=drive._csiu_enforcer.policy.policy_digest, privacy_cohort={"kind":"aggregate"})
+    phase={'n':1}
     def provider(k):
         calls['n']+=1
-        if k=='metrics.window_start': return (base+timedelta(minutes=6)-timedelta(minutes=5)).isoformat().replace('+00:00','Z')
-        if k=='metrics.window_end': return (base+timedelta(minutes=6)).isoformat().replace('+00:00','Z')
+        start=base-timedelta(minutes=5) if phase['n']==1 else base+timedelta(minutes=1)
+        end=base if phase['n']==1 else base+timedelta(minutes=6)
+        if k=='metrics.window_start': return start.isoformat().replace('+00:00','Z')
+        if k=='metrics.window_end': return end.isoformat().replace('+00:00','Z')
         if k=='metrics.sample_count': return 30
         if k=='metrics.aggregation_method': return 'mean'
         if k=='metrics.metric_definition_version': return drive._csiu_enforcer.policy.metric_definition_version
         if k=='metrics.provider_id': return 'typed-provider'
-        if k=='metrics.provenance_digest': return 'b'*64
+        if k=='metrics.provenance_digest': return ('a' if phase['n']==1 else 'b')*64
+        if phase['n']==1: return 0.5
         return 0.6 if k.endswith(("alignment_coherence_idx","intent_clarity_score","empathy_index","user_satisfaction")) else 0.4
     drive.set_metrics_provider(provider)
+    d1=drive.observe_csiu_telemetry()
+    assert d1.reason_code=="baseline_established"
+    assert drive._csiu_enforcer.check_cumulative_influence()["cumulative_influence"]==0
+    phase['n']=2
     return repo, drive, prop
+
+def issue_for(drive, approval_id):
+    pending=next(a for a in drive.state.pending_approvals if a["approval_id"]==approval_id)
+    bindings={"approval_id":approval_id,"proposal_digest":pending["proposal_digest"],"policy_digest":pending["policy_digest"],"original_source_digest":pending["original_source_digest"],"required_scope":"self_improvement.approve"}
+    principal=ApprovalIssuer().issue_principal("independent-reviewer",("self_improvement.approve",),bindings=bindings,ttl_seconds=60)
+    drive.approval_verifier=ClosedApprovalVerifier({principal.principal_id:principal})
+    return principal
 
 def test_governed_drive_e2e_step_approval_resume_success(tmp_path, monkeypatch):
     monkeypatch.setenv('INTRINSIC_CSIU_OFF','0'); monkeypatch.setenv(DISABLED_ENV,'0')
@@ -61,7 +65,7 @@ def test_governed_drive_e2e_step_approval_resume_success(tmp_path, monkeypatch):
     assert action['status']=='pending_governed_approval' and action['_wait_for_approval'] is True
     assert action['approval_id'] and action['proposal_digest']==prop.digest()
     assert (repo/'src/t.py').read_bytes()==original
-    assert drive.approve_governed_pending(action['approval_id'],'independent-reviewer')
+    assert drive.approve_governed_pending(action['approval_id'], issue_for(drive, action['approval_id']))
     resumed=drive.resume_governed_pending(action['approval_id'])
     assert resumed['status']==TransactionStatus.APPLIED_AND_VERIFIED.value
     assert (repo/'src/t.py').read_text()=='X=2\n'
@@ -69,6 +73,11 @@ def test_governed_drive_e2e_step_approval_resume_success(tmp_path, monkeypatch):
     assert drive._last_governed_transaction_result.status==TransactionStatus.APPLIED_AND_VERIFIED
     assert drive._csiu_last_decision is not None
     assert (tmp_path/'state.json').exists() and (tmp_path/'audit.jsonl').exists()
+    drive.audit_owner.readiness(); events=drive.audit_owner.events_for_proposal(prop.digest())
+    lifecycle=[e.event_type for e in events]
+    assert lifecycle[-6:]==["improvement.proposed","improvement.approved","improvement.apply_prepared","improvement.candidate_installed","improvement.gate_completed","improvement.applied"]
+    assert all(e.data["proposal_digest"]==prop.digest() and e.data["policy_digest"]==drive.improvement_policy.digest and e.data["original_digest"]==prop.expected_original_sha256 and e.data["candidate_digest"]==prop.candidate_sha256 for e in events)
+    drive.audit_owner.close(); reopened=CanonicalAudit(tmp_path/'audit.jsonl'); reopened.readiness(); assert len(reopened.events_for_proposal(prop.digest()))==len(events); reopened.close()
     assert drive.approval_store.load(action['approval_id']).state=='consumed'
     again=drive.resume_governed_pending(action['approval_id'])
     assert drive.state.improvements_this_session==1 and again['applied'] is False
@@ -79,10 +88,12 @@ def test_governed_drive_e2e_step_approval_resume_rollback(tmp_path, monkeypatch)
     repo, drive, prop = mk_drive(tmp_path, VerificationGate('fail',('python','-c','import sys; sys.exit(1)')))
     action=drive.step({'force':True})
     assert action['status']=='pending_governed_approval'
-    assert drive.approve_governed_pending(action['approval_id'],'independent-reviewer')
+    assert drive.approve_governed_pending(action['approval_id'], issue_for(drive, action['approval_id']))
     resumed=drive.resume_governed_pending(action['approval_id'])
     assert resumed['status']==TransactionStatus.VERIFICATION_FAILED_ROLLBACK_SUCCEEDED.value
     assert (repo/'src/t.py').read_text()=='X=1\n'
     assert drive.state.improvements_this_session==0
     assert len([a for a in drive.state.pending_approvals if a.get('status')=='pending_governed_approval'])==0
+    drive.audit_owner.readiness(); events=drive.audit_owner.events_for_proposal(prop.digest())
+    assert [e.event_type for e in events][-1]=="improvement.rollback_completed"
     drive.audit_owner.close()

--- a/tests/test_phase9g_runtime_ownership.py
+++ b/tests/test_phase9g_runtime_ownership.py
@@ -8,7 +8,7 @@ from vulcan.world_model.meta_reasoning.csiu_enforcement import (
     CSIUEnforcement, CSIUEnforcementConfig, CSIUPolicy, CSIUMetricSnapshot, METRIC_ORDER, CSIUValidationError
 )
 from vulcan.world_model.meta_reasoning.self_improvement_drive import SelfImprovementDrive
-from vulcan.world_model.meta_reasoning.governed_transaction import ClosedApprovalAuthority, ApprovalRecord, ApprovalStore, TransactionError
+from vulcan.world_model.meta_reasoning.governed_transaction import ClosedApprovalAuthority, ApprovalIssuer, ApprovalRecord, ApprovalStore, TransactionError
 
 
 def _snap(enf, end, vals=None, prov="a"):
@@ -70,9 +70,9 @@ def test_public_csiu_observation_accepts_baseline(tmp_path, monkeypatch):
 
 def test_closed_approval_authority_accepts_only_trusted_principal(tmp_path):
     store=ApprovalStore(tmp_path/'a.json')
-    auth=ClosedApprovalAuthority()
-    p=auth.issue_principal('reviewer', ['self_improvement.approve'], 60)
     b={'approval_id':'a','proposal_digest':'1'*64,'policy_digest':'2'*64,'original_source_digest':'3'*64,'required_scope':'self_improvement.approve'}
+    p=ApprovalIssuer().issue_principal('reviewer', ['self_improvement.approve'], bindings=b, ttl_seconds=60)
+    auth=ClosedApprovalAuthority({'reviewer':p})
     assert not auth.is_authorized('reviewer', b)
     assert auth.is_authorized(p, b)
     store.save(ApprovalRecord('a','1'*64,'2'*64,'3'*64,'reviewer',time.time(),time.time()+60))


### PR DESCRIPTION
### Motivation
- Close the remaining Phase 9 acceptance gaps by making CSIU telemetry observation evaluation-only, hardening approval issuance/verification, and proving durable budget/atomicity properties.
- Ensure governed self-improvement uses only public telemetry state, real CanonicalAudit evidence, and a verifier-only approval interface so tests exercise production artifacts and can prove exact budget/concurrency bounds.
- Replace loose substring terminal-state checks and duck-typed approval compatibility with typed, auditable, and bounded interfaces for safety and auditability.

### Description
- Add an evaluation-only telemetry API `CSIUEnforcement.observe_telemetry_snapshots()` that validates typed snapshots, advances/persists cursor and EWMA, records telemetry records, rejects replay, and never constructs a plan or consumes influence capacity. (see `CSIUEnforcement`) 
- Update `SelfImprovementDrive.observe_csiu_telemetry()` to call the new public observation API and synchronize `_csiu_previous_snapshot` on accepted terminal telemetry decisions. 
- Split approval responsibilities: introduce `ApprovalIssuer` to create bounded `TrustedApprovalPrincipal` artifacts and `ApprovalVerifierPort`/`ClosedApprovalVerifier` for drive-side verification only, and require verifier injection into the drive; remove legacy string/duck-typed issuance compatibility. (see `governed_transaction.py` and usages in `self_improvement_drive.py`) 
- Harden `ApprovalStore` with a single lock path and `flock()` usage for `load`/`save`/`claim`/`terminalize`, strict duplicate-key JSON parsing, schema validation, expiry/binding checks, symlink fail-closed checks, and atomic writes. (see `ApprovalStore`) 
- Replace substring terminal-state heuristics with a typed `AutoApplyResult` returned by `_maybe_auto_apply()` and used by `process_plan()` so auto-apply logic yields structured state (`applied`, `terminal`, `approval_required`, `rollback_succeeded`, `manual_recovery_required`). 
- Strengthen the alignment-review bridge in `CSIUEnforcement.propose_alignment_policy()` to require four fresh ordered unique windows, consistent provider/cohort/policy, an active alignment binding, sustained G/M worsening semantics, evidence cooldown, and produce review-only deltas that pass `validate_policy()`. 
- Allow CanonicalAudit payloads to contain finite floats (reject non-finite values) so the real `CanonicalAudit` is usable in E2E tests. 
- Update Phase 9 tests to use only public telemetry APIs, `CanonicalAudit` (instead of test-local adapters), external approval issuance via `ApprovalIssuer`, and to assert audit lifecycle ordering, approval bindings, exact budget/concurrency proofs, and alignment-review behavior. Key tests updated: `tests/test_phase9d_governed_drive_e2e.py`, `tests/test_phase9d_approval_atomicity.py`, `tests/test_phase9b_csiu_persistence.py`, `tests/test_phase9d_alignment_review.py`.

### Testing
- Ran the Phase 9 acceptance suites: `PYTHONPATH=src pytest -q` over the requested Phase 9 test groups and the drive/e2e tests; final comprehensive run reported all tests passing (74 passed, 1 skipped). 
- Ran compilation checks with `python -m compileall -q src tests` and `python -O -m compileall -q src tests` which succeeded. 
- Verified dependency-light imports from `/tmp` and import-time initialization for the modified modules succeeded. 
- Ran `git diff --check` to ensure no whitespace/conflict markers were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5bccf00b50832f9d51f862a8aceb39)