### PR TITLE
Introduce typed RuntimeSettings authority

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,18 +68,40 @@ ANTHROPIC_API_KEY=sk-ant-...your-anthropic-key...
 # Graphix API Key (Optional - for Graphix services)
 GRAPHIX_API_KEY=...your-graphix-key...
 
+
 ################################################################################
-# JWT & Security Configuration (Required)
+# Canonical RuntimeSettings authority (P06)
+################################################################################
+VULCAN_ENV=development
+VULCAN_JWT_SECRET=replace-with-32-plus-char-secret-from-openssl-rand-base64-48
+VULCAN_JWT_ISSUER=vulcan
+VULCAN_JWT_AUDIENCE=vulcan-runtime
+VULCAN_RUNTIME_DURABLE_ROOT=/var/lib/vulcan/runtime
+VULCAN_LANGUAGE_MODE=deterministic_only
+VULCAN_MEMORY_ENABLED=1
+VULCAN_MEMORY_BACKEND=sqlite
+VULCAN_MEMORY_SQLITE_PATH=/var/lib/vulcan/runtime/memory/memory.sqlite
+VULCAN_AUDIT_ENABLED=1
+VULCAN_CSIU_ENABLED=1
+VULCAN_LEARNING_ENABLED=1
+VULCAN_ENABLE_SELF_IMPROVEMENT=0
+VULCAN_APPROVAL_HMAC_SECRET=replace-with-32-plus-char-approval-hmac-secret
+VULCAN_RUNTIME_REPLICAS=1
+VULCAN_REQUEST_TIMEOUT_SECONDS=30
+VULCAN_PUBLIC_DIAGNOSTICS=0
+
+################################################################################
+# JWT & Security Configuration (Deprecated aliases; prefer VULCAN_JWT_SECRET)
 ################################################################################
 
 # JWT Secret Key (Required)
 # Used for JWT token generation and validation
 # Generate with: openssl rand -base64 48
 # NOTE: This is a placeholder value only, not a real secret
-JWT_SECRET_KEY=your-jwt-secret-key-here
+JWT_SECRET_KEY=${VULCAN_JWT_SECRET}
 
 # Graphix JWT Secret (used by api_server.py)
-GRAPHIX_JWT_SECRET=${JWT_SECRET_KEY}
+GRAPHIX_JWT_SECRET=${VULCAN_JWT_SECRET}
 
 # Bootstrap Key (Required)
 # Used for initial system bootstrap and authentication

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -322,9 +322,8 @@ services:
       - VECLIB_MAXIMUM_THREADS=${VECLIB_MAXIMUM_THREADS:-4}
       - NUMEXPR_NUM_THREADS=${NUMEXPR_NUM_THREADS:-4}
       - TOKENIZERS_PARALLELISM=${TOKENIZERS_PARALLELISM:-false}
-      - JWT_SECRET_KEY=${JWT_SECRET_KEY:-dev-jwt-secret-key-change-in-production-minimum-32-chars}
-      - JWT_SECRET=${JWT_SECRET:-dev-jwt-secret-key-change-in-production-minimum-32-chars}
-      - GRAPHIX_JWT_SECRET=${GRAPHIX_JWT_SECRET:-dev-jwt-secret-key-change-in-production-minimum-32-chars}
+      - VULCAN_JWT_SECRET=${VULCAN_JWT_SECRET:-dev-jwt-secret-key-change-in-production-minimum-32-chars}
+      - VULCAN_RUNTIME_DURABLE_ROOT=${VULCAN_RUNTIME_DURABLE_ROOT:-/var/lib/vulcan/runtime}
       - BOOTSTRAP_KEY=${BOOTSTRAP_KEY:-dev-bootstrap-key-change-in-production}
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -222,9 +222,8 @@ services:
       - ENVIRONMENT=production
       - VERSION=${VERSION:-latest}
       - PORT=8000
-      - JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY is required}
-      - JWT_SECRET=${JWT_SECRET_KEY:?JWT_SECRET_KEY is required}
-      - GRAPHIX_JWT_SECRET=${JWT_SECRET_KEY:?JWT_SECRET_KEY is required}
+      - VULCAN_JWT_SECRET=${VULCAN_JWT_SECRET:?VULCAN_JWT_SECRET is required}
+      - VULCAN_RUNTIME_DURABLE_ROOT=${VULCAN_RUNTIME_DURABLE_ROOT:-/var/lib/vulcan/runtime}
       - BOOTSTRAP_KEY=${BOOTSTRAP_KEY:?BOOTSTRAP_KEY is required}
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432
@@ -431,7 +430,7 @@ services:
     environment:
       - ENVIRONMENT=production
       - VERSION=${VERSION:-latest}
-      - JWT_SECRET_KEY=${JWT_SECRET_KEY:?JWT_SECRET_KEY is required}
+      - VULCAN_JWT_SECRET=${VULCAN_JWT_SECRET:?VULCAN_JWT_SECRET is required}
       - BOOTSTRAP_KEY=${BOOTSTRAP_KEY:?BOOTSTRAP_KEY is required}
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -112,7 +112,7 @@ SECRET_OK=0
 SELECTED=""
 EXPIRY_NOTE="(rotate secrets periodically)"
 
-for VAR in GRAPHIX_JWT_SECRET JWT_SECRET_KEY JWT_SECRET; do
+for VAR in VULCAN_JWT_SECRET GRAPHIX_JWT_SECRET JWT_SECRET_KEY JWT_SECRET; do
   VAL="$(get_env "$VAR")"
   if [ -n "$VAL" ]; then
     if validate_secret "$VAR" "$VAL"; then
@@ -130,7 +130,7 @@ if [ "$SECRET_OK" -ne 1 ]; then
   cat >&2 <<'EOF'
 ERROR: No valid JWT secret provided.
 Production serving refuses to downgrade into limited/no-auth mode.
-Provide one STRONG secret (>=32 chars, not common/weak) via GRAPHIX_JWT_SECRET, JWT_SECRET_KEY, or JWT_SECRET.
+Provide one STRONG secret (>=32 chars, not common/weak) via VULCAN_JWT_SECRET. Deprecated aliases GRAPHIX_JWT_SECRET, JWT_SECRET_KEY, and JWT_SECRET are accepted for one migration window only.
 EOF
   exit 78
 else
@@ -142,6 +142,10 @@ fi
 export VULCAN_ENV="${VULCAN_ENV:-production}"
 export VULCAN_SAFETY_LEVEL="${VULCAN_SAFETY_LEVEL:-strict}"
 export VULCAN_ENABLE_SELF_IMPROVEMENT="${VULCAN_ENABLE_SELF_IMPROVEMENT:-false}"
+export VULCAN_RUNTIME_DURABLE_ROOT="${VULCAN_RUNTIME_DURABLE_ROOT:-/var/lib/vulcan/runtime}"
+export VULCAN_MEMORY_ENABLED="${VULCAN_MEMORY_ENABLED:-1}"
+export VULCAN_MEMORY_BACKEND="${VULCAN_MEMORY_BACKEND:-sqlite}"
+export VULCAN_MEMORY_SQLITE_PATH="${VULCAN_MEMORY_SQLITE_PATH:-$VULCAN_RUNTIME_DURABLE_ROOT/memory/memory.sqlite}"
 
 # Execute main process
 exec "$@"

--- a/helm/vulcanami/templates/deployment.yaml
+++ b/helm/vulcanami/templates/deployment.yaml
@@ -91,11 +91,33 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         env:
-        - name: JWT_SECRET_KEY
+        - name: VULCAN_JWT_SECRET
           valueFrom:
             secretKeyRef:
               name: {{ include "vulcanami.fullname" . }}-secrets
               key: jwtSecretKey
+        - name: VULCAN_ENV
+          value: {{ .Values.runtime.environment | quote }}
+        - name: VULCAN_JWT_ISSUER
+          value: {{ .Values.runtime.jwtIssuer | quote }}
+        - name: VULCAN_JWT_AUDIENCE
+          value: {{ .Values.runtime.jwtAudience | quote }}
+        - name: VULCAN_RUNTIME_DURABLE_ROOT
+          value: {{ .Values.runtime.durableRoot | quote }}
+        - name: VULCAN_LANGUAGE_MODE
+          value: {{ .Values.runtime.languageMode | quote }}
+        - name: VULCAN_AUDIT_ENABLED
+          value: {{ .Values.runtime.auditEnabled | quote }}
+        - name: VULCAN_CSIU_ENABLED
+          value: {{ .Values.runtime.csiuEnabled | quote }}
+        - name: VULCAN_LEARNING_ENABLED
+          value: {{ .Values.runtime.learningEnabled | quote }}
+        - name: VULCAN_ENABLE_SELF_IMPROVEMENT
+          value: {{ .Values.runtime.selfImprovementEnabled | quote }}
+        - name: VULCAN_REQUEST_TIMEOUT_SECONDS
+          value: {{ .Values.runtime.requestTimeoutSeconds | quote }}
+        - name: VULCAN_PUBLIC_DIAGNOSTICS
+          value: {{ .Values.runtime.publicDiagnostics | quote }}
         - name: BOOTSTRAP_KEY
           valueFrom:
             secretKeyRef:

--- a/helm/vulcanami/values.yaml
+++ b/helm/vulcanami/values.yaml
@@ -31,6 +31,20 @@ image:
   # If digest is provided, it will be appended to the tag
   digest: ""  # Example: "sha256:abc123def456..."
 
+
+runtime:
+  environment: production
+  jwtIssuer: vulcan
+  jwtAudience: vulcan-runtime
+  durableRoot: /var/lib/vulcan/runtime
+  languageMode: deterministic_only
+  auditEnabled: true
+  csiuEnabled: true
+  learningEnabled: true
+  selfImprovementEnabled: false
+  requestTimeoutSeconds: 30
+  publicDiagnostics: false
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/src/vulcan/runtime/app.py
+++ b/src/vulcan/runtime/app.py
@@ -1,6 +1,6 @@
 """Canonical statically-composed authenticated ASGI application."""
 from __future__ import annotations
-import asyncio, json, os
+import asyncio, json
 from contextlib import asynccontextmanager
 from uuid import uuid4
 try:
@@ -39,6 +39,7 @@ except Exception:  # pragma: no cover
 from .auth import AuthConfig, AuthError, AuthorizationError, authenticate_bearer
 from .case import CognitiveCase
 from .composition import compose_runtime
+from .settings import load_runtime_settings
 from .kernel import KernelRequest
 from .semantic import Utterance
 from vulcan.memory.governed import MemoryActorContext, MemoryKind, MemoryReadRequest, MemoryWriteProposal, MemoryReason
@@ -46,15 +47,15 @@ from vulcan.memory.governed import MemoryActorContext, MemoryKind, MemoryReadReq
 MAX_BODY=16_384
 ABSENT_ETAG='"absent"'
 
-def _auth_config_from_env()->AuthConfig:
-    return AuthConfig(secret=os.getenv('VULCAN_JWT_SECRET') or os.getenv('GRAPHIX_JWT_SECRET') or os.getenv('JWT_SECRET') or '', issuer=os.getenv('VULCAN_JWT_ISSUER','vulcan'), audience=os.getenv('VULCAN_JWT_AUDIENCE','vulcan-runtime'))
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    app.state.ready=False; app.state.runtime=None; app.state.auth_config=None; runtime=None
+    app.state.ready=False; app.state.runtime=None; app.state.auth_config=None; app.state.runtime_settings=None; runtime=None
     try:
-        app.state.auth_config=_auth_config_from_env()
-        runtime=await asyncio.to_thread(compose_runtime)
+        settings=load_runtime_settings()
+        app.state.runtime_settings=settings
+        app.state.auth_config=settings.auth_config()
+        runtime=await asyncio.to_thread(compose_runtime, settings)
         await runtime.readiness(); app.state.runtime=runtime; app.state.ready=True
         yield
     except BaseException:
@@ -128,7 +129,10 @@ def create_app()->FastAPI:
     async def live(): return {'status':'alive'}
     @app.get('/health/ready')
     async def ready(request:Request):
-        try: rt=await _runtime(request); return {'status':'ready','runtime_id':rt.runtime_id,'learning_owner_id':rt.learning_owner.owner_id,'learning_status':rt.learning_owner.capability.value,'capabilities':list(rt.capabilities()),'learning_capabilities':[c.__dict__ | {'status': c.status.value, 'readiness_state': c.readiness_state.value} for c in rt.learning_owner.capability_matrix()]}
+        try:
+            rt=await _runtime(request)
+            diagnostics = rt.settings.public_dict() if rt.settings.public_diagnostics else {'environment': rt.settings.environment.value, 'settings_schema': rt.settings.schema()['schema_version']}
+            return {'status':'ready','runtime_id':rt.runtime_id,'diagnostics':diagnostics,'learning_owner_id':rt.learning_owner.owner_id,'learning_status':rt.learning_owner.capability.value,'capabilities':list(rt.capabilities()),'learning_capabilities':[c.__dict__ | {'status': c.status.value, 'readiness_state': c.readiness_state.value} for c in rt.learning_owner.capability_matrix()]}
         except HTTPException: return JSONResponse(status_code=503, content={'status':'not_ready'})
     @app.get('/v1/capabilities')
     async def capabilities():

--- a/src/vulcan/runtime/composition.py
+++ b/src/vulcan/runtime/composition.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 from types import SimpleNamespace
 from .container import RuntimeContainer
+from .settings import RuntimeSettings
 
 class _FallbackSafety:
     def readiness(self): return True
@@ -19,12 +20,12 @@ class _FallbackDeployment:
     def readiness(self): return True
     def close(self): pass
 
-def compose_runtime() -> RuntimeContainer:
-    """Construct the deployment graph; legacy endpoint orchestration is unreachable."""
+def compose_runtime(settings: RuntimeSettings) -> RuntimeContainer:
+    """Construct the deployment graph from the already-parsed settings authority."""
     try:
         from vulcan.config import get_config
         from vulcan.orchestrator.deployment import ProductionDeployment
         deployment=ProductionDeployment(get_config())
     except Exception:
         deployment=_FallbackDeployment()
-    return RuntimeContainer.new(deployment=deployment)
+    return RuntimeContainer.new(deployment=deployment, settings=settings)

--- a/src/vulcan/runtime/container.py
+++ b/src/vulcan/runtime/container.py
@@ -6,9 +6,8 @@ from dataclasses import dataclass
 from typing import Any, Literal
 from uuid import uuid4
 from pathlib import Path
-import os
 
-from vulcan.memory.governed import GovernedMemoryPort, compose_governed_memory
+from vulcan.memory.governed import GovernedMemoryPort, MemoryRuntimeConfig, compose_governed_memory
 from vulcan.learning_owner import LearningCapabilityStatus, LearningOwner
 from vulcan.learning_bandit import ShadowLinUCBToolBandit
 
@@ -20,6 +19,7 @@ from .kernel import CognitiveKernel
 from .output import DeterministicLanguageOutput, LanguageOutputPort
 from .semantic import DeterministicLanguageInput, LanguageInputPort
 from .self_improvement import SelfImprovementRuntime, compose_self_improvement_runtime
+from .settings import RuntimeSettings
 
 
 LanguageMode = Literal["disabled", "deterministic_only", "transformer_proposal"]
@@ -41,28 +41,6 @@ class LanguageRuntimeConfig:
                 raise RuntimeError("transformer mode requires an absolute approved release path")
         return self
 
-def _validated_durable_root(value: object) -> str:
-    if not isinstance(value, str) or not value:
-        raise RuntimeError("VULCAN_RUNTIME_DURABLE_ROOT is required for persistent runtime capabilities")
-    p = Path(value)
-    if not p.is_absolute():
-        raise RuntimeError("durable root must be absolute")
-    resolved = p.resolve(strict=False)
-    repo = Path(__file__).resolve().parents[3]
-    forbidden = {Path('/'), Path('/tmp'), Path.home(), repo.resolve()}
-    if resolved in forbidden or str(resolved).startswith(str(repo.resolve()) + os.sep):
-        raise RuntimeError("unsafe durable root rejected")
-    cur = Path('/')
-    for part in resolved.parts[1:]:
-        cur = cur / part
-        if cur.exists() and cur.is_symlink():
-            raise RuntimeError("symlinked durable root component rejected")
-    resolved.mkdir(parents=True, exist_ok=True)
-    if resolved.is_symlink():
-        raise RuntimeError("symlinked durable root rejected")
-    return str(resolved)
-
-
 @dataclass
 class RuntimeContainer:
     runtime_id: str
@@ -80,6 +58,7 @@ class RuntimeContainer:
     durable_root: Path | None = None
     self_improvement: SelfImprovementRuntime | None = None
     learning_owner: LearningOwner | None = None
+    settings: RuntimeSettings | None = None
     closed: bool = False
 
     async def close(self) -> None:
@@ -178,7 +157,7 @@ class RuntimeContainer:
         return result
 
     @classmethod
-    def new(cls, *, deployment: Any, language_config: LanguageRuntimeConfig | None = None) -> "RuntimeContainer":
+    def new(cls, *, deployment: Any, settings: RuntimeSettings, language_config: LanguageRuntimeConfig | None = None) -> "RuntimeContainer":
         deps = getattr(getattr(deployment, "collective", None), "deps", None)
         world_state = getattr(deps, "world_model", None)
         if world_state is None:
@@ -186,7 +165,7 @@ class RuntimeContainer:
         safety = getattr(deps, "safety_validator", None)
         if safety is None:
             raise RuntimeError("required safety finalization service is unavailable")
-        config = (language_config or LanguageRuntimeConfig()).validated()
+        config = (language_config or LanguageRuntimeConfig(settings.language_mode.value, str(settings.language_release_path) if settings.language_release_path else None)).validated()
         # Deterministic remains default/fallback; transformer mode is admitted only after strict release verification.
         language_input: LanguageInputPort = DeterministicLanguageInput()
         if config.mode == "transformer_proposal":
@@ -195,15 +174,16 @@ class RuntimeContainer:
             from vulcan.local_language import build_verified_adapter
             language_input = build_verified_adapter(release_root=config.release_path or "", provider_factory=config.provider_factory)
         language_output: LanguageOutputPort = DeterministicLanguageOutput()
-        memory = compose_governed_memory()
-        root = _validated_durable_root(os.getenv("VULCAN_RUNTIME_DURABLE_ROOT") or getattr(deployment, "runtime_root", None) or getattr(deployment, "data_dir", None))
+        memory = compose_governed_memory(MemoryRuntimeConfig(settings.memory_enabled, settings.memory_sqlite_path, settings.durable_root, settings.replicas, settings.memory_backend.value))
+        root = str(settings.durable_root)
+        Path(root).mkdir(parents=True, exist_ok=True)
         audit = alignment = domain_registry = self_improvement = None
         try:
             memory.readiness()
             audit = CanonicalAudit(f"{root}/audit/events.jsonl")
             alignment = AlignmentRegistry(f"{root}/alignment/active.json", audit=audit)
             domain_registry = PersistentDomainRegistry(f"{root}/domains", audit=audit)
-            self_improvement = compose_self_improvement_runtime(durable_root=Path(root), audit=audit, alignment=alignment, world_model=world_state)
+            self_improvement = compose_self_improvement_runtime(durable_root=Path(root), audit=audit, alignment=alignment, world_model=world_state, approval_hmac_secret=settings.approval_hmac_secret.reveal() if settings.approval_hmac_secret else None)
             shadow_bandit = ShadowLinUCBToolBandit()
             learning_owner = LearningOwner(
                 capability=LearningCapabilityStatus.SHADOW,
@@ -221,7 +201,7 @@ class RuntimeContainer:
             kernel = CognitiveKernel(state_authority=world_state, finalizer=SafetyResponseFinalizer(safety),
                                      language_input=language_input, language_output=language_output, memory=memory, audit=audit, alignment=alignment)
             return cls(str(uuid4()), deployment, world_state, kernel, safety, memory,
-                       language_input, language_output, config, audit, alignment, domain_registry, Path(root), self_improvement, learning_owner)
+                       language_input, language_output, config, audit, alignment, domain_registry, Path(root), self_improvement, learning_owner, settings)
         except Exception:
             for r in (locals().get("learning_owner"), self_improvement, domain_registry, alignment, audit, memory, language_output, language_input):
                 if r is not None:

--- a/src/vulcan/runtime/self_improvement.py
+++ b/src/vulcan/runtime/self_improvement.py
@@ -1,7 +1,7 @@
 """Canonical runtime-owned self-improvement graph."""
 from __future__ import annotations
 
-import hashlib, hmac, json, os, time
+import hashlib, hmac, json, time
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -59,9 +59,9 @@ class PersistentImprovementJournal:
 class SelfImprovementRuntime:
     durable_root: Path; audit: Any; alignment: Any; csiu: CSIUEnforcement; policy: ImprovementPolicy; approval_store: ApprovalStore; approval_authority: ApprovalAuthority; verifier: Any; journal: PersistentImprovementJournal; transaction: GovernedSelfImprovementTransaction; drive: Any; telemetry: AggregateCSIUTelemetryPort; status_port: CSIUStatusPort
     def readiness(self) -> bool:
-        assert self.drive._csiu_enforcer is self.csiu
-        assert self.transaction.audit is self.audit
-        assert self.drive.transaction is self.transaction
+        if self.drive._csiu_enforcer is not self.csiu: raise RuntimeError("CSIU authority mismatch")
+        if self.transaction.audit is not self.audit: raise RuntimeError("audit authority mismatch")
+        if self.drive.transaction is not self.transaction: raise RuntimeError("transaction authority mismatch")
         self.csiu.readiness(); self.journal.readiness(); self.approval_store._check_paths()
         return True
     def capabilities(self) -> tuple[str,...]:
@@ -71,13 +71,15 @@ class SelfImprovementRuntime:
 def build_default_policy(repo: Path) -> ImprovementPolicy:
     return ImprovementPolicy('vulcan-improvement-policy/1', True, repo, ('fix_known_bugs','improve_test_coverage','optimize_performance','enhance_safety_systems','fix_circular_imports'), ('src/**/*.py','tests/**/*.py'), ('.git/**','data/**','logs/**'), 1, 50000, 200, True, {}, (VerificationGate('compile-target', ('python','-m','compileall','-q','src'), 30.0),), 30.0, 20000, True)
 
-def compose_self_improvement_runtime(*, durable_root: Path, audit: Any, alignment: Any, world_model: Any) -> SelfImprovementRuntime:
+def compose_self_improvement_runtime(*, durable_root: Path, audit: Any, alignment: Any, world_model: Any, approval_hmac_secret: str | None) -> SelfImprovementRuntime:
     repo=Path(__file__).resolve().parents[3]
     policy=build_default_policy(repo)
     csiu_store=durable_root/'csiu'/'accounting.jsonl'; csiu_store.parent.mkdir(parents=True, exist_ok=True); csiu_store.touch(exist_ok=True)
     csiu=CSIUEnforcement(CSIUEnforcementConfig(durable_store_path=str(csiu_store), durable_accounting_required=True))
     approvals=ApprovalStore(durable_root/'approvals'/'approvals.json')
-    authority=ApprovalAuthority(approvals, os.getenv('VULCAN_APPROVAL_HMAC_SECRET','dev-secret-change-me').encode())
+    if approval_hmac_secret is None:
+        approval_hmac_secret = 'development-approval-hmac-secret-change-me-32'
+    authority=ApprovalAuthority(approvals, approval_hmac_secret.encode())
     journal=PersistentImprovementJournal(durable_root/'improvements'/'journal.jsonl')
     tx=GovernedSelfImprovementTransaction(policy, audit, approvals)
     drive=compose_self_improvement_drive(world_model=world_model, csiu_enforcer=csiu, improvement_policy=policy, approval_store=approvals, approval_verifier=authority, audit_owner=audit)

--- a/src/vulcan/runtime/settings.py
+++ b/src/vulcan/runtime/settings.py
@@ -1,0 +1,172 @@
+"""One immutable authority for canonical runtime process settings."""
+from __future__ import annotations
+
+import json, os, re
+from dataclasses import dataclass, field, fields, is_dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Mapping
+
+_CTL = re.compile(r"[\x00-\x1f\x7f]")
+_TRUE={"1","true","yes","on"}; _FALSE={"0","false","no","off"}
+
+class SettingsError(ValueError): pass
+class VulcanEnvironment(str, Enum): development="development"; test="test"; production="production"
+class LanguageMode(str, Enum): disabled="disabled"; deterministic_only="deterministic_only"; transformer_proposal="transformer_proposal"
+class MemoryBackend(str, Enum): disabled="disabled"; sqlite="sqlite"
+class SecretSource(str, Enum): direct="direct"; file="file"
+
+@dataclass(frozen=True, repr=False)
+class OpaqueSecret:
+    source: SecretSource
+    value: str = field(repr=False)
+    env_name: str = ""
+    def reveal(self) -> str: return self.value
+    def __repr__(self)->str: return "OpaqueSecret(**redacted**)"
+    def to_public(self)->dict[str,str]: return {"source": self.source.value, "env_name": self.env_name, "redacted": "true"}
+
+@dataclass(frozen=True)
+class RuntimeSettings:
+    environment: VulcanEnvironment
+    jwt_issuer: str
+    jwt_audience: str
+    jwt_secret: OpaqueSecret = field(repr=False)
+    durable_root: Path
+    language_mode: LanguageMode = LanguageMode.deterministic_only
+    language_release_path: Path|None = None
+    openai_enabled: bool = False
+    anthropic_enabled: bool = False
+    memory_enabled: bool = True
+    memory_backend: MemoryBackend = MemoryBackend.sqlite
+    memory_sqlite_path: Path|None = None
+    audit_enabled: bool = True
+    csiu_enabled: bool = True
+    learning_enabled: bool = True
+    self_improvement_enabled: bool = False
+    approval_hmac_secret: OpaqueSecret|None = field(default=None, repr=False)
+    replicas: int = 1
+    request_timeout_seconds: float = 30.0
+    public_diagnostics: bool = False
+    deprecation_warnings: tuple[str,...] = ()
+
+    def auth_config(self):
+        from .auth import AuthConfig
+        return AuthConfig(secret=self.jwt_secret.reveal(), issuer=self.jwt_issuer, audience=self.jwt_audience)
+    def public_dict(self)->dict[str,object]: return _public(self)
+    def schema(self)->dict[str,object]: return generate_settings_schema()
+
+ALIASES={
+ "VULCAN_ENV": ("VULCAN_ENV",),
+ "VULCAN_JWT_SECRET": ("VULCAN_JWT_SECRET","GRAPHIX_JWT_SECRET","JWT_SECRET_KEY","JWT_SECRET"),
+ "VULCAN_JWT_ISSUER": ("VULCAN_JWT_ISSUER",),
+ "VULCAN_JWT_AUDIENCE": ("VULCAN_JWT_AUDIENCE",),
+ "VULCAN_RUNTIME_DURABLE_ROOT": ("VULCAN_RUNTIME_DURABLE_ROOT",),
+ "VULCAN_LANGUAGE_MODE": ("VULCAN_LANGUAGE_MODE",),
+ "VULCAN_LANGUAGE_RELEASE_PATH": ("VULCAN_LANGUAGE_RELEASE_PATH","VULCAN_TEXT_MODEL_REVISION"),
+ "OPENAI_API_KEY": ("OPENAI_API_KEY",),
+ "ANTHROPIC_API_KEY": ("ANTHROPIC_API_KEY",),
+ "VULCAN_MEMORY_ENABLED": ("VULCAN_MEMORY_ENABLED",),
+ "VULCAN_MEMORY_BACKEND": ("VULCAN_MEMORY_BACKEND",),
+ "VULCAN_MEMORY_SQLITE_PATH": ("VULCAN_MEMORY_SQLITE_PATH",),
+ "VULCAN_AUDIT_ENABLED": ("VULCAN_AUDIT_ENABLED",),
+ "VULCAN_CSIU_ENABLED": ("VULCAN_CSIU_ENABLED","INTRINSIC_CSIU_OFF"),
+ "VULCAN_LEARNING_ENABLED": ("VULCAN_LEARNING_ENABLED",),
+ "VULCAN_ENABLE_SELF_IMPROVEMENT": ("VULCAN_ENABLE_SELF_IMPROVEMENT","ENABLE_SELF_IMPROVEMENT"),
+ "VULCAN_APPROVAL_HMAC_SECRET": ("VULCAN_APPROVAL_HMAC_SECRET",),
+ "VULCAN_RUNTIME_REPLICAS": ("VULCAN_RUNTIME_REPLICAS",),
+ "VULCAN_REQUEST_TIMEOUT_SECONDS": ("VULCAN_REQUEST_TIMEOUT_SECONDS","HYBRID_EXECUTOR_TIMEOUT"),
+ "VULCAN_PUBLIC_DIAGNOSTICS": ("VULCAN_PUBLIC_DIAGNOSTICS",),
+}
+DEPRECATED={"GRAPHIX_JWT_SECRET":"VULCAN_JWT_SECRET","JWT_SECRET_KEY":"VULCAN_JWT_SECRET","JWT_SECRET":"VULCAN_JWT_SECRET","ENABLE_SELF_IMPROVEMENT":"VULCAN_ENABLE_SELF_IMPROVEMENT","HYBRID_EXECUTOR_TIMEOUT":"VULCAN_REQUEST_TIMEOUT_SECONDS","INTRINSIC_CSIU_OFF":"VULCAN_CSIU_ENABLED","VULCAN_TEXT_MODEL_REVISION":"VULCAN_LANGUAGE_RELEASE_PATH"}
+
+def _select(env:Mapping[str,str], canonical:str, warnings:list[str])->str|None:
+    found=[(n,env[n]) for n in ALIASES[canonical] if env.get(n) not in (None,"")]
+    if not found: return None
+    vals={v for _,v in found}
+    if len(vals)>1: raise SettingsError(f"conflicting values for {canonical}")
+    for n,_ in found:
+        if n in DEPRECATED: warnings.append(f"deprecated environment variable {n}; use {DEPRECATED[n]}")
+    return found[0][1]
+
+def _text(v:str|None, name:str, default:str|None=None)->str:
+    v = default if v is None else v
+    if not isinstance(v,str) or not v or len(v)>256 or _CTL.search(v): raise SettingsError(f"invalid {name}")
+    return v
+
+def _bool(v:str|None, name:str, default:bool)->bool:
+    if v is None: return default
+    lv=v.lower()
+    if lv in _TRUE: return True
+    if lv in _FALSE: return False
+    if name=="VULCAN_CSIU_ENABLED" and lv in _TRUE|_FALSE: return not (lv in _TRUE)
+    raise SettingsError(f"invalid boolean for {name}")
+
+def _int(v:str|None, name:str, default:int, lo:int, hi:int)->int:
+    if v is None: return default
+    try: x=int(v)
+    except ValueError: raise SettingsError(f"invalid integer for {name}") from None
+    if not lo<=x<=hi: raise SettingsError(f"out-of-range integer for {name}")
+    return x
+
+def _float(v:str|None, name:str, default:float, lo:float, hi:float)->float:
+    if v is None: return default
+    try: x=float(v)
+    except ValueError: raise SettingsError(f"invalid float for {name}") from None
+    if not lo<=x<=hi: raise SettingsError(f"out-of-range float for {name}")
+    return x
+
+def _path(v:str|None, name:str, required:bool)->Path|None:
+    if v is None:
+        if required: raise SettingsError(f"{name} is required")
+        return None
+    p=Path(v)
+    if not p.is_absolute(): raise SettingsError(f"{name} must be absolute")
+    r=p.resolve(strict=False); repo=Path(__file__).resolve().parents[3]
+    if r in {Path('/'),Path('/tmp'),Path.home(),repo.resolve()} or str(r).startswith(str(repo.resolve())+os.sep): raise SettingsError(f"unsafe {name}")
+    cur=Path('/')
+    for part in r.parts[1:]:
+        cur=cur/part
+        if cur.exists() and cur.is_symlink(): raise SettingsError(f"symlinked {name}")
+    return r
+
+def _secret(value:str|None, name:str, *, required:bool)->OpaqueSecret|None:
+    if value is None:
+        if required: raise SettingsError(f"{name} is required")
+        return None
+    if len(value.encode())<32 or value.lower() in {"changeme","secret","password","dev-secret-change-me"}: raise SettingsError(f"weak secret for {name}")
+    return OpaqueSecret(SecretSource.direct, value, name)
+
+def load_runtime_settings(env:Mapping[str,str]|None=None)->RuntimeSettings:
+    env=dict(os.environ if env is None else env); warnings=[]
+    get=lambda n: _select(env,n,warnings)
+    environment=VulcanEnvironment(_text(get("VULCAN_ENV"),"VULCAN_ENV","development"))
+    durable=_path(get("VULCAN_RUNTIME_DURABLE_ROOT"),"VULCAN_RUNTIME_DURABLE_ROOT", True)
+    lang=LanguageMode(_text(get("VULCAN_LANGUAGE_MODE"),"VULCAN_LANGUAGE_MODE","deterministic_only"))
+    release=_path(get("VULCAN_LANGUAGE_RELEASE_PATH"),"VULCAN_LANGUAGE_RELEASE_PATH", lang is LanguageMode.transformer_proposal)
+    jwt=_secret(get("VULCAN_JWT_SECRET"),"VULCAN_JWT_SECRET", required=True)
+    approval=_secret(get("VULCAN_APPROVAL_HMAC_SECRET"),"VULCAN_APPROVAL_HMAC_SECRET", required=environment is VulcanEnvironment.production)
+    replicas=_int(get("VULCAN_RUNTIME_REPLICAS"),"VULCAN_RUNTIME_REPLICAS",1,1,1)
+    self_imp=_bool(get("VULCAN_ENABLE_SELF_IMPROVEMENT"),"VULCAN_ENABLE_SELF_IMPROVEMENT",False)
+    csiu_val=get("VULCAN_CSIU_ENABLED"); csiu = (not _bool(csiu_val,"VULCAN_CSIU_ENABLED",False)) if "INTRINSIC_CSIU_OFF" in env and "VULCAN_CSIU_ENABLED" not in env else _bool(csiu_val,"VULCAN_CSIU_ENABLED",True)
+    if environment is VulcanEnvironment.production and (not csiu or not _bool(get("VULCAN_AUDIT_ENABLED"),"VULCAN_AUDIT_ENABLED",True)):
+        raise SettingsError("production requires audit and CSIU")
+    if self_imp and approval is None: raise SettingsError("self-improvement requires approval HMAC secret")
+    mem_enabled=_bool(get("VULCAN_MEMORY_ENABLED"),"VULCAN_MEMORY_ENABLED",True)
+    mem_backend=MemoryBackend(_text(get("VULCAN_MEMORY_BACKEND"),"VULCAN_MEMORY_BACKEND","sqlite" if mem_enabled else "disabled"))
+    mem_path=_path(get("VULCAN_MEMORY_SQLITE_PATH") or (str(durable/"memory"/"memory.sqlite") if mem_enabled else None),"VULCAN_MEMORY_SQLITE_PATH", mem_enabled)
+    return RuntimeSettings(environment,_text(get("VULCAN_JWT_ISSUER"),"VULCAN_JWT_ISSUER","vulcan"),_text(get("VULCAN_JWT_AUDIENCE"),"VULCAN_JWT_AUDIENCE","vulcan-runtime"),jwt,durable,lang,release,get("OPENAI_API_KEY") is not None,get("ANTHROPIC_API_KEY") is not None,mem_enabled,mem_backend,mem_path,_bool(get("VULCAN_AUDIT_ENABLED"),"VULCAN_AUDIT_ENABLED",True),csiu,_bool(get("VULCAN_LEARNING_ENABLED"),"VULCAN_LEARNING_ENABLED",True),self_imp,approval,replicas,_float(get("VULCAN_REQUEST_TIMEOUT_SECONDS"),"VULCAN_REQUEST_TIMEOUT_SECONDS",30.0,0.1,300.0),_bool(get("VULCAN_PUBLIC_DIAGNOSTICS"),"VULCAN_PUBLIC_DIAGNOSTICS",False),tuple(warnings[:16]))
+
+def _public(v):
+    if isinstance(v,OpaqueSecret): return v.to_public()
+    if isinstance(v,Enum): return v.value
+    if isinstance(v,Path): return str(v)
+    if is_dataclass(v): return {f.name:_public(getattr(v,f.name)) for f in fields(v)}
+    if isinstance(v,tuple): return [_public(x) for x in v]
+    return v
+
+def generate_settings_schema()->dict[str,object]:
+    return {"schema_version":"vulcan-runtime-settings/1","environment_variables":{k:{"aliases":list(v),"deprecated":[a for a in v if a in DEPRECATED]} for k,v in ALIASES.items()},"fields":[f.name for f in fields(RuntimeSettings)],"secret_fields":["jwt_secret","approval_hmac_secret"]}
+
+def generate_environment_reference()->str:
+    lines=["# Vulcan runtime environment reference", json.dumps(generate_settings_schema(), sort_keys=True, indent=2)]
+    return "\n".join(lines)+"\n"

--- a/tests/runtime/test_settings_contract.py
+++ b/tests/runtime/test_settings_contract.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from vulcan.runtime.settings import RuntimeSettings, SettingsError, generate_settings_schema, load_runtime_settings
+
+SECRET = "x" * 40
+APPROVAL = "y" * 40
+
+def env(tmp_path: Path, **overrides: str) -> dict[str, str]:
+    base = {
+        "VULCAN_ENV": "development",
+        "VULCAN_JWT_SECRET": SECRET,
+        "VULCAN_RUNTIME_DURABLE_ROOT": str(tmp_path / "runtime"),
+        "VULCAN_MEMORY_SQLITE_PATH": str(tmp_path / "runtime" / "memory" / "memory.sqlite"),
+    }
+    base.update(overrides)
+    return base
+
+@pytest.mark.parametrize("alias", ["GRAPHIX_JWT_SECRET", "JWT_SECRET_KEY", "JWT_SECRET"])
+def test_deprecated_jwt_aliases_are_bounded_and_redacted(tmp_path: Path, alias: str) -> None:
+    data = env(tmp_path)
+    data.pop("VULCAN_JWT_SECRET")
+    data[alias] = SECRET
+    settings = load_runtime_settings(data)
+    assert settings.jwt_secret.reveal() == SECRET
+    assert alias in settings.deprecation_warnings[0]
+    assert SECRET not in repr(settings)
+    assert SECRET not in str(settings.public_dict())
+
+@pytest.mark.parametrize("canonical,alias", [("VULCAN_ENABLE_SELF_IMPROVEMENT", "ENABLE_SELF_IMPROVEMENT"), ("VULCAN_REQUEST_TIMEOUT_SECONDS", "HYBRID_EXECUTOR_TIMEOUT")])
+def test_deprecated_nonsecret_aliases_match_canonical_value(tmp_path: Path, canonical: str, alias: str) -> None:
+    value = "1" if canonical == "VULCAN_ENABLE_SELF_IMPROVEMENT" else "1.0"
+    settings = load_runtime_settings(env(tmp_path, **{canonical: value, alias: value, "VULCAN_APPROVAL_HMAC_SECRET": APPROVAL}))
+    assert alias in " ".join(settings.deprecation_warnings)
+
+@pytest.mark.parametrize("bad", ["", "short", "dev-secret-change-me"])
+def test_weak_jwt_secret_rejected_without_leaking_value(tmp_path: Path, bad: str) -> None:
+    with pytest.raises(SettingsError) as exc:
+        load_runtime_settings(env(tmp_path, VULCAN_JWT_SECRET=bad))
+    if bad:
+        assert bad not in str(exc.value)
+    assert "weak secret" in str(exc.value) or "required" in str(exc.value)
+
+def test_conflicting_aliases_fail_closed(tmp_path: Path) -> None:
+    with pytest.raises(SettingsError, match="conflicting values for VULCAN_JWT_SECRET"):
+        load_runtime_settings(env(tmp_path, GRAPHIX_JWT_SECRET="z" * 40))
+
+def test_production_requires_approval_secret_and_csiu(tmp_path: Path) -> None:
+    with pytest.raises(SettingsError, match="required"):
+        load_runtime_settings(env(tmp_path, VULCAN_ENV="production"))
+    with pytest.raises(SettingsError, match="production requires"):
+        load_runtime_settings(env(tmp_path, VULCAN_ENV="production", VULCAN_APPROVAL_HMAC_SECRET=APPROVAL, VULCAN_CSIU_ENABLED="0"))
+    settings = load_runtime_settings(env(tmp_path, VULCAN_ENV="production", VULCAN_APPROVAL_HMAC_SECRET=APPROVAL))
+    assert settings.environment.value == "production"
+
+@pytest.mark.parametrize("key,value", [("VULCAN_LANGUAGE_MODE", "provider"), ("VULCAN_MEMORY_BACKEND", "redis"), ("VULCAN_RUNTIME_REPLICAS", "2"), ("VULCAN_REQUEST_TIMEOUT_SECONDS", "999")])
+def test_invalid_enums_topology_and_bounds_rejected(tmp_path: Path, key: str, value: str) -> None:
+    with pytest.raises((SettingsError, ValueError)):
+        load_runtime_settings(env(tmp_path, **{key: value}))
+
+def test_transformer_mode_requires_absolute_release(tmp_path: Path) -> None:
+    with pytest.raises(SettingsError, match="VULCAN_LANGUAGE_RELEASE_PATH"):
+        load_runtime_settings(env(tmp_path, VULCAN_LANGUAGE_MODE="transformer_proposal", VULCAN_LANGUAGE_RELEASE_PATH="relative"))
+
+def test_schema_docs_entrypoint_helm_and_fields_share_names() -> None:
+    schema = generate_settings_schema()
+    canonical = set(schema["environment_variables"])
+    entrypoint = Path("entrypoint.sh").read_text()
+    helm = Path("helm/vulcanami/templates/deployment.yaml").read_text()
+    example = Path(".env.example").read_text()
+    fields = set(schema["fields"])
+    assert set(RuntimeSettings.__dataclass_fields__) == fields
+    for name in ["VULCAN_ENV", "VULCAN_JWT_SECRET", "VULCAN_RUNTIME_DURABLE_ROOT", "VULCAN_MEMORY_ENABLED", "VULCAN_CSIU_ENABLED"]:
+        assert name in canonical
+        assert name in entrypoint or name in helm
+        assert name in example


### PR DESCRIPTION
### Motivation
- Replace scattered ad-hoc environment parsing with a single immutable, validated settings authority to remove contradictory defaults and fail closed at trust boundaries.
- Ensure secrets are opaque and never leaked in diagnostics, and provide a machine-readable schema/reference for entrypoints, Helm, and tests.

### Description
- Add `src/vulcan/runtime/settings.py` defining `RuntimeSettings`, typed enums, `OpaqueSecret`, alias handling, deprecation warnings, validation helpers, `load_runtime_settings()`, and generated schema/reference helpers.
- Parse settings once on ASGI startup and inject the parsed `RuntimeSettings` into composition and runtime (`src/vulcan/runtime/app.py`, `src/vulcan/runtime/composition.py`, `src/vulcan/runtime/container.py`) so business logic no longer reads environment directly for these concerns.
- Wire governed-memory, durable-root ownership, language-mode selection, and self-improvement approval-secret via settings (adapt `compose_governed_memory` usage and `compose_self_improvement_runtime`), and replace `assert` checks in self-improvement readiness with explicit `RuntimeError` failures.
- Update runtime entrypoint, `.env.example`, docker-compose, and Helm values/templates to prefer canonical `VULCAN_*` names while retaining deprecated aliases for a bounded migration window, and add `tests/runtime/test_settings_contract.py` covering aliasing, conflicts, redaction, production constraints, bounds, and schema coverage.

### Testing
- Ran `python -m pytest -q tests/runtime/test_settings_contract.py` which passed (16 tests passing).
- Ran `python -m compileall -q src` and `git diff --check`, both of which succeeded with no issues reported.
- Attempted broader import tests with `python -m pytest -q tests/test_import_redirects.py tests/test_platform_shell.py ...` which reported unrelated import failures due to missing optional local dependencies (`numpy`, `fastapi`) in the environment; the settings contract tests still passed in that run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d788098a8832f9d8be82e56c28d88)