### PR TITLE
Make canonical durable root executable across Docker, Compose, and Helm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -264,10 +264,11 @@ COPY --from=builder /app/sbom.json ./sbom.json
 
 # Production runtime immutability: source, bundled policy/config, and model assets are read-only.
 # Only explicit state/cache directories are writable by the non-root runtime user.
-RUN mkdir -p /app/data /app/data/backups /app/memory_store /app/cache /tmp/vulcan /app/models && \
+RUN mkdir -p /var/lib/vulcan/audit /var/lib/vulcan/alignment /var/lib/vulcan/domains /var/lib/vulcan/memory /var/lib/vulcan/learning/outbox /var/lib/vulcan/csiu /var/lib/vulcan/approval /var/lib/vulcan/improvement /app/data /app/data/backups /tmp/vulcan-cache /app/models && \
     chown -R root:root /app/src /app/configs /app/config /app/models && \
     chmod -R a-w /app/src /app/configs /app/config /app/models && \
-    chown -R graphix:graphix /app/data /app/memory_store /app/cache /tmp/vulcan
+    chown -R graphix:graphix /var/lib/vulcan /app/data /tmp/vulcan-cache && \
+    chmod 0700 /var/lib/vulcan /var/lib/vulcan/audit /var/lib/vulcan/alignment /var/lib/vulcan/domains /var/lib/vulcan/memory /var/lib/vulcan/learning /var/lib/vulcan/learning/outbox /var/lib/vulcan/csiu /var/lib/vulcan/approval /var/lib/vulcan/improvement /tmp/vulcan-cache
 
 # Add hardened entrypoint script
 # This updated script enforces:
@@ -286,6 +287,9 @@ ENV PYTHONPATH=/app/src
 ENV VULCAN_ENV=production
 ENV VULCAN_SAFETY_LEVEL=strict
 ENV VULCAN_ENABLE_SELF_IMPROVEMENT=false
+ENV VULCAN_RUNTIME_DURABLE_ROOT=/var/lib/vulcan
+ENV VULCAN_CACHE_ROOT=/tmp/vulcan-cache
+VOLUME ["/var/lib/vulcan"]
 
 # Default port for containerized deployments (can be overridden via PORT env var)
 ENV PORT=8000

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -41,7 +41,7 @@ volumes:
     driver: local
   etcd_data:
     driver: local
-  memory_store_data:
+  vulcan_durable_data:
     driver: local
 
 ################################################################################
@@ -223,7 +223,7 @@ services:
       - VERSION=${VERSION:-latest}
       - PORT=8000
       - VULCAN_JWT_SECRET=${VULCAN_JWT_SECRET:?VULCAN_JWT_SECRET is required}
-      - VULCAN_RUNTIME_DURABLE_ROOT=${VULCAN_RUNTIME_DURABLE_ROOT:-/var/lib/vulcan/runtime}
+      - VULCAN_RUNTIME_DURABLE_ROOT=/var/lib/vulcan
       - BOOTSTRAP_KEY=${BOOTSTRAP_KEY:?BOOTSTRAP_KEY is required}
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432
@@ -373,15 +373,19 @@ services:
       - INDEX_TYPE=${INDEX_TYPE:-disk_based_tier_c}
       - UNLEARNING_METHOD=${UNLEARNING_METHOD:-gradient_surgery}
       - PROOF_SYSTEM=${PROOF_SYSTEM:-groth16}
-      - MEMORY_STORE_PATH=/app/memory_store
-      - CACHE_ROOT=/tmp/vulcan_cache
+      - MEMORY_STORE_PATH=/var/lib/vulcan/memory
+      - CACHE_ROOT=/tmp/vulcan-cache
+      - VULCAN_CACHE_ROOT=/tmp/vulcan-cache
+      - VULCAN_RUNTIME_REPLICAS=1
       - CONFIG_PATH=/app/configs
       # Learning State Persistence Configuration
       # Path for persisting learning state (tool weights, concepts, contraindications)
       # This ensures learning persists across queries and server restarts
-      - VULCAN_STORAGE_PATH=/app/memory_store
+      - VULCAN_STORAGE_PATH=/var/lib/vulcan/learning
     volumes:
-      - memory_store_data:/app/memory_store
+      - vulcan_durable_data:/var/lib/vulcan
+      - type: tmpfs
+        target: /tmp/vulcan-cache
     ports:
       - "8000:8000"
     depends_on:

--- a/docs/deployment/durable-root.md
+++ b/docs/deployment/durable-root.md
@@ -1,0 +1,16 @@
+# Vulcan durable-root operations
+
+The production image and Helm chart use one canonical durable root: `/var/lib/vulcan`.
+It is owned by UID/GID `1001`, mounted from a single ReadWriteOnce volume/PVC, and kept writable while the root filesystem remains read-only.
+
+Authoritative persistent owners live below typed subdirectories: `audit/`, `alignment/`, `domains/`, `memory/`, `learning/outbox/`, `csiu/`, `approval/`, and `improvement/`.
+Model scratch and caches are ephemeral (`/tmp/vulcan-cache`) and may be discarded on restart.
+
+Backup and restore assumptions:
+
+- Back up the complete `/var/lib/vulcan` volume as one consistency unit while the single writer is stopped or quiesced.
+- Restore the full directory tree with UID/GID `1001:1001` and mode `0700` before starting the pod/container.
+- Capacity planning starts at the Helm PVC size (`50Gi` by default); increase it before audit or memory growth reaches the storage-class expansion threshold.
+- Disaster recovery assumes one active writer. Do not run multiple replicas with the SQLite durable backend; promote exactly one restored volume.
+
+Rollback: stop the new workload, restore the previous `/var/lib/vulcan` snapshot, and redeploy the previous image/chart revision. Ephemeral caches do not need restoration.

--- a/docs/security_serving_boundary.md
+++ b/docs/security_serving_boundary.md
@@ -14,7 +14,7 @@ Chat request safety is mandatory. Client `enable_safety=false` is ignored, the t
 
 Health semantics follow Kubernetes probe intent: liveness is a cheap process response, startup reports initialization state, and readiness returns HTTP 503 until mandatory serving-boundary conditions and service initialization are satisfied. Health output avoids secrets and traces.
 
-The production image runs as a non-root user and makes `/app/src`, `/app/configs`, `/app/config`, and `/app/models` read-only. Writable state is limited to `/app/data`, `/app/memory_store`, `/app/cache`, and `/tmp/vulcan`.
+The production image runs as a non-root user and makes `/app/src`, `/app/configs`, `/app/config`, and `/app/models` read-only. Writable durable authority state is limited to `/var/lib/vulcan`; `/app/data`, `/dev/shm`, and `/tmp/vulcan-cache` are ephemeral runtime scratch locations.
 
 ## Transformer authority boundary (sequence item 2)
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -144,10 +144,33 @@ export JWT_VALIDATION_MODE="enabled"
 export VULCAN_ENV="${VULCAN_ENV:-production}"
 export VULCAN_SAFETY_LEVEL="${VULCAN_SAFETY_LEVEL:-strict}"
 export VULCAN_ENABLE_SELF_IMPROVEMENT="${VULCAN_ENABLE_SELF_IMPROVEMENT:-false}"
-export VULCAN_RUNTIME_DURABLE_ROOT="${VULCAN_RUNTIME_DURABLE_ROOT:-/var/lib/vulcan/runtime}"
+export VULCAN_RUNTIME_DURABLE_ROOT="${VULCAN_RUNTIME_DURABLE_ROOT:-/var/lib/vulcan}"
 export VULCAN_MEMORY_ENABLED="${VULCAN_MEMORY_ENABLED:-1}"
 export VULCAN_MEMORY_BACKEND="${VULCAN_MEMORY_BACKEND:-sqlite}"
 export VULCAN_MEMORY_SQLITE_PATH="${VULCAN_MEMORY_SQLITE_PATH:-$VULCAN_RUNTIME_DURABLE_ROOT/memory/memory.sqlite}"
+export VULCAN_RUNTIME_REPLICAS="${VULCAN_RUNTIME_REPLICAS:-1}"
+export VULCAN_CACHE_ROOT="${VULCAN_CACHE_ROOT:-/tmp/vulcan-cache}"
+export PYTHONPATH="${PYTHONPATH:-/app/src:src}"
+EXPECTED_UID=""
+EXPECTED_GID=""
+if [ "$(id -u)" = "1001" ]; then
+  EXPECTED_UID=1001
+  EXPECTED_GID=1001
+fi
+VALIDATION_CATEGORY=$(EXPECTED_UID="$EXPECTED_UID" EXPECTED_GID="$EXPECTED_GID" python - <<'PY'
+import os
+from pathlib import Path
+from vulcan.runtime.settings import validate_durable_root
+uid = int(os.environ["EXPECTED_UID"]) if os.environ.get("EXPECTED_UID") else None
+gid = int(os.environ["EXPECTED_GID"]) if os.environ.get("EXPECTED_GID") else None
+r = validate_durable_root(Path(os.environ["VULCAN_RUNTIME_DURABLE_ROOT"]), expected_uid=uid, expected_gid=gid)
+print(r.category)
+PY
+)
+if [ "$VALIDATION_CATEGORY" != "ok" ]; then
+  echo "ERROR: durable root validation failed: $VALIDATION_CATEGORY" >&2
+  exit 78
+fi
 
 # Execute main process
 exec "$@"

--- a/helm/vulcanami/templates/deployment.yaml
+++ b/helm/vulcanami/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "vulcanami.labels" . | nindent 4 }}
 spec:
+  {{- if and (eq .Values.runtime.environment "production") (or .Values.autoscaling.enabled (ne (int .Values.replicaCount) 1)) }}{{ fail "canonical durable-root sqlite backend requires replicaCount=1 and autoscaling.enabled=false" }}{{ end }}
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
@@ -512,6 +513,10 @@ spec:
           mountPath: /tmp
         - name: app-data
           mountPath: /app/data
+        - name: durable-root
+          mountPath: {{ .Values.runtime.durableRoot }}
+        - name: model-cache
+          mountPath: {{ .Values.memorySystem.paths.cacheRoot }}
         # Shared memory for Ray object store (prevents /dev/shm warning)
         - name: dshm
           mountPath: /dev/shm
@@ -532,6 +537,11 @@ spec:
       - name: tmp
         emptyDir: {}
       - name: app-data
+        emptyDir: {}
+      - name: durable-root
+        persistentVolumeClaim:
+          claimName: {{ include "vulcanami.fullname" . }}-durable-root
+      - name: model-cache
         emptyDir: {}
       # Shared memory for Ray object store (prevents /dev/shm warning)
       # Ray recommends at least 30% of available RAM for object store

--- a/helm/vulcanami/templates/pvc.yaml
+++ b/helm/vulcanami/templates/pvc.yaml
@@ -1,3 +1,26 @@
+{{- if .Values.persistence.durableRoot.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "vulcanami.fullname" . }}-durable-root
+  labels:
+    {{- include "vulcanami.labels" . | nindent 4 }}
+    component: durable-root
+  {{- if .Values.persistence.durableRoot.retain }}
+  annotations:
+    "helm.sh/resource-policy": keep
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.durableRoot.accessMode }}
+  {{- if .Values.persistence.durableRoot.storageClass }}
+  storageClassName: {{ .Values.persistence.durableRoot.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.durableRoot.size }}
+---
+{{- end }}
 {{- if .Values.persistence.memoryStore.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/helm/vulcanami/values.yaml
+++ b/helm/vulcanami/values.yaml
@@ -36,7 +36,7 @@ runtime:
   environment: production
   jwtIssuer: vulcan
   jwtAudience: vulcan-runtime
-  durableRoot: /var/lib/vulcan/runtime
+  durableRoot: /var/lib/vulcan
   languageMode: deterministic_only
   auditEnabled: true
   csiuEnabled: true
@@ -176,8 +176,8 @@ config:
 # supplies a single-writer PVC-backed root and an absolute database path.
 governedMemory:
   enabled: false
-  durableRoot: /var/lib/vulcan-governed-memory
-  sqlitePath: /var/lib/vulcan-governed-memory/preferences.sqlite
+  durableRoot: /var/lib/vulcan
+  sqlitePath: /var/lib/vulcan/memory/memory.sqlite
   replicas: 1
   backend: sqlite
   policyVersion: memory-policy/2
@@ -402,8 +402,8 @@ memorySystem:
     proofSystem: groth16
   # Persistent storage paths
   paths:
-    memoryStore: /app/memory_store
-    cacheRoot: /tmp/vulcan_cache
+    memoryStore: /var/lib/vulcan/memory
+    cacheRoot: /tmp/vulcan-cache
     configPath: /app/configs
   # Learning State Persistence Configuration
   # Persists tool weights, concepts, and contraindications across queries and restarts
@@ -414,19 +414,25 @@ memorySystem:
 
 # Persistent Volume Claims for memory system
 persistence:
-  memoryStore:
+  durableRoot:
     enabled: true
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    size: 50Gi
+    retain: true
+  cache:
+    enabled: false
+    storageClass: ""
+    accessMode: ReadWriteOnce
+    size: 10Gi
+    retain: false
+  memoryStore:
+    enabled: false
     storageClass: ""  # Uses default storage class if empty
     accessMode: ReadWriteOnce
     size: 50Gi
     # Set to true to keep PVC when helm release is deleted
     retain: true
-  cache:
-    enabled: true
-    storageClass: ""
-    accessMode: ReadWriteOnce
-    size: 10Gi
-    retain: false
 
 # Secrets (REQUIRED: Must be set via --set-string or external secret management)
 # Empty values will cause deployment validation to fail

--- a/src/vulcan/runtime/settings.py
+++ b/src/vulcan/runtime/settings.py
@@ -1,7 +1,7 @@
 """One immutable authority for canonical runtime process settings."""
 from __future__ import annotations
 
-import json, os, re
+import errno, json, os, re, stat, tempfile
 from dataclasses import dataclass, field, fields, is_dataclass
 from enum import Enum
 from pathlib import Path
@@ -26,12 +26,29 @@ class OpaqueSecret:
     def to_public(self)->dict[str,str]: return {"source": self.source.value, "env_name": self.env_name, "redacted": "true"}
 
 @dataclass(frozen=True)
+class DurableRootPaths:
+    audit: Path
+    alignment: Path
+    domains: Path
+    governed_memory: Path
+    learning_outbox: Path
+    csiu: Path
+    approval: Path
+    improvement: Path
+
+@dataclass(frozen=True)
+class DurableRootValidation:
+    category: str
+    public_message: str
+
+@dataclass(frozen=True)
 class RuntimeSettings:
     environment: VulcanEnvironment
     jwt_issuer: str
     jwt_audience: str
     jwt_secret: OpaqueSecret = field(repr=False)
     durable_root: Path
+    durable_paths: DurableRootPaths
     language_mode: LanguageMode = LanguageMode.deterministic_only
     language_release_path: Path|None = None
     openai_enabled: bool = False
@@ -122,11 +139,12 @@ def _path(v:str|None, name:str, required:bool)->Path|None:
     p=Path(v)
     if not p.is_absolute(): raise SettingsError(f"{name} must be absolute")
     r=p.resolve(strict=False); repo=Path(__file__).resolve().parents[3]
-    if r in {Path('/'),Path('/tmp'),Path.home(),repo.resolve()} or str(r).startswith(str(repo.resolve())+os.sep): raise SettingsError(f"unsafe {name}")
     cur=Path('/')
-    for part in r.parts[1:]:
+    for part in p.parts[1:]:
         cur=cur/part
         if cur.exists() and cur.is_symlink(): raise SettingsError(f"symlinked {name}")
+    tmp=Path(tempfile.gettempdir()).resolve()
+    if r in {Path('/'),tmp,Path.home(),repo.resolve()} or str(r).startswith(str(repo.resolve())+os.sep): raise SettingsError(f"unsafe {name}")
     return r
 
 def _secret(value:str|None, name:str, *, required:bool)->OpaqueSecret|None:
@@ -141,6 +159,59 @@ def _secret(value:str|None, name:str, *, required:bool)->OpaqueSecret|None:
     classes=sum([any(c.islower() for c in value), any(c.isupper() for c in value), any(c.isdigit() for c in value), any(not c.isalnum() for c in value)])
     if len(set(value)) < 12 and classes < 3: raise SettingsError(f"weak secret for {name}")
     return OpaqueSecret(SecretSource.direct, value, name)
+
+def durable_root_paths(root: Path) -> DurableRootPaths:
+    root = root.resolve(strict=False)
+    return DurableRootPaths(
+        audit=root/"audit",
+        alignment=root/"alignment",
+        domains=root/"domains",
+        governed_memory=root/"memory",
+        learning_outbox=root/"learning"/"outbox",
+        csiu=root/"csiu",
+        approval=root/"approval",
+        improvement=root/"improvement",
+    )
+
+def validate_durable_root(root: Path, *, expected_uid: int|None=None, expected_gid: int|None=None) -> DurableRootValidation:
+    try:
+        resolved = _path(str(root), "VULCAN_RUNTIME_DURABLE_ROOT", True)
+        if resolved is None: return DurableRootValidation("missing", "durable root validation failed: missing")
+        resolved.mkdir(mode=0o700, parents=True, exist_ok=True)
+        st = resolved.stat()
+        if stat.S_IMODE(st.st_mode) & 0o077:
+            return DurableRootValidation("insecure_permissions", "durable root validation failed: permissions")
+        if expected_uid is not None and st.st_uid != expected_uid:
+            return DurableRootValidation("owner_mismatch", "durable root validation failed: owner")
+        if expected_gid is not None and st.st_gid != expected_gid:
+            return DurableRootValidation("owner_mismatch", "durable root validation failed: owner")
+        for directory in durable_root_paths(resolved).__dict__.values():
+            directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        probe = resolved/".fsync-probe"
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        fd = os.open(probe, flags, 0o600)
+        try:
+            os.write(fd, b"vulcan-durable-root-probe\n")
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        dir_fd = os.open(resolved, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+        probe.unlink(missing_ok=True)
+        return DurableRootValidation("ok", "durable root validation ok")
+    except PermissionError:
+        return DurableRootValidation("not_writable", "durable root validation failed: writable")
+    except OSError as exc:
+        if exc.errno in (errno.EROFS, errno.EACCES, errno.EPERM):
+            return DurableRootValidation("not_writable", "durable root validation failed: writable")
+        return DurableRootValidation("fsync_unavailable", "durable root validation failed: fsync")
+    except SettingsError as exc:
+        text=str(exc)
+        category="unsafe_path" if "unsafe" in text or "symlinked" in text else "invalid_path"
+        return DurableRootValidation(category, f"durable root validation failed: {category}")
 
 def load_runtime_settings(env:Mapping[str,str]|None=None)->RuntimeSettings:
     env=dict(os.environ if env is None else env); warnings=[]
@@ -159,8 +230,11 @@ def load_runtime_settings(env:Mapping[str,str]|None=None)->RuntimeSettings:
     if self_imp and approval is None: raise SettingsError("self-improvement requires approval HMAC secret")
     mem_enabled=_bool(get("VULCAN_MEMORY_ENABLED"),"VULCAN_MEMORY_ENABLED",True)
     mem_backend=MemoryBackend(_text(get("VULCAN_MEMORY_BACKEND"),"VULCAN_MEMORY_BACKEND","sqlite" if mem_enabled else "disabled"))
-    mem_path=_path(get("VULCAN_MEMORY_SQLITE_PATH") or (str(durable/"memory"/"memory.sqlite") if mem_enabled else None),"VULCAN_MEMORY_SQLITE_PATH", mem_enabled)
-    return RuntimeSettings(environment,_text(get("VULCAN_JWT_ISSUER"),"VULCAN_JWT_ISSUER","vulcan"),_text(get("VULCAN_JWT_AUDIENCE"),"VULCAN_JWT_AUDIENCE","vulcan-runtime"),jwt,durable,lang,release,get("OPENAI_API_KEY") is not None,get("ANTHROPIC_API_KEY") is not None,mem_enabled,mem_backend,mem_path,_bool(get("VULCAN_AUDIT_ENABLED"),"VULCAN_AUDIT_ENABLED",True),csiu,_bool(get("VULCAN_LEARNING_ENABLED"),"VULCAN_LEARNING_ENABLED",True),self_imp,approval,replicas,_float(get("VULCAN_REQUEST_TIMEOUT_SECONDS"),"VULCAN_REQUEST_TIMEOUT_SECONDS",30.0,0.1,300.0),_bool(get("VULCAN_PUBLIC_DIAGNOSTICS"),"VULCAN_PUBLIC_DIAGNOSTICS",False),tuple(warnings[:16]))
+    paths=durable_root_paths(durable)
+    mem_path=_path(get("VULCAN_MEMORY_SQLITE_PATH") or (str(paths.governed_memory/"memory.sqlite") if mem_enabled else None),"VULCAN_MEMORY_SQLITE_PATH", mem_enabled)
+    validation=validate_durable_root(durable)
+    if environment is VulcanEnvironment.production and validation.category != "ok": raise SettingsError(validation.public_message)
+    return RuntimeSettings(environment,_text(get("VULCAN_JWT_ISSUER"),"VULCAN_JWT_ISSUER","vulcan"),_text(get("VULCAN_JWT_AUDIENCE"),"VULCAN_JWT_AUDIENCE","vulcan-runtime"),jwt,durable,paths,lang,release,get("OPENAI_API_KEY") is not None,get("ANTHROPIC_API_KEY") is not None,mem_enabled,mem_backend,mem_path,_bool(get("VULCAN_AUDIT_ENABLED"),"VULCAN_AUDIT_ENABLED",True),csiu,_bool(get("VULCAN_LEARNING_ENABLED"),"VULCAN_LEARNING_ENABLED",True),self_imp,approval,replicas,_float(get("VULCAN_REQUEST_TIMEOUT_SECONDS"),"VULCAN_REQUEST_TIMEOUT_SECONDS",30.0,0.1,300.0),_bool(get("VULCAN_PUBLIC_DIAGNOSTICS"),"VULCAN_PUBLIC_DIAGNOSTICS",False),tuple(warnings[:16]))
 
 def _public(v):
     if isinstance(v,OpaqueSecret): return v.to_public()

--- a/tests/deployment/test_durable_root.py
+++ b/tests/deployment/test_durable_root.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from vulcan.runtime.settings import SettingsError, load_runtime_settings, validate_durable_root
+
+SECRET = "AbCdEfGhIjKlMnOpQrStUvWxYz7890+/safe"
+APPROVAL = "YnOpQrStUvWxAbCdEfGhIjKlM7890+/approval"
+
+
+def _env(root: Path, **overrides: str) -> dict[str, str]:
+    env = {
+        "VULCAN_ENV": "production",
+        "VULCAN_JWT_SECRET": SECRET,
+        "VULCAN_APPROVAL_HMAC_SECRET": APPROVAL,
+        "VULCAN_RUNTIME_DURABLE_ROOT": str(root),
+    }
+    env.update(overrides)
+    return env
+
+
+def test_runtime_settings_places_canonical_owners_under_durable_root(tmp_path: Path) -> None:
+    root = tmp_path / "durable"
+    root.mkdir(mode=0o700)
+    settings = load_runtime_settings(_env(root))
+
+    assert settings.durable_root == root.resolve()
+    assert settings.memory_sqlite_path == root.resolve() / "memory" / "memory.sqlite"
+    assert settings.durable_paths.audit == root.resolve() / "audit"
+    assert settings.durable_paths.alignment == root.resolve() / "alignment"
+    assert settings.durable_paths.domains == root.resolve() / "domains"
+    assert settings.durable_paths.governed_memory == root.resolve() / "memory"
+    assert settings.durable_paths.learning_outbox == root.resolve() / "learning" / "outbox"
+    assert settings.durable_paths.csiu == root.resolve() / "csiu"
+    assert settings.durable_paths.approval == root.resolve() / "approval"
+    assert settings.durable_paths.improvement == root.resolve() / "improvement"
+
+
+def test_runtime_validation_as_uid_1001_writes_fsyncs_and_reopens(tmp_path: Path) -> None:
+    root = tmp_path / "durable"
+    root.mkdir(mode=0o700)
+    result = validate_durable_root(root, expected_uid=os.getuid() if os.name != "nt" else None, expected_gid=os.getgid() if os.name != "nt" else None)
+    assert result.category == "ok"
+
+    marker = root / "audit" / "restart.marker"
+    marker.write_text("preserved", encoding="utf-8")
+    with marker.open("r+b") as fh:
+        fh.flush()
+        os.fsync(fh.fileno())
+    assert (root / "audit" / "restart.marker").read_text(encoding="utf-8") == "preserved"
+
+
+@pytest.mark.parametrize("bad", ["/tmp", ".", "relative/path"])
+def test_durable_root_rejects_tmp_source_tree_and_relative_paths(tmp_path: Path, bad: str) -> None:
+    with pytest.raises(SettingsError):
+        load_runtime_settings(_env(tmp_path / "unused", VULCAN_RUNTIME_DURABLE_ROOT=bad))
+
+
+def test_durable_root_rejects_symlink_components(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    link = tmp_path / "link"
+    link.symlink_to(target, target_is_directory=True)
+    with pytest.raises(SettingsError, match="symlinked"):
+        load_runtime_settings(_env(link / "state"))
+
+
+def test_validate_durable_root_fails_closed_for_read_only_or_missing_fsync(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    root = tmp_path / "durable"
+    root.mkdir(mode=0o700)
+
+    def deny_fsync(_fd: int) -> None:
+        raise OSError("fsync unavailable")
+
+    monkeypatch.setattr(os, "fsync", deny_fsync)
+    result = validate_durable_root(root)
+    assert result.category == "fsync_unavailable"
+    assert str(root) not in result.public_message
+
+
+def test_dockerfile_declares_canonical_volume_uid_and_restrictive_permissions() -> None:
+    dockerfile = Path("Dockerfile").read_text(encoding="utf-8")
+    assert "VULCAN_RUNTIME_DURABLE_ROOT=/var/lib/vulcan" in dockerfile
+    assert "VOLUME [\"/var/lib/vulcan\"]" in dockerfile
+    assert "chown -R graphix:graphix /var/lib/vulcan" in dockerfile
+    assert "chmod 0700 /var/lib/vulcan" in dockerfile
+
+
+def test_compose_uses_single_canonical_durable_volume_and_ephemeral_cache() -> None:
+    compose = Path("docker-compose.prod.yml").read_text(encoding="utf-8")
+    assert "vulcan_durable_data:" in compose
+    assert "VULCAN_RUNTIME_DURABLE_ROOT=/var/lib/vulcan" in compose
+    assert "VULCAN_RUNTIME_REPLICAS=1" in compose
+    assert "VULCAN_CACHE_ROOT=/tmp/vulcan-cache" in compose
+    assert "vulcan_durable_data:/var/lib/vulcan" in compose
+
+
+def test_helm_templates_mount_canonical_pvc_env_and_single_replica_guard() -> None:
+    values = Path("helm/vulcanami/values.yaml").read_text(encoding="utf-8")
+    deployment = Path("helm/vulcanami/templates/deployment.yaml").read_text(encoding="utf-8")
+    pvc = Path("helm/vulcanami/templates/pvc.yaml").read_text(encoding="utf-8")
+
+    assert "durableRoot: /var/lib/vulcan" in values
+    assert "replicaCount: 1" in values
+    assert "enabled: false" in values
+    assert "readOnlyRootFilesystem: true" in values
+    assert "fail \"canonical durable-root sqlite backend requires replicaCount=1" in deployment
+    assert "mountPath: {{ .Values.runtime.durableRoot }}" in deployment
+    assert "claimName: {{ include \"vulcanami.fullname\" . }}-durable-root" in deployment
+    assert "kind: PersistentVolumeClaim" in pvc
+    assert "-durable-root" in pvc

--- a/tests/security/test_container_immutability.py
+++ b/tests/security/test_container_immutability.py
@@ -4,7 +4,7 @@ from pathlib import Path
 def test_dockerfile_freezes_source_and_config_paths():
     dockerfile = Path("Dockerfile").read_text()
     assert "chmod -R a-w /app/src /app/configs /app/config /app/models" in dockerfile
-    assert "chown -R graphix:graphix /app/data /app/memory_store /app/cache" in dockerfile
+    assert "chown -R graphix:graphix /var/lib/vulcan /app/data /tmp/vulcan-cache" in dockerfile
     assert "ENV VULCAN_ENV=production" in dockerfile
 
 


### PR DESCRIPTION
### Motivation
- Establish a single, safe, writable durable authority root for the runtime to avoid source-tree or /tmp persistence, and to make production topology and single-writer invariants explicit across image, Compose, and Helm deployments.
- Harden startup to fail closed on unsafe durable-root configuration, missing fsync support, symlinked components, wrong ownership, or insecure permissions to prevent split-brain and data loss with the SQLite single-writer backend.

### Description
- Added typed durable-root support and validation helpers in `src/vulcan/runtime/settings.py` (`DurableRootPaths`, `DurableRootValidation`, `durable_root_paths`, `validate_durable_root`) and wired them into `load_runtime_settings` so production fails closed on non-`ok` validation.
- Updated `Dockerfile` to standardize on `/var/lib/vulcan`, create typed subdirectories (audit, alignment, domains, memory, learning/outbox, csiu, approval, improvement), set UID/GID ownership for the non-root user, restrict permissions (`0700`), expose the durable `VOLUME`, and add a separate ephemeral cache path `/tmp/vulcan-cache`.
- Hardened `entrypoint.sh` to default `VULCAN_RUNTIME_DURABLE_ROOT=/var/lib/vulcan`, export `VULCAN_CACHE_ROOT`, evaluate durable-root validation (bounded category result) before executing the main process, and set `VULCAN_RUNTIME_REPLICAS=1` default for the canonical topology.
- Updated `docker-compose.prod.yml` to declare a single `vulcan_durable_data` volume mounted at `/var/lib/vulcan`, set ephemeral cache as `tmpfs`, and inject the canonical durable-root and replica envs.
- Updated Helm (`helm/vulcanami/values.yaml`, `helm/vulcanami/templates/deployment.yaml`, `helm/vulcanami/templates/pvc.yaml`) to use `/var/lib/vulcan` as the durableRoot default, add a durable-root PVC resource and volume mount, provide readOnlyRootFilesystem-compatible mounts, and fail chart rendering for production when `replicaCount != 1` or autoscaling is enabled.
- Added deployment documentation `docs/deployment/durable-root.md` detailing backup/restore, ownership, capacity, DR and rollback assumptions, and updated serving-boundary docs to distinguish durable vs ephemeral state.
- Added tests `tests/deployment/test_durable_root.py` (path validation, fsync/write/reopen behavior, Dockerfile/Compose/Helm contract checks) and adjusted `tests/security/test_container_immutability.py` to reflect the new durable/cache paths.

### Testing
- Ran `python -m pytest -q tests/deployment/test_durable_root.py tests/security/test_container_immutability.py` and both test modules passed (green).
- Ran `python -m pytest -q tests/runtime/test_settings_contract.py tests/security/test_auth_configuration.py` and the runtime/settings and entrypoint-related tests passed (green).
- Verified compilation with `python -m compileall -q src` succeeded and `git diff --check` reported no whitespace/conflict issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d7ccfca6c832fa363e7d88856d1f5)