### PR TITLE
Make the governed CSIU runtime path real

### DIFF
--- a/src/vulcan/reasoning/singletons.py
+++ b/src/vulcan/reasoning/singletons.py
@@ -812,8 +812,8 @@ def get_self_improvement_drive(config_path: Optional[str] = None, state_path: Op
         
         logger.info("[Singletons] Creating global SelfImprovementDrive (ONCE)")
         try:
-            from vulcan.world_model.meta_reasoning.self_improvement_drive import SelfImprovementDrive
-            _self_improvement_drive = SelfImprovementDrive(
+            from vulcan.world_model.meta_reasoning.self_improvement_drive import compose_self_improvement_drive
+            _self_improvement_drive = compose_self_improvement_drive(
                 config_path=config_path,
                 state_path=state_path
             )

--- a/src/vulcan/world_model/meta_reasoning/__init__.py
+++ b/src/vulcan/world_model/meta_reasoning/__init__.py
@@ -8,6 +8,7 @@ _LAZY = {
     "FailureType": ".self_improvement_drive",
     "ImprovementObjective": ".self_improvement_drive",
     "SelfImprovementState": ".self_improvement_drive",
+    "compose_self_improvement_drive": ".self_improvement_drive",
     "CodeIntrospector": ".self_improvement_drive",
     "LogAnalyzer": ".self_improvement_drive",
     "CodeKnowledgeStore": ".self_improvement_drive",

--- a/src/vulcan/world_model/meta_reasoning/csiu_enforcement.py
+++ b/src/vulcan/world_model/meta_reasoning/csiu_enforcement.py
@@ -192,8 +192,9 @@ class CSIUEnforcement(SerializationMixin):
     _unpickleable_attrs=["_lock","_clock"]
     def __init__(self, config: Optional[CSIUEnforcementConfig]=None, policy: Optional[CSIUPolicy]=None):
         self.config=config or CSIUEnforcementConfig(); self._explicit_policy = policy is not None; self.policy=policy or CSIUPolicy(max_single_influence=self.config.max_single_influence,max_cumulative_influence_window=self.config.max_cumulative_influence_window,cumulative_window_seconds=self.config.cumulative_window_seconds)
-        self._lock=threading.RLock(); self._clock=self.config.clock or _now; self.enforcer_id=f"csiu:{self.policy.policy_id}:{self.policy.policy_digest}"; self._durable_ready=False; self._durable_prev="0"*64; self._durable_fd=None; self._influence_history=[]; self._audit_trail=[]; self._last_decision=None; self._last_snapshot=None; self._last_ewma=0.0; self._closed=False; self._seen_snapshot_digests=set(); self._total_applications=0; self._total_blocked=0; self._total_capped=0; self._max_influence_seen=0.0; self._last_snapshot_digest=""
-        try: self._load_durable()
+        self._lock=threading.RLock(); self._clock=self.config.clock or _now; self.enforcer_id=f"csiu:{self.policy.policy_id}:{self.policy.policy_digest}"; self._durable_ready=False; self._durable_prev="0"*64; self._durable_fd=None; self._influence_history=[]; self._audit_trail=[]; self._last_decision=None; self._last_snapshot=None; self._last_ewma=0.0; self._closed=False; self._seen_snapshot_digests=set(); self._total_applications=0; self._total_blocked=0; self._total_capped=0; self._max_influence_seen=0.0; self._last_snapshot_digest=""; self._alignment_cooldown_evidence_id=""; self._alignment_cooldown_until=datetime.min.replace(tzinfo=UTC); self._alignment_cooldown_proposal_digest=""; self._alignment_cooldown_active_digest=""; self._alignment_cooldown_active_revision=0; self._alignment_cooldown_created_at=""
+        try:
+            self._load_durable(); self._load_alignment_state()
         except Exception:
             if self._durable_fd is not None:
                 try: os.close(self._durable_fd)
@@ -359,6 +360,10 @@ class CSIUEnforcement(SerializationMixin):
             self._persist(r)
 
     def observe_telemetry_snapshots(self, previous: Optional[CSIUMetricSnapshot], current: Optional[CSIUMetricSnapshot], *, observation_id: str = "telemetry-observation") -> CSIUDecision:
+        with self._lock:
+            return self._observe_telemetry_snapshots_locked(previous, current, observation_id=observation_id)
+
+    def _observe_telemetry_snapshots_locked(self, previous: Optional[CSIUMetricSnapshot], current: Optional[CSIUMetricSnapshot], *, observation_id: str = "telemetry-observation") -> CSIUDecision:
         """Accept typed telemetry for accounting/cursor state without plan influence.
 
         This public operation is intentionally evaluation-only: it never builds a
@@ -436,6 +441,10 @@ class CSIUEnforcement(SerializationMixin):
             self._last_snapshot=snapshot; self._seen_snapshot_digests.add(snapshot.snapshot_digest)
         return proposed,dec
     def apply_regularization_from_snapshots(self, plan: Dict[str,Any], previous: Optional[CSIUMetricSnapshot], current: Optional[CSIUMetricSnapshot], plan_id="unknown", action_type="improvement"):
+        with self._lock:
+            return self._apply_regularization_from_snapshots_locked(plan, previous, current, plan_id, action_type)
+
+    def _apply_regularization_from_snapshots_locked(self, plan: Dict[str,Any], previous: Optional[CSIUMetricSnapshot], current: Optional[CSIUMetricSnapshot], plan_id="unknown", action_type="improvement"):
         original=copy.deepcopy(plan or {})
         if self._closed: raise CSIUValidationError("csiu enforcer closed")
         if previous is None or current is None:
@@ -493,6 +502,27 @@ class CSIUEnforcement(SerializationMixin):
         return CSIUDecision(did,self.policy.policy_digest,pd,reason,u,ew,p,effect,applied,blocked,getattr(snapshot,"snapshot_id",''),getattr(snapshot,"snapshot_digest",''))
     def propose_weight_revision(self, snapshots: List[CSIUMetricSnapshot])->Dict[str,Any]:
         return {"schema_version":"vulcan-csiu-weight-proposal/1","active_policy_digest":self.policy.policy_digest,"proposed_weights":dict(self.policy.weights),"supporting_snapshot_digests":[s.snapshot_digest for s in snapshots],"approval_state":"pending_review","proposal_digest":canonical_digest({"active_policy_digest":self.policy.policy_digest,"weights":dict(self.policy.weights)})}
+    def _alignment_state_path(self) -> Optional[Path]:
+        if not self.config.durable_store_path:
+            return None
+        return Path(str(self.config.durable_store_path) + ".alignment.json")
+    def _load_alignment_state(self) -> None:
+        path=self._alignment_state_path()
+        if not path or not path.exists(): return
+        doc=json.loads(path.read_text(encoding="utf-8"))
+        self._alignment_cooldown_evidence_id=str(doc.get("evidence_id", ""))
+        self._alignment_cooldown_until=_parse_ts(str(doc.get("cooldown_until", "1970-01-01T00:00:00Z")))
+        self._alignment_cooldown_proposal_digest=str(doc.get("proposal_digest", ""))
+        self._alignment_cooldown_active_digest=str(doc.get("active_alignment_digest", ""))
+        self._alignment_cooldown_active_revision=int(doc.get("active_alignment_revision", 0))
+        self._alignment_cooldown_created_at=str(doc.get("created_at", ""))
+    def _persist_alignment_state(self, doc: Mapping[str,Any]) -> None:
+        path=self._alignment_state_path()
+        if not path: return
+        tmp=path.with_suffix(path.suffix+".tmp")
+        tmp.write_text(json.dumps(dict(doc),sort_keys=True,separators=(",",":"),allow_nan=False),encoding="utf-8")
+        os.replace(tmp,path)
+
     def propose_alignment_policy(self, active_policy: Any, snapshots: List[CSIUMetricSnapshot])->CSIUAlignmentProposal:
         dig=getattr(active_policy,"policy_digest",""); rev=int(getattr(active_policy,"revision",0)); pid=getattr(active_policy,"policy_id","vulcan-alignment/1")
         if not (dig and rev >= 1):
@@ -504,7 +534,13 @@ class CSIUEnforcement(SerializationMixin):
             raise CSIUValidationError("alignment evidence windows must be ordered and unique")
         provider=snapshots[0].provider_id; cohort=snapshots[0].privacy_cohort; last_end=None
         for s in snapshots:
-            ok,reason=self.validate_snapshot(s) if s.snapshot_digest not in self._seen_snapshot_digests else (s.policy_digest==self.policy.policy_digest and s.metric_definition_version==self.policy.metric_definition_version and s.sample_count>=self.policy.min_sample_count, "ok")
+            prior_last = self._last_snapshot
+            prior_seen = set(self._seen_snapshot_digests)
+            self._last_snapshot = None
+            self._seen_snapshot_digests = {d for d in self._seen_snapshot_digests if d != s.snapshot_digest}
+            ok,reason=self.validate_snapshot(s)
+            self._last_snapshot = prior_last
+            self._seen_snapshot_digests = prior_seen
             if not ok:
                 raise CSIUValidationError(f"invalid alignment evidence: {reason}")
             if s.policy_digest != self.policy.policy_digest:
@@ -543,6 +579,8 @@ class CSIUEnforcement(SerializationMixin):
         prop=CSIUAlignmentProposal(pid,rev,dig,self.policy.policy_digest,evidence,trend,reasons,"review human-understanding and safety thresholds; proposed deltas only tighten controls","authorized governance review plus ordinary alignment CAS activation",_ts(self._clock()+timedelta(hours=24)),delta)
         if delta:
             self._alignment_cooldown_evidence_id=evidence_id; self._alignment_cooldown_until=self._clock()+timedelta(hours=1)
+            self._alignment_cooldown_proposal_digest=prop.proposal_digest; self._alignment_cooldown_active_digest=dig; self._alignment_cooldown_active_revision=rev; self._alignment_cooldown_created_at=prop.created_at
+            self._persist_alignment_state({"evidence_id":evidence_id,"active_alignment_revision":rev,"active_alignment_digest":dig,"proposal_digest":prop.proposal_digest,"created_at":prop.created_at,"cooldown_until":_ts(self._alignment_cooldown_until)})
         return prop
     def get_statistics(self):
         c=self.check_cumulative_influence(); return {"enabled":self.is_enabled(),"policy_digest":self.policy.policy_digest,"metric_definition_version":self.policy.metric_definition_version,"last_valid_snapshot_digest":getattr(self._last_snapshot,"snapshot_digest",None),"last_decision_digest":getattr(self._last_decision,"decision_digest",None),"total_applications":self._total_applications,"total_blocked":self._total_blocked,"total_capped":self._total_capped,"max_influence_seen":self._max_influence_seen,"cumulative_stats":c,"kill_switches":{"global_enabled":self.config.global_enabled,"calculation_enabled":self.config.calculation_enabled,"regularization_enabled":self.config.regularization_enabled,"proposal_generation_enabled":self.config.proposal_generation_enabled,"history_display_enabled":self.config.history_tracking_enabled,"emergency_stop":self.config.emergency_stop}}

--- a/src/vulcan/world_model/meta_reasoning/governed_transaction.py
+++ b/src/vulcan/world_model/meta_reasoning/governed_transaction.py
@@ -204,6 +204,8 @@ class ApprovalRecord:
         if not all(isinstance(x,(int,float)) and math.isfinite(float(x)) for x in (self.approved_at,self.expires_at)): raise TransactionError("bad approval timestamp")
         if self.expires_at <= self.approved_at: raise TransactionError("bad approval expiry")
         if self.state not in {"approved","claimed","consumed","rejected","expired","verification_failed","aborted","manual_recovery_required"}: raise TransactionError("bad approval state")
+        if self.used and self.state in {"approved","claimed"}: raise TransactionError("bad approval used state")
+        if (not self.used) and self.state in {"consumed","rejected","verification_failed","aborted","manual_recovery_required"}: raise TransactionError("bad approval terminal state")
 
 @dataclass
 class TransactionResult:
@@ -259,14 +261,16 @@ class ApprovalStore:
         if not isinstance(doc, dict): raise TransactionError("approval store schema invalid")
         for k,v in doc.items():
             if not isinstance(k,str) or not isinstance(v,dict): raise TransactionError("approval store schema invalid")
-            rec=ApprovalRecord(**v); ApprovalStore._strict_record_static(rec)
+            rec=ApprovalRecord(**v)
+            if k != rec.approval_id: raise TransactionError("approval store key mismatch")
+            ApprovalStore._strict_record_static(rec, allow_expired=True)
         return doc
     @staticmethod
-    def _strict_record_static(record: ApprovalRecord) -> None:
+    def _strict_record_static(record: ApprovalRecord, allow_expired: bool = False) -> None:
         import re
         for n in ("proposal_digest","policy_digest","original_source_digest"):
             if not re.fullmatch(r"[0-9a-f]{64}", getattr(record,n)): raise TransactionError("bad approval digest")
-        if record.state in {"approved","claimed"} and record.expires_at < time.time(): raise TransactionError("approval expired")
+        if not allow_expired and record.state in {"approved","claimed"} and record.expires_at < time.time(): raise TransactionError("approval expired")
     def _read_doc_locked(self) -> Dict[str, Any]:
         self._check_paths()
         if not self.path.exists(): return {}
@@ -319,7 +323,7 @@ class ApprovalStore:
         try:
             doc=self._read_doc_locked()
             if approval_id not in doc: raise TransactionError("approval not found")
-            rec=ApprovalRecord(**doc[approval_id]); self._strict_record(rec)
+            rec=ApprovalRecord(**doc[approval_id]); self._strict_record_static(rec, allow_expired=(state=="expired"))
             if rec.state in {"consumed","rejected","expired","verification_failed","aborted","manual_recovery_required"}: raise TransactionError("approval already terminal")
             doc[approval_id]["used"] = True; doc[approval_id]["state"] = state
             self._write_doc_locked(doc)

--- a/src/vulcan/world_model/meta_reasoning/self_improvement_drive.py
+++ b/src/vulcan/world_model/meta_reasoning/self_improvement_drive.py
@@ -61,15 +61,35 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 # Initialize logger early - before it's used in import blocks
 logger = logging.getLogger(__name__)
 
+class AutoApplyStatus(str, Enum):
+    NOT_ATTEMPTED = "not_attempted"
+    UNAVAILABLE = "unavailable"
+    MISSING_GOVERNED_PROPOSAL = "missing_governed_proposal"
+    CONFIGURATION_MISSING = "configuration_missing"
+    GOVERNED_EXCEPTION = "governed_exception"
+    QUEUED = "queued"
+    APPLIED_AND_VERIFIED = "applied_and_verified"
+    REJECTED_BEFORE_INSTALLATION = "rejected_before_installation"
+    VERIFICATION_FAILED_ROLLBACK_SUCCEEDED = "verification_failed_rollback_succeeded"
+    VERIFICATION_FAILED_ROLLBACK_FAILED = "verification_failed_rollback_failed"
+    EXTERNAL_MUTATION_PREVENTED_ROLLBACK = "external_mutation_prevented_rollback"
+
 @dataclass(frozen=True)
 class AutoApplyResult:
     applied: bool
-    status: str
+    status: AutoApplyStatus
     reason: str
     approval_required: bool
     terminal: bool
     rollback_succeeded: bool = False
     manual_recovery_required: bool = False
+    transaction_result: Any = None
+    def __post_init__(self):
+        if isinstance(self.status, str):
+            object.__setattr__(self, "status", AutoApplyStatus(self.status))
+    @property
+    def status_code(self) -> str:
+        return self.status.value
 
 # ==========================================================================
 # CONSTANTS
@@ -934,6 +954,14 @@ class SelfImprovementDrive:
         state_path: str = "data/agent_state.json",
         alert_callback: Optional[Callable[[str, Dict[str, Any]], None]] = None,
         approval_checker: Optional[Callable[[str], Optional[str]]] = None,
+        csiu_enforcer: Any = None,
+        improvement_policy: Any = None,
+        approval_store: Any = None,
+        approval_verifier: Any = None,
+        audit_owner: Any = None,
+        owns_csiu_enforcer: bool = True,
+        owns_approval_store: bool = False,
+        owns_audit_owner: bool = False,
     ):
         """
         Initialize self-improvement drive.
@@ -950,6 +978,15 @@ class SelfImprovementDrive:
         self.alert_callback = alert_callback
         self.approval_checker = approval_checker
         self._lock = threading.RLock()
+        self._closed = False
+        self._owns_csiu_enforcer = bool(owns_csiu_enforcer and csiu_enforcer is None)
+        self._owns_approval_store = bool(owns_approval_store)
+        self._owns_audit_owner = bool(owns_audit_owner)
+        self.improvement_policy = improvement_policy
+        self.approval_store = approval_store
+        self.approval_verifier = approval_verifier
+        self.audit_owner = audit_owner
+        self._last_governed_transaction_result = None
         
         # FIX Issue 5: Track if blacklisted objectives have been logged (only log once)
         self._blacklist_logged = False
@@ -1033,13 +1070,15 @@ class SelfImprovementDrive:
         self._metrics_cache: Dict[str, Any] = {}
 
         # CSIU: Initialize enforcer with kill switches from environment
-        self._csiu_enforcer = None
-        if get_csiu_enforcer is not None and self._csiu_enabled:
+        self._csiu_enforcer = csiu_enforcer
+        if self._csiu_enforcer is None and get_csiu_enforcer is not None and self._csiu_enabled:
             enforcer_config = CSIUEnforcementConfig(
                 global_enabled=self._csiu_enabled,
                 calculation_enabled=self._csiu_calc_enabled,
                 regularization_enabled=self._csiu_regs_enabled,
                 history_tracking_enabled=self._csiu_hist_enabled,
+                durable_accounting_required=bool(self.config.get("constraints", {}).get("csiu_durable_accounting_required", False)),
+                durable_store_path=self.config.get("constraints", {}).get("csiu_durable_store_path"),
             )
             self._csiu_enforcer = get_csiu_enforcer(enforcer_config)
             logger.info("CSIU enforcement module initialized with safety controls")
@@ -1077,10 +1116,11 @@ class SelfImprovementDrive:
             logger.debug(f"Operation failed: {e}")
 
         self._auto_apply_policy = load_policy(policy_path)
-        self._auto_apply_enabled = bool(
-            self._auto_apply_policy.enabled
-            and not getattr(self, "require_human_approval", True)
-        )
+        constraints = self.config.get("constraints", {}) if isinstance(self.config, dict) else {}
+        self._governed_transactions_enabled = bool(constraints.get("governed_transactions_enabled", True))
+        self._unattended_application_permitted = bool(constraints.get("unattended_application_permitted", not self.require_human_approval))
+        self._independent_approval_required = bool(constraints.get("independent_approval_required", self.require_human_approval))
+        self._auto_apply_enabled = bool(self._auto_apply_policy.enabled and self._governed_transactions_enabled and (self._unattended_application_permitted or self._independent_approval_required))
 
         # PRIORITY 1: Safe Execution Module Integration
         # Initialize safe executor for sandboxed improvement execution
@@ -1152,6 +1192,31 @@ class SelfImprovementDrive:
         """
         self.__dict__.update(state)
         self._lock = threading.RLock()
+
+    def readiness(self) -> Tuple[bool, str]:
+        if self._closed:
+            return False, "self-improvement drive closed"
+        if self._csiu_enabled and self._csiu_enforcer is not None:
+            try:
+                self._csiu_enforcer.readiness()
+            except Exception as exc:
+                return False, f"csiu unavailable: {exc}"
+        if self._governed_transactions_enabled:
+            if self.improvement_policy is None or self.audit_owner is None:
+                return False, "governed improvement policy or audit owner missing"
+            if self._independent_approval_required and self.approval_store is None:
+                return False, "approval store missing"
+        return True, "ready"
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        for owner, owned in ((getattr(self, "_csiu_enforcer", None), self._owns_csiu_enforcer), (getattr(self, "approval_store", None), self._owns_approval_store), (getattr(self, "audit_owner", None), self._owns_audit_owner)):
+            if owned and owner is not None:
+                close = getattr(owner, "close", None)
+                if callable(close):
+                    close()
 
     # ---------- Helper Methods ----------
 
@@ -2810,6 +2875,9 @@ class SelfImprovementDrive:
         with self._lock:
             for approval in self.state.pending_approvals:
                 if approval["id"] == approval_id:
+                    if approval.get("status") == "pending_governed_approval" or "proposal_digest" in approval:
+                        logger.warning("Legacy approve_pending rejects governed approval records; use approve_governed_pending")
+                        return False
                     approval["status"] = "approved"
                     approval["approved_at"] = time.time()
                     self._save_state()
@@ -2893,7 +2961,13 @@ class SelfImprovementDrive:
                     if not verifier.is_authorized(principal, bindings):
                         return False
                     pid = principal.principal_id
-                    rec = ApprovalRecord(approval_id, approval["proposal_digest"], approval["policy_digest"], approval["original_source_digest"], pid, time.time(), time.time()+ttl_seconds)
+                    now = time.time()
+                    if isinstance(ttl_seconds, bool) or not isinstance(ttl_seconds, (int, float)) or not math.isfinite(float(ttl_seconds)) or float(ttl_seconds) <= 0:
+                        return False
+                    expires = min(principal.expires_at, now + min(float(ttl_seconds), 3600.0))
+                    if expires <= now:
+                        return False
+                    rec = ApprovalRecord(approval_id, approval["proposal_digest"], approval["policy_digest"], approval["original_source_digest"], pid, now, expires)
                     self.approval_store.save(rec)
                     approval["status"] = "independently_approved"; approval["approved_at"] = rec.approved_at; approval["approver_identity"] = pid
                     self._save_state(); return True
@@ -2910,8 +2984,8 @@ class SelfImprovementDrive:
         plan = {"id": pending.get("id"), "governed_proposal": proposal_map}
         auto_result = self._maybe_auto_apply(plan)
         applied, reason = auto_result.applied, auto_result.reason
-        result = getattr(self, "_last_governed_transaction_result", None)
-        status = result.status_code if result is not None else ("applied" if applied else reason)
+        result = auto_result.transaction_result
+        status = result.status_code if result is not None else auto_result.status_code
         with self._lock:
             pending["status"] = "applied" if applied else status
             pending["transaction_status"] = status
@@ -2937,16 +3011,16 @@ class SelfImprovementDrive:
     def _maybe_auto_apply(self, plan: Dict[str, Any]) -> AutoApplyResult:
         """Auto-apply only through GovernedSelfImprovementTransaction."""
         if not self._auto_apply_enabled:
-            return AutoApplyResult(False,"not_attempted","auto-apply disabled",True,False)
+            return AutoApplyResult(False,AutoApplyStatus.NOT_ATTEMPTED,"auto-apply disabled",True,False)
         if GovernedSelfImprovementTransaction is None or ImprovementProposal is None or inspect_repository is None:
-            return AutoApplyResult(False,"unavailable","governed transaction unavailable",True,False)
+            return AutoApplyResult(False,AutoApplyStatus.UNAVAILABLE,"governed transaction unavailable",True,False)
         proposal_map = plan.get("governed_proposal") or plan.get("improvement_proposal")
         policy = getattr(self, "improvement_policy", None) or getattr(self, "governed_improvement_policy", None)
         audit_owner = getattr(self, "audit_owner", None) or getattr(self, "audit", None)
         if not isinstance(proposal_map, dict):
-            return AutoApplyResult(False,"missing_governed_proposal","missing governed improvement proposal",True,False)
+            return AutoApplyResult(False,AutoApplyStatus.MISSING_GOVERNED_PROPOSAL,"missing governed improvement proposal",True,False)
         if policy is None or audit_owner is None:
-            return AutoApplyResult(False,"configuration_missing","governed transaction policy or audit owner missing",True,False)
+            return AutoApplyResult(False,AutoApplyStatus.CONFIGURATION_MISSING,"governed transaction policy or audit owner missing",True,False)
         try:
             proposal = ImprovementProposal.from_mapping(proposal_map)
             snapshot = inspect_repository(policy.repo_root, policy.permitted_path_globs, max_files=policy.max_files)
@@ -2954,13 +3028,13 @@ class SelfImprovementDrive:
             result = tx.apply(proposal, snapshot, actor="self-improvement-drive")
             self._last_governed_transaction_result = result
             if result.verified_success:
-                return AutoApplyResult(True,result.status_code,result.status_code,False,True)
+                return AutoApplyResult(True,AutoApplyStatus(result.status_code),result.status_code,False,True, transaction_result=result)
             if result.status_code == "rejected_before_installation" and result.failure_category == "approval required":
-                return AutoApplyResult(False,result.status_code,result.failure_category,True,False)
+                return AutoApplyResult(False,AutoApplyStatus(result.status_code),result.failure_category,True,False, transaction_result=result)
             manual = result.status_code in {"external_mutation_prevented_rollback","verification_failed_rollback_failed"}
-            return AutoApplyResult(False,result.status_code,result.failure_category or result.status_code,False,True,result.status_code=="verification_failed_rollback_succeeded",manual)
+            return AutoApplyResult(False,AutoApplyStatus(result.status_code),result.failure_category or result.status_code,False,True,result.status_code=="verification_failed_rollback_succeeded",manual,result)
         except Exception as e:
-            return AutoApplyResult(False,"governed_exception",f"governed transaction failed: {type(e).__name__}",False,True)
+            return AutoApplyResult(False,AutoApplyStatus.GOVERNED_EXCEPTION,f"governed transaction failed: {type(e).__name__}",False,True)
 
     # Where improvements are processed, insert a call to _maybe_auto_apply before queueing/approval
     def process_plan(self, plan: Dict[str, Any]) -> Dict[str, Any]:
@@ -2968,21 +3042,21 @@ class SelfImprovementDrive:
         Process a single improvement plan. Auto-apply if policy allows, otherwise queue for approval.
         """
         # ... any existing validation ...
-        result = AutoApplyResult(False,"queued","queued",True,False)
+        result = AutoApplyResult(False,AutoApplyStatus.QUEUED,"queued",True,False)
         if self._auto_apply_enabled:
             result = self._maybe_auto_apply(plan)
 
         if result.applied:
-            status = {"status": "applied", "plan_id": plan.get("id"), "reason": result.reason, "transaction_status": result.status}
+            status = {"status": "applied", "plan_id": plan.get("id"), "reason": result.reason, "transaction_status": result.status_code}
             logger.info(f"Auto-applied plan {plan.get('id')}")
             # Potentially call record_outcome here or let external orchestrator do it
         else:
             if self._auto_apply_enabled and result.terminal:
-                status = {"status": result.status, "plan_id": plan.get("id"), "reason": result.reason, "terminal": True, "rollback_succeeded": result.rollback_succeeded, "manual_recovery_required": result.manual_recovery_required}
+                status = {"status": result.status_code, "plan_id": plan.get("id"), "reason": result.reason, "terminal": True, "rollback_succeeded": result.rollback_succeeded, "manual_recovery_required": result.manual_recovery_required}
             elif result.approval_required:
                 status = self._queue_governed_approval(plan, result.reason)
             else:
-                status = {"status": result.status, "plan_id": plan.get("id"), "reason": result.reason}
+                status = {"status": result.status_code, "plan_id": plan.get("id"), "reason": result.reason}
 
         # Update state if your class tracks it
         try:
@@ -4563,3 +4637,13 @@ Output the complete modified file content.
             )
         
         return boosted_objectives
+
+
+def compose_self_improvement_drive(*, world_model: Any = None, config_path: Any = "configs/intrinsic_drives.json", state_path: str = "data/agent_state.json", alert_callback: Any = None, approval_checker: Any = None, csiu_enforcer: Any = None, improvement_policy: Any = None, approval_store: Any = None, approval_verifier: Any = None, audit_owner: Any = None) -> SelfImprovementDrive:
+    """Canonical public composition path for the governed CSIU drive.
+
+    The drive receives shared owners explicitly.  The drive closes only the CSIU
+    owner it creates itself; supplied owners remain the caller/container's close
+    responsibility.
+    """
+    return SelfImprovementDrive(world_model=world_model, config_path=config_path, state_path=state_path, alert_callback=alert_callback, approval_checker=approval_checker, csiu_enforcer=csiu_enforcer, improvement_policy=improvement_policy, approval_store=approval_store, approval_verifier=approval_verifier, audit_owner=audit_owner, owns_csiu_enforcer=(csiu_enforcer is None), owns_approval_store=False, owns_audit_owner=False)

--- a/src/vulcan/world_model/world_model_core.py
+++ b/src/vulcan/world_model/world_model_core.py
@@ -116,6 +116,7 @@ ObjectiveNegotiator = None
 ValidationTracker = None
 TransparencyInterface = None
 SelfImprovementDrive = None
+compose_self_improvement_drive = None
 TriggerType = None
 ImprovementObjective = None
 # Note: Add missing meta-reasoning components for full integration
@@ -294,7 +295,7 @@ from .self_improvement import CodeLLMClient
 
 
 def _lazy_import_meta_reasoning():
-    global MotivationalIntrospection, ObjectiveHierarchy, CounterfactualObjectiveReasoner, GoalConflictDetector, ObjectiveNegotiator, ValidationTracker, TransparencyInterface, SelfImprovementDrive, TriggerType, ImprovementObjective, InternalCritic, CuriosityRewardShaper, EthicalBoundaryMonitor, PreferenceLearner, ValueEvolutionTracker
+    global MotivationalIntrospection, ObjectiveHierarchy, CounterfactualObjectiveReasoner, GoalConflictDetector, ObjectiveNegotiator, ValidationTracker, TransparencyInterface, SelfImprovementDrive, compose_self_improvement_drive, TriggerType, ImprovementObjective, InternalCritic, CuriosityRewardShaper, EthicalBoundaryMonitor, PreferenceLearner, ValueEvolutionTracker
     if MotivationalIntrospection is None:
         try:
             from .meta_reasoning import (
@@ -305,6 +306,7 @@ def _lazy_import_meta_reasoning():
                 ObjectiveHierarchy,
                 ObjectiveNegotiator,
                 SelfImprovementDrive,
+                compose_self_improvement_drive,
                 TransparencyInterface,
                 TriggerType,
                 ValidationTracker,
@@ -816,7 +818,7 @@ class WorldModel:
                     hasattr(self, "_check_improvement_approval"),
                 )
 
-                self.self_improvement_drive = SelfImprovementDrive(
+                self.self_improvement_drive = compose_self_improvement_drive(
                     world_model=self,
                     config_path=config.get(
                         "self_improvement_config", "configs/intrinsic_drives.json"

--- a/tests/test_phase9b_csiu_persistence.py
+++ b/tests/test_phase9b_csiu_persistence.py
@@ -89,7 +89,7 @@ def test_concurrent_remaining_budget_race(tmp_path):
     barrier=threading.Barrier(2); results=[]
     def worker():
         barrier.wait()
-        now=e._clock(); tag=format(threading.get_ident() % 16, "x")
+        now=e._clock(); tag=("1" if threading.current_thread().name.endswith("0") else "2")
         to_high = base.metrics["A"] < 0.5
         nxt=CSIUMetricSnapshot(metrics={k:((1.0 if to_high else 0.0) if k in ("A","C","E","U") else (0.0 if to_high else 1.0)) for k in METRIC_ORDER}, window_start=(now-timedelta(minutes=5)).isoformat().replace("+00:00","Z"), window_end=now.isoformat().replace("+00:00","Z"), sample_count=30, aggregation_method="mean", metric_definition_version=e.policy.metric_definition_version, provider_id="p", provenance_digest=tag*64, policy_digest=e.policy.policy_digest)
         results.append(e.apply_regularization_from_snapshots(plan(),base,nxt,plan_id="p"))
@@ -98,7 +98,7 @@ def test_concurrent_remaining_budget_race(tmp_path):
     applied=sum(1 for _,d in results if d.applied); blocked=sum(1 for _,d in results if d.blocked)
     assert applied == 1
     assert blocked == 1
-    assert [d.reason_code for _,d in results if d.blocked] == ["cumulative_cap_exceeded"]
+    assert [d.reason_code for _,d in results if d.blocked] in (["previous_snapshot_digest_mismatch"], ["replayed_snapshot"])
     expected = first + abs(results[0][1].pressure or results[1][1].pressure)
     assert e.check_cumulative_influence()['cumulative_influence'] == pytest.approx(expected, abs=1e-12)
     pol=e.policy; e.close(); e2=CSIUEnforcement(cfg(store,c,cap=0.05,single=0.05), policy=pol)

--- a/tests/test_phase9d_governed_drive_e2e.py
+++ b/tests/test_phase9d_governed_drive_e2e.py
@@ -1,7 +1,7 @@
 import hashlib, os, time
 from datetime import datetime, timezone, timedelta
 
-from vulcan.world_model.meta_reasoning.self_improvement_drive import SelfImprovementDrive
+from vulcan.world_model.meta_reasoning.self_improvement_drive import compose_self_improvement_drive
 from vulcan.world_model.meta_reasoning.csiu_enforcement import METRIC_ORDER, CSIUMetricSnapshot, reset_csiu_enforcer
 from vulcan.world_model.meta_reasoning.governed_transaction import (
     ApprovalStore, ImprovementPolicy, ImprovementProposal, VerificationGate,
@@ -10,11 +10,19 @@ from vulcan.world_model.meta_reasoning.governed_transaction import (
 )
 from vulcan.runtime.audit import CanonicalAudit
 
+class MutableVerifier(ClosedApprovalVerifier):
+    def __init__(self):
+        self.principals={}
+        super().__init__(self.principals)
+    def is_authorized(self, principal, bindings):
+        self._principals=dict(self.principals)
+        return super().is_authorized(principal, bindings)
+
 
 def sha(s): return hashlib.sha256(s.encode()).hexdigest()
 
 def cfg():
-    return {"drives":{"self_improvement":{"enabled":True,"priority":1,"objectives":[{"type":"bugfix","weight":1.0}],"constraints":{"require_human_approval":True,"max_changes_per_session":5},"triggers":[],"resource_limits":{}}}}
+    return {"drives":{"self_improvement":{"enabled":True,"priority":1,"objectives":[{"type":"bugfix","weight":1.0}],"constraints":{"require_human_approval":True,"governed_transactions_enabled":True,"unattended_application_permitted":True,"independent_approval_required":True,"max_changes_per_session":5},"triggers":[],"resource_limits":{}}}}
 
 def mk_drive(tmp_path, gate):
     reset_csiu_enforcer()
@@ -22,8 +30,13 @@ def mk_drive(tmp_path, gate):
     pol=ImprovementPolicy('auto-apply-policy/2',True,repo,('bugfix',),('src/*.py',),(),1,1000,10,True,{'deterministic':('rel',)},(gate,),5,2000,True)
     snap=inspect_repository(repo,('src/*.py',))
     prop=ImprovementProposal(SCHEMA_VERSION,'prop-1','bugfix','src/t.py',sha('X=1\n'),'X=1\n','X=2\n',sha('X=2\n'),snap.digest,'deterministic','rel','proof',pol.digest,'')
-    drive=SelfImprovementDrive(config_path=cfg(), state_path=str(tmp_path/'state.json'))
-    drive.improvement_policy=pol; drive.approval_store=ApprovalStore(tmp_path/'approvals.json'); drive.audit_owner=CanonicalAudit(tmp_path/'audit.jsonl'); drive._auto_apply_enabled=True
+    policy_file=tmp_path/'auto_policy.json'
+    policy_file.write_text('{"auto_apply": {"enabled": true}}', encoding='utf-8')
+    os.environ['VULCAN_AUTO_APPLY_POLICY']=str(policy_file)
+    verifier=MutableVerifier()
+    store=ApprovalStore(tmp_path/'approvals.json')
+    audit=CanonicalAudit(tmp_path/'audit.jsonl')
+    drive=compose_self_improvement_drive(config_path=cfg(), state_path=str(tmp_path/'state.json'), improvement_policy=pol, approval_store=store, approval_verifier=verifier, audit_owner=audit)
     obj=drive.objectives[0]
     drive.should_trigger=lambda ctx: True
     drive.select_objective=lambda: obj
@@ -48,24 +61,24 @@ def mk_drive(tmp_path, gate):
     assert d1.reason_code=="baseline_established"
     assert drive._csiu_enforcer.check_cumulative_influence()["cumulative_influence"]==0
     phase['n']=2
-    return repo, drive, prop
+    return repo, drive, prop, verifier.principals
 
-def issue_for(drive, approval_id):
+def issue_for(drive, approval_id, verifier_map):
     pending=next(a for a in drive.state.pending_approvals if a["approval_id"]==approval_id)
     bindings={"approval_id":approval_id,"proposal_digest":pending["proposal_digest"],"policy_digest":pending["policy_digest"],"original_source_digest":pending["original_source_digest"],"required_scope":"self_improvement.approve"}
     principal=ApprovalIssuer().issue_principal("independent-reviewer",("self_improvement.approve",),bindings=bindings,ttl_seconds=60)
-    drive.approval_verifier=ClosedApprovalVerifier({principal.principal_id:principal})
+    verifier_map[principal.principal_id]=principal
     return principal
 
 def test_governed_drive_e2e_step_approval_resume_success(tmp_path, monkeypatch):
     monkeypatch.setenv('INTRINSIC_CSIU_OFF','0'); monkeypatch.setenv(DISABLED_ENV,'0')
-    repo, drive, prop = mk_drive(tmp_path, VerificationGate('pycompile',('python','-m','py_compile','src/t.py')))
+    repo, drive, prop, verifier_map = mk_drive(tmp_path, VerificationGate('pycompile',('python','-m','py_compile','src/t.py')))
     original=(repo/'src/t.py').read_bytes()
     action=drive.step({'force':True})
     assert action['status']=='pending_governed_approval' and action['_wait_for_approval'] is True
     assert action['approval_id'] and action['proposal_digest']==prop.digest()
     assert (repo/'src/t.py').read_bytes()==original
-    assert drive.approve_governed_pending(action['approval_id'], issue_for(drive, action['approval_id']))
+    assert drive.approve_governed_pending(action['approval_id'], issue_for(drive, action['approval_id'], verifier_map))
     resumed=drive.resume_governed_pending(action['approval_id'])
     assert resumed['status']==TransactionStatus.APPLIED_AND_VERIFIED.value
     assert (repo/'src/t.py').read_text()=='X=2\n'
@@ -85,10 +98,10 @@ def test_governed_drive_e2e_step_approval_resume_success(tmp_path, monkeypatch):
 
 def test_governed_drive_e2e_step_approval_resume_rollback(tmp_path, monkeypatch):
     monkeypatch.setenv('INTRINSIC_CSIU_OFF','0'); monkeypatch.setenv(DISABLED_ENV,'0')
-    repo, drive, prop = mk_drive(tmp_path, VerificationGate('fail',('python','-c','import sys; sys.exit(1)')))
+    repo, drive, prop, verifier_map = mk_drive(tmp_path, VerificationGate('fail',('python','-c','import sys; sys.exit(1)')))
     action=drive.step({'force':True})
     assert action['status']=='pending_governed_approval'
-    assert drive.approve_governed_pending(action['approval_id'], issue_for(drive, action['approval_id']))
+    assert drive.approve_governed_pending(action['approval_id'], issue_for(drive, action['approval_id'], verifier_map))
     resumed=drive.resume_governed_pending(action['approval_id'])
     assert resumed['status']==TransactionStatus.VERIFICATION_FAILED_ROLLBACK_SUCCEEDED.value
     assert (repo/'src/t.py').read_text()=='X=1\n'


### PR DESCRIPTION
### Motivation
- Make the governed CSIU runtime path real and production-safe by wiring explicit owners and factory composition instead of relying on test-time mutation or ad-hoc construction. 
- Ensure CSIU cursor transitions and regularization are atomic and restart-safe, and prevent approval lifecycle corruption from expired or caller-controlled values. 
- Separate governed-transaction enablement, unattended application permission, and independent-approval requirement so valid external approvals allow resume without disabling resume semantics. 

### Description
- Add explicit constructor/factory dependencies to `SelfImprovementDrive` for `csiu_enforcer`, `improvement_policy`, `approval_store`, `approval_verifier` (verifier-only port), and `audit_owner`, plus ownership flags and `readiness`/`close` behavior to avoid double-closing shared owners. 
- Introduce public factory `compose_self_improvement_drive(...)` and update runtime construction sites to use it (singleton and `WorldModel` wiring now call the factory instead of constructing the drive directly). 
- Make CSIU snapshot operations enter under the enforcer lock by wrapping `observe_telemetry_snapshots` and `apply_regularization_from_snapshots` with an authoritative lock and add alignment cooldown persistence adjacent to the durable CSIU store. 
- Harden approval store and approval record handling by tightening validation, allowing reading/terminalizing expired records without poisoning other records, enforcing key==record.approval_id, and bounding approval TTLs to the principal expiry during `approve_governed_pending`. 
- Convert auto-apply return model to a closed `AutoApplyStatus` enum and make `_maybe_auto_apply` carry the actual `TransactionResult` so `resume_governed_pending` uses the current attempt result rather than stale state. 
- Prevent legacy `approve_pending()` from incorrectly approving governed records and update tests to compose the drive only via the public factory (no private attribute mutation). 
- Tests and small test harness adjustments to use deterministic provenance tags and verifier injection to assert atomic cursor/CAS outcomes and real-path governed-drive flows. 

### Testing
- Ran the Phase-9 test matrix: `PYTHONPATH=src pytest -q tests/test_phase9_csiu.py tests/test_phase9b_csiu_persistence.py tests/test_phase9b_alignment_bridge.py tests/test_phase9d_csiu_snapshot_state.py tests/test_phase9d_approval_atomicity.py tests/test_phase9d_alignment_review.py tests/test_phase9d_governed_drive_e2e.py tests/test_phase9f_regressions.py tests/test_phase9g_runtime_ownership.py tests/test_csiu_enforcement_integration.py tests/test_governed_self_improvement_transaction.py tests/security/test_persistent_audit_alignment.py` — result: 74 passed, 1 skipped. 
- Ran focused suites: `tests/test_phase9d_governed_drive_e2e.py` — passed (2 tests), `tests/test_phase9b_csiu_persistence.py::test_concurrent_remaining_budget_race` — passed (concurrent CAS behavior asserted), and `tests/test_csiu_enforcement_integration.py` — passed (7 passed, 1 skipped). 
- Performed bytecode checks with `python -m compileall -q src tests` and `python -O -m compileall -q src tests`, and ran `git diff --check`, all succeeded. 

Notes: the legacy `src/vulcan/tests/test_self_improvement_drive.py` test collection was observed (142 nodes) but a full run of that slow legacy suite was interrupted by environment time constraints and therefore not fully executed here; real-path governed-drive tests and the Phase‑9 focused suites that exercise ownership, approval lifecycle, CSIU atomicity, and restart persistence were updated and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5be26c94f0832f8e881446378fed81)