### PR TITLE
Unify JWT secret selection, enforce strength, and harden HS256 auth

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -322,7 +322,7 @@ services:
       - VECLIB_MAXIMUM_THREADS=${VECLIB_MAXIMUM_THREADS:-4}
       - NUMEXPR_NUM_THREADS=${NUMEXPR_NUM_THREADS:-4}
       - TOKENIZERS_PARALLELISM=${TOKENIZERS_PARALLELISM:-false}
-      - VULCAN_JWT_SECRET=${VULCAN_JWT_SECRET:-dev-jwt-secret-key-change-in-production-minimum-32-chars}
+      - VULCAN_JWT_SECRET=${VULCAN_JWT_SECRET:?VULCAN_JWT_SECRET is required; generate with openssl rand -base64 48}
       - VULCAN_RUNTIME_DURABLE_ROOT=${VULCAN_RUNTIME_DURABLE_ROOT:-/var/lib/vulcan/runtime}
       - BOOTSTRAP_KEY=${BOOTSTRAP_KEY:-dev-bootstrap-key-change-in-production}
       - POSTGRES_HOST=postgres
@@ -650,7 +650,7 @@ services:
       - MINIO_ENDPOINT=http://minio:9000
       - MINIO_ACCESS_KEY=${MINIO_ROOT_USER:-minioadmin}
       - MINIO_SECRET_KEY=${MINIO_ROOT_PASSWORD:-minioadmin123}
-      - JWT_SECRET=${JWT_SECRET:-dev_secret_change_in_production}
+      - VULCAN_JWT_SECRET=${VULCAN_JWT_SECRET:?VULCAN_JWT_SECRET is required; generate with openssl rand -base64 48}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
     ports:
       - "8000:8000"  # API

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,8 +54,9 @@ echo "Thread limits set: OMP=$OMP_NUM_THREADS, MKL=$MKL_NUM_THREADS, TORCH=$TORC
 # ============================================================================
 # JWT SECRET VALIDATION (Security Best Practice)
 # ============================================================================
-INSECURE_DEFAULTS="super-secret-key insecure-dev-secret default-super-secret-key-change-me changeme password secret admin"
+INSECURE_DEFAULTS="super-secret-key insecure-dev-secret default-super-secret-key-change-me changeme password secret admin dev-secret-change-me"
 MIN_LENGTH=32
+JWT_SECRET_NAMES="VULCAN_JWT_SECRET GRAPHIX_JWT_SECRET JWT_SECRET_KEY JWT_SECRET"
 
 get_env() {
   var_name="$1"
@@ -71,72 +72,73 @@ is_weak() {
       return 0
     fi
   done
-  # Very naive pattern checks (extend as needed)
   case "$lower" in
-    *"123456"*|*"password"*|*"qwerty"*|*"letmein"*|*"jwtsecret"*|*"graphixsecret"*)
-      return 0
-      ;;
+    *"123456"*|*"password"*|*"qwerty"*|*"letmein"*|*"jwtsecret"*|*"graphixsecret"*|*"change-in-production"*) return 0 ;;
   esac
+  uniq_count=$(printf '%s' "$val" | fold -w1 | sort -u | wc -l | tr -d ' ')
+  classes=0
+  printf '%s' "$val" | grep -q '[a-z]' && classes=$((classes + 1))
+  printf '%s' "$val" | grep -q '[A-Z]' && classes=$((classes + 1))
+  printf '%s' "$val" | grep -q '[0-9]' && classes=$((classes + 1))
+  printf '%s' "$val" | grep -q '[^A-Za-z0-9]' && classes=$((classes + 1))
+  if [ "$uniq_count" -lt 12 ] && [ "$classes" -lt 3 ]; then
+    return 0
+  fi
   return 1
 }
 
-is_urlsafe() {
-  # Basic check: only URL-safe base64 chars plus length > 0
-  # We allow any printable char; stronger checks can be added.
-  val="$1"
-  echo "$val" | grep -Eq '^[A-Za-z0-9_\-]+$'
-}
-
 validate_secret() {
-  name="$1"
-  value="$2"
-  if [ -z "$value" ]; then
+  value="$1"
+  if [ -z "$value" ]; then return 1; fi
+  if [ "${#value}" -lt "$MIN_LENGTH" ]; then
+    echo "ERROR: JWT secret configuration is invalid." >&2
     return 1
   fi
-  if [ "${#value}" -lt "$MIN_LENGTH" ]; then
-    echo "ERROR: $name is too short (< $MIN_LENGTH chars)." >&2
+  if printf '%s' "$value" | LC_ALL=C grep -q '[[:cntrl:]]'; then
+    echo "ERROR: JWT secret configuration is invalid." >&2
     return 1
   fi
   if is_weak "$value"; then
-    echo "ERROR: $name matches known weak pattern." >&2
+    echo "ERROR: JWT secret configuration is invalid." >&2
     return 1
-  fi
-  # Warn (do not fail) if not urlsafe
-  if ! is_urlsafe "$value"; then
-    echo "WARNING: $name contains characters outside URL-safe set. (Acceptable but consider using urlsafe token)" >&2
   fi
   return 0
 }
 
-SECRET_OK=0
-SELECTED=""
-EXPIRY_NOTE="(rotate secrets periodically)"
-
-for VAR in VULCAN_JWT_SECRET GRAPHIX_JWT_SECRET JWT_SECRET_KEY JWT_SECRET; do
+FOUND_NAMES=""
+UNIQUE_VALUES_FILE="${TMPDIR:-/tmp}/vulcan-jwt-values.$$"
+: > "$UNIQUE_VALUES_FILE"
+for VAR in $JWT_SECRET_NAMES; do
   VAL="$(get_env "$VAR")"
   if [ -n "$VAL" ]; then
-    if validate_secret "$VAR" "$VAL"; then
-      SECRET_OK=1
-      SELECTED="$VAR"
-      break
-    else
-      echo "Validation failed for $VAR." >&2
-      SECRET_OK=0
-    fi
+    FOUND_NAMES="$FOUND_NAMES $VAR"
+    printf '%s\n' "$VAL" >> "$UNIQUE_VALUES_FILE"
   fi
 done
 
-if [ "$SECRET_OK" -ne 1 ]; then
+if [ ! -s "$UNIQUE_VALUES_FILE" ]; then
+  rm -f "$UNIQUE_VALUES_FILE"
   cat >&2 <<'EOF'
 ERROR: No valid JWT secret provided.
 Production serving refuses to downgrade into limited/no-auth mode.
-Provide one STRONG secret (>=32 chars, not common/weak) via VULCAN_JWT_SECRET. Deprecated aliases GRAPHIX_JWT_SECRET, JWT_SECRET_KEY, and JWT_SECRET are accepted for one migration window only.
+Provide one STRONG secret (>=32 chars, high entropy, not a placeholder) via VULCAN_JWT_SECRET. Deprecated aliases GRAPHIX_JWT_SECRET, JWT_SECRET_KEY, and JWT_SECRET are accepted for one migration window only when they carry the same single value.
 EOF
   exit 78
-else
-  echo "Verified JWT secret in variable: $SELECTED $EXPIRY_NOTE"
-  export JWT_VALIDATION_MODE="enabled"
 fi
+UNIQUE_COUNT=$(sort -u "$UNIQUE_VALUES_FILE" | wc -l | tr -d ' ')
+SELECTED_VALUE=$(sed -n '1p' "$UNIQUE_VALUES_FILE")
+rm -f "$UNIQUE_VALUES_FILE"
+if [ "$UNIQUE_COUNT" -ne 1 ]; then
+  echo "ERROR: Conflicting JWT secret configuration." >&2
+  exit 78
+fi
+if ! validate_secret "$SELECTED_VALUE"; then
+  echo "ERROR: No valid JWT secret provided." >&2
+  exit 78
+fi
+export VULCAN_JWT_SECRET="$SELECTED_VALUE"
+echo "Verified canonical JWT secret configuration (rotate secrets periodically)"
+export JWT_VALIDATION_MODE="enabled"
 
 # Execute production-owned safety/profile defaults
 export VULCAN_ENV="${VULCAN_ENV:-production}"

--- a/helm/vulcanami/templates/deployment.yaml
+++ b/helm/vulcanami/templates/deployment.yaml
@@ -95,7 +95,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: {{ include "vulcanami.fullname" . }}-secrets
-              key: jwtSecretKey
+              key: vulcanJwtSecret
         - name: VULCAN_ENV
           value: {{ .Values.runtime.environment | quote }}
         - name: VULCAN_JWT_ISSUER

--- a/helm/vulcanami/templates/secret.yaml
+++ b/helm/vulcanami/templates/secret.yaml
@@ -6,10 +6,10 @@ metadata:
     {{- include "vulcanami.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- if .Values.secrets.jwtSecretKey }}
-  jwtSecretKey: {{ .Values.secrets.jwtSecretKey | b64enc | quote }}
+  {{- if .Values.secrets.vulcanJwtSecret }}
+  vulcanJwtSecret: {{ .Values.secrets.vulcanJwtSecret | b64enc | quote }}
   {{- else }}
-  {{- fail "secrets.jwtSecretKey is required" }}
+  {{- fail "secrets.vulcanJwtSecret is required" }}
   {{- end }}
   {{- if .Values.secrets.bootstrapKey }}
   bootstrapKey: {{ .Values.secrets.bootstrapKey | b64enc | quote }}

--- a/helm/vulcanami/values.yaml
+++ b/helm/vulcanami/values.yaml
@@ -431,7 +431,7 @@ persistence:
 # Secrets (REQUIRED: Must be set via --set-string or external secret management)
 # Empty values will cause deployment validation to fail
 secrets:
-  jwtSecretKey: ""  # REQUIRED
+  vulcanJwtSecret: ""  # REQUIRED
   bootstrapKey: ""  # REQUIRED
   postgresPassword: ""  # REQUIRED
   redisPassword: ""  # REQUIRED

--- a/src/vulcan/runtime/auth.py
+++ b/src/vulcan/runtime/auth.py
@@ -1,34 +1,53 @@
-"""Dependency-light strict HS256 bearer authentication for canonical runtime."""
+"""Dependency-light strict HS256 bearer authentication for canonical runtime.
+
+Rotation strategy: issue tokens with a canonical ``jti`` and the active ``kid``.
+Keep the previous key in ``keyring`` only for the shorter of max token lifetime or the
+planned overlap window, then remove it.  Do not accept unsigned tokens, dynamic key
+URLs, caller-supplied JWKs, duplicate JSON keys, or algorithms other than HS256.
+"""
 from __future__ import annotations
 import base64, binascii, hashlib, hmac, json, math, re, time, unicodedata
-from dataclasses import dataclass
-from typing import Callable, Iterable
+from dataclasses import dataclass, field
+from typing import Callable, Mapping
 
 _B64=re.compile(r"^[A-Za-z0-9_-]+$")
 _CTL=re.compile(r"[\x00-\x1f\x7f]")
-KEY_FIELDS={"jku","jwk","kid","x5u","x5c","x5t","x5t#S256","crit"}
+FORBIDDEN_KEY_FIELDS={"jku","jwk","x5u","x5c","x5t","x5t#S256","crit"}
 MAX_HEADER=8192; MAX_JWT=6144; MAX_SEG=2048; MAX_JSON=4096; MAX_CLAIMS=32; MAX_LIST=16; MAX_TEXT=256
+MAX_TOKEN_LIFETIME_SECONDS=3600
+_JTI=re.compile(r"^[A-Za-z0-9_-]{16,128}$")
+_KID=re.compile(r"^[A-Za-z0-9_.-]{1,64}$")
 class AuthError(ValueError): pass
 class AuthorizationError(AuthError): pass
 @dataclass(frozen=True)
 class AuthConfig:
-    secret: str; issuer: str; audience: str; skew_seconds:int=60; require_typ:bool=True; tenant_claim:str="tenant"
+    secret: str; issuer: str; audience: str; skew_seconds:int=60; require_typ:bool=True; tenant_claim:str="tenant"; key_version:str="v1"; keyring:Mapping[str,str]=field(default_factory=dict); max_token_lifetime_seconds:int=MAX_TOKEN_LIFETIME_SECONDS
     def __post_init__(self):
-        if len(self.secret.encode('utf-8'))<32: raise AuthError("strong JWT secret required")
+        _validate_secret(self.secret)
         for v in (self.issuer,self.audience,self.tenant_claim): _text(v,MAX_TEXT,"config")
-        if not (0<=self.skew_seconds<=300): raise AuthError("invalid auth skew")
+        if not (0<=self.skew_seconds<=300): raise AuthError("invalid auth configuration")
+        if not (60<=self.max_token_lifetime_seconds<=86400): raise AuthError("invalid auth configuration")
+        _kid(self.key_version)
+        kr=dict(self.keyring or {})
+        kr.setdefault(self.key_version,self.secret)
+        for k,v in kr.items(): _kid(k); _validate_secret(v)
+        object.__setattr__(self,"keyring",kr)
 @dataclass(frozen=True)
 class AuthenticatedPrincipal:
-    subject:str; tenant:str; issuer:str; audience:tuple[str,...]; scopes:frozenset[str]
+    subject:str; tenant:str; issuer:str; audience:tuple[str,...]; scopes:frozenset[str]; jti:str; key_version:str
     def require(self, scope:str)->None:
         if scope not in self.scopes: raise AuthorizationError("missing required scope")
 
+def _validate_secret(v):
+    if not isinstance(v,str) or len(v.encode('utf-8'))<32 or v.lower() in {"changeme","secret","password","dev-secret-change-me"}: raise AuthError("invalid auth configuration")
+def _kid(v):
+    if not isinstance(v,str) or not _KID.fullmatch(v): raise AuthError("invalid auth configuration")
+    return v
 def _text(v,max_len,name):
     if not isinstance(v,str) or not v or len(v)>max_len: raise AuthError(f"invalid {name}")
     n=unicodedata.normalize('NFC',v)
     if n!=v or _CTL.search(n) or any(0xD800<=ord(c)<=0xDFFF for c in n): raise AuthError(f"invalid {name}")
     return n
-
 def _b64(seg):
     if not isinstance(seg,str) or not seg or len(seg)>MAX_SEG or '=' in seg or not _B64.fullmatch(seg): raise AuthError("invalid JWT encoding")
     try: raw=base64.urlsafe_b64decode(seg+'='*((4-len(seg)%4)%4))
@@ -36,7 +55,6 @@ def _b64(seg):
     if not raw or len(raw)>MAX_JSON: raise AuthError("decoded JWT segment too large")
     if base64.urlsafe_b64encode(raw).rstrip(b'=').decode('ascii')!=seg: raise AuthError("noncanonical JWT encoding")
     return raw
-
 def _loads(raw):
     def pairs(p):
         if len(p)>MAX_CLAIMS: raise AuthError("too many claims")
@@ -50,11 +68,9 @@ def _loads(raw):
     except (UnicodeDecodeError,json.JSONDecodeError) as e: raise AuthError("invalid JWT JSON") from e
     if not isinstance(obj,dict): raise AuthError("JWT object required")
     return obj
-
 def _finite_time(o,name):
     if type(o) not in (int,float) or not math.isfinite(o): raise AuthError(f"invalid {name}")
     return float(o)
-
 def _aud(v):
     if isinstance(v,str): return (_text(v,MAX_TEXT,"audience"),)
     if isinstance(v,list) and 1<=len(v)<=MAX_LIST:
@@ -62,7 +78,6 @@ def _aud(v):
         if len(set(vals))!=len(vals): raise AuthError("duplicate audience")
         return vals
     raise AuthError("invalid audience")
-
 def _scopes(v):
     if isinstance(v,str): vals=tuple(x for x in v.split(' ') if x)
     elif isinstance(v,list): vals=tuple(v)
@@ -71,26 +86,32 @@ def _scopes(v):
     vals=tuple(_text(x,64,"scope") for x in vals)
     if len(set(vals))!=len(vals): raise AuthError("duplicate scopes")
     return frozenset(vals)
-
 def authenticate_bearer(header:str|None, config:AuthConfig, *, clock:Callable[[],float]|None=None)->AuthenticatedPrincipal:
     if not isinstance(header,str) or not header.startswith('Bearer ') or len(header)>MAX_HEADER: raise AuthError("missing bearer token")
     token=header[7:]
     if len(token)>MAX_JWT or token.count('.')!=2: raise AuthError("malformed JWT")
     hseg,pseg,sseg=token.split('.')
     header_obj,payload=_loads(_b64(hseg)),_loads(_b64(pseg))
-    if set(header_obj)&KEY_FIELDS: raise AuthError("JWT key selection is forbidden")
-    if header_obj.get('alg')!='HS256': raise AuthError("unsupported JWT algorithm")
-    if config.require_typ and header_obj.get('typ')!='JWT': raise AuthError("invalid JWT typ")
-    if set(header_obj)-{'alg','typ'}: raise AuthError("unsupported JWT header")
-    expected=base64.urlsafe_b64encode(hmac.new(config.secret.encode(), f'{hseg}.{pseg}'.encode('ascii'), hashlib.sha256).digest()).rstrip(b'=').decode('ascii')
-    if not hmac.compare_digest(expected,sseg): raise AuthError("invalid JWT signature")
+    if set(header_obj)&FORBIDDEN_KEY_FIELDS: raise AuthError("invalid token")
+    if header_obj.get('alg')!='HS256': raise AuthError("invalid token")
+    if config.require_typ and header_obj.get('typ')!='JWT': raise AuthError("invalid token")
+    if set(header_obj)-{'alg','typ','kid'}: raise AuthError("invalid token")
+    key_version=_kid(header_obj.get('kid',config.key_version))
+    secret=config.keyring.get(key_version)
+    if secret is None: raise AuthError("invalid token")
+    expected=base64.urlsafe_b64encode(hmac.new(secret.encode(), f'{hseg}.{pseg}'.encode('ascii'), hashlib.sha256).digest()).rstrip(b'=').decode('ascii')
+    if not hmac.compare_digest(expected,sseg): raise AuthError("invalid token")
     now=(clock or time.time)(); exp=_finite_time(payload.get('exp'), 'exp')
-    if exp<=now: raise AuthError("expired JWT")
-    if 'nbf' in payload and _finite_time(payload['nbf'],'nbf')>now+config.skew_seconds: raise AuthError("JWT not yet valid")
-    if 'iat' in payload and _finite_time(payload['iat'],'iat')>now+config.skew_seconds: raise AuthError("JWT issued in future")
+    if exp<=now: raise AuthError("invalid token")
+    iat=_finite_time(payload.get('iat'), 'iat')
+    if iat>now+config.skew_seconds: raise AuthError("invalid token")
+    if exp-iat>config.max_token_lifetime_seconds: raise AuthError("invalid token")
+    if 'nbf' in payload and _finite_time(payload['nbf'],'nbf')>now+config.skew_seconds: raise AuthError("invalid token")
+    jti=_text(payload.get('jti'),128,'jti')
+    if not _JTI.fullmatch(jti): raise AuthError("invalid token")
     sub=_text(payload.get('sub'),128,'subject'); tenant=_text(payload.get(config.tenant_claim),128,'tenant')
-    if payload.get('iss')!=config.issuer: raise AuthError("issuer mismatch")
+    if payload.get('iss')!=config.issuer: raise AuthError("invalid token")
     audiences=_aud(payload.get('aud'))
-    if config.audience not in audiences: raise AuthError("audience mismatch")
+    if config.audience not in audiences: raise AuthError("invalid token")
     scopes=_scopes(payload.get('scope', payload.get('scopes')))
-    return AuthenticatedPrincipal(sub, tenant, config.issuer, audiences, scopes)
+    return AuthenticatedPrincipal(sub, tenant, config.issuer, audiences, scopes, jti, key_version)

--- a/src/vulcan/runtime/settings.py
+++ b/src/vulcan/runtime/settings.py
@@ -133,7 +133,13 @@ def _secret(value:str|None, name:str, *, required:bool)->OpaqueSecret|None:
     if value is None:
         if required: raise SettingsError(f"{name} is required")
         return None
-    if len(value.encode())<32 or value.lower() in {"changeme","secret","password","dev-secret-change-me"}: raise SettingsError(f"weak secret for {name}")
+    if len(value.encode())<32 or _CTL.search(value): raise SettingsError(f"weak secret for {name}")
+    lower=value.lower()
+    weak={"changeme","secret","password","admin","super-secret-key","insecure-dev-secret","default-super-secret-key-change-me","dev-secret-change-me"}
+    if lower in weak or any(x in lower for x in ("123456","password","qwerty","letmein","jwtsecret","graphixsecret","change-in-production")):
+        raise SettingsError(f"weak secret for {name}")
+    classes=sum([any(c.islower() for c in value), any(c.isupper() for c in value), any(c.isdigit() for c in value), any(not c.isalnum() for c in value)])
+    if len(set(value)) < 12 and classes < 3: raise SettingsError(f"weak secret for {name}")
     return OpaqueSecret(SecretSource.direct, value, name)
 
 def load_runtime_settings(env:Mapping[str,str]|None=None)->RuntimeSettings:

--- a/tests/runtime/test_settings_contract.py
+++ b/tests/runtime/test_settings_contract.py
@@ -6,8 +6,8 @@ import pytest
 
 from vulcan.runtime.settings import RuntimeSettings, SettingsError, generate_settings_schema, load_runtime_settings
 
-SECRET = "x" * 40
-APPROVAL = "y" * 40
+SECRET = "AbCdEfGhIjKlMnOpQrStUvWxYz7890+/safe"
+APPROVAL = "YnOpQrStUvWxAbCdEfGhIjKlM7890+/approval"
 
 def env(tmp_path: Path, **overrides: str) -> dict[str, str]:
     base = {

--- a/tests/security/test_auth_configuration.py
+++ b/tests/security/test_auth_configuration.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+import base64, hashlib, hmac, json, os, subprocess, time
+from pathlib import Path
+
+import pytest
+
+from vulcan.runtime.auth import AuthConfig, AuthError, authenticate_bearer
+from vulcan.runtime.settings import SettingsError, load_runtime_settings
+
+SECRET="AbCdEfGhIjKlMnOpQrStUvWxYz7890+/rotation"
+OLD="OldSecretAbCdEfGhIjKlMnOpQrStUvWxYz7890+/"
+NOW=1_700_000_000.0
+
+def b64(o):
+    raw=json.dumps(o,separators=(",",":"),sort_keys=True).encode()
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+def token(secret=SECRET, *, kid="v1", **claims):
+    h={"alg":"HS256","typ":"JWT","kid":kid}
+    p={"iss":"vulcan","aud":"vulcan-runtime","sub":"alice","tenant":"t1","scope":"reason:write","iat":NOW,"exp":NOW+300,"jti":"jti_0123456789abcdef"}
+    p.update(claims)
+    msg=f"{b64(h)}.{b64(p)}"
+    sig=base64.urlsafe_b64encode(hmac.new(secret.encode(),msg.encode(),hashlib.sha256).digest()).rstrip(b"=").decode()
+    return f"{msg}.{sig}"
+def env(tmp_path: Path, **overrides: str):
+    e={"VULCAN_ENV":"development","VULCAN_JWT_SECRET":SECRET,"VULCAN_RUNTIME_DURABLE_ROOT":str(tmp_path/"rt"),"VULCAN_MEMORY_SQLITE_PATH":str(tmp_path/"rt"/"memory.sqlite")}
+    e.update(overrides); return e
+
+@pytest.mark.parametrize("name", ["VULCAN_JWT_SECRET","GRAPHIX_JWT_SECRET","JWT_SECRET_KEY","JWT_SECRET"])
+def test_runtime_settings_accept_exactly_one_supported_name(tmp_path, name):
+    e=env(tmp_path); e.pop("VULCAN_JWT_SECRET"); e[name]=SECRET
+    assert load_runtime_settings(e).jwt_secret.reveal()==SECRET
+
+def test_runtime_settings_accepts_matching_alias_overlap(tmp_path):
+    assert load_runtime_settings(env(tmp_path, JWT_SECRET=SECRET, JWT_SECRET_KEY=SECRET)).jwt_secret.reveal()==SECRET
+
+def test_runtime_settings_rejects_conflicts_and_weak_values(tmp_path):
+    with pytest.raises(SettingsError): load_runtime_settings(env(tmp_path, JWT_SECRET="DifferentSecretAbCdEfGhIjKlMnOpQrStUvWxYz012345"))
+    with pytest.raises(SettingsError): load_runtime_settings(env(tmp_path, VULCAN_JWT_SECRET="short"))
+    with pytest.raises(SettingsError): load_runtime_settings(env(tmp_path, VULCAN_JWT_SECRET="dev-jwt-secret-key-change-in-production-minimum-32-chars"))
+
+@pytest.mark.parametrize("name", ["VULCAN_JWT_SECRET","GRAPHIX_JWT_SECRET","JWT_SECRET_KEY","JWT_SECRET"])
+def test_entrypoint_accepts_each_supported_alias(name):
+    e={"PATH":os.environ["PATH"], name:SECRET}
+    cp=subprocess.run(["sh","entrypoint.sh","sh","-c","test \"$VULCAN_JWT_SECRET\" = \"$EXPECTED\""], env=e|{"EXPECTED":SECRET}, text=True, capture_output=True, timeout=5)
+    assert cp.returncode==0, cp.stderr
+
+def test_entrypoint_rejects_conflicts_and_weak_values():
+    base={"PATH":os.environ["PATH"],"VULCAN_JWT_SECRET":SECRET,"JWT_SECRET":OLD}
+    cp=subprocess.run(["sh","entrypoint.sh","true"], env=base, text=True, capture_output=True, timeout=5)
+    assert cp.returncode==78
+    assert SECRET not in cp.stderr and OLD not in cp.stderr
+    cp=subprocess.run(["sh","entrypoint.sh","true"], env={"PATH":os.environ["PATH"],"VULCAN_JWT_SECRET":"short"}, text=True, capture_output=True, timeout=5)
+    assert cp.returncode==78
+
+def test_jwt_requires_jti_kid_issuer_audience_and_max_lifetime():
+    cfg=AuthConfig(SECRET,"vulcan","vulcan-runtime",key_version="v1")
+    p=authenticate_bearer("Bearer "+token(), cfg, clock=lambda: NOW)
+    assert p.jti=="jti_0123456789abcdef" and p.key_version=="v1"
+    for bad in [token(jti="not canonical spaces"), token(iss="evil"), token(aud="evil"), token(exp=NOW+7200)]:
+        with pytest.raises(AuthError): authenticate_bearer("Bearer "+bad, cfg, clock=lambda: NOW)
+
+def test_rotation_overlap_accepts_old_and_new_key_versions_with_bounded_timing():
+    cfg=AuthConfig(SECRET,"vulcan","vulcan-runtime",key_version="v2",keyring={"v1":OLD,"v2":SECRET})
+    assert authenticate_bearer("Bearer "+token(OLD,kid="v1"), cfg, clock=lambda: NOW).key_version=="v1"
+    assert authenticate_bearer("Bearer "+token(SECRET,kid="v2"), cfg, clock=lambda: NOW).key_version=="v2"
+    start=time.perf_counter()
+    for _ in range(100):
+        with pytest.raises(AuthError): authenticate_bearer("Bearer "+token(OLD,kid="missing"), cfg, clock=lambda: NOW)
+    assert time.perf_counter()-start < 1.0


### PR DESCRIPTION
### Motivation
- Ensure there is one canonical runtime JWT secret (`VULCAN_JWT_SECRET`) across shell startup, ASGI app, Compose and Helm wiring, and tests, avoiding silent alias conflicts or weak defaults.
- Fail fast and fail-closed on conflicting/weak secret configurations and provide defense-in-depth by repeating validation in Python `RuntimeSettings`.
- Improve JWT handling with rotation/key-version support, bounded token lifetimes, canonical `jti`, and non-leaking, uniform auth failure semantics.

### Description
- Entrypoint: `entrypoint.sh` now selects exactly one canonical secret and exports `VULCAN_JWT_SECRET`; deprecated aliases (`GRAPHIX_JWT_SECRET`, `JWT_SECRET_KEY`, `JWT_SECRET`) are accepted only when they collapse to one unique value, and conflicting/weak values cause fail-closed startup; secret strength checks (length, blacklist/patterns, entropy heuristics) run in shell without echoing secrets.
- Runtime settings: `src/vulcan/runtime/settings.py` mirrors alias selection and rejects conflicts/weak secrets via `_select` and `_secret`, emitting redacted warnings for deprecated aliases.
- Auth runtime: `src/vulcan/runtime/auth.py` replaced/extended to enforce HS256-only tokens, add `jti` canonical format checks, `kid`/key-version and `keyring` support, max token lifetime enforcement, bounded time checks, and rotation-overlap acceptance for previous key versions; all validation errors surface generic auth failures that do not reveal which secret/alias/validation detail failed.
- Deployment wiring: `docker-compose.dev.yml` and `docker-compose.prod.yml` now require `VULCAN_JWT_SECRET` (no weak dev fallback) and other compose entries were aligned to the canonical variable; Helm templates and values renamed to the canonical secret key (`vulcanJwtSecret`) and `deployment.yaml` uses that secret key for `VULCAN_JWT_SECRET`.
- Tests: Added `tests/security/test_auth_configuration.py` to exercise entrypoint alias acceptance/rejection, settings alias handling, JWT `jti`/`kid`/issuer/audience/max-lifetime checks, and rotation overlap behavior; updated `tests/runtime/test_settings_contract.py` test constants to use high-entropy test secrets and preserve contract expectations.

### Testing
- Ran `pytest -q tests/security/test_auth_configuration.py` and all tests passed (auth and entrypoint checks succeeded).
- Ran `pytest -q tests/runtime/test_settings_contract.py` and all tests passed (settings alias/conflict/weak-secret assertions succeeded).
- Verified Python byte-compile with `python -m compileall -q src` and it succeeded.
- Ran `git diff --check` and there were no whitespace/diff-check issues.
- Blocking evidence: `pytest -q tests/test_helm_chart.py` could not collect due to a missing environment dependency (`PyYAML` / `yaml`), so helm-chart collection was not executed in this environment; deployment template/value renames are included but the helm unit test requires `PyYAML` to be installed to run in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d7afdce0c832f999ff550dc0adefe)