### PR TITLE
Fail-closed production runtime composition; remove silent fallbacks and fake FastAPI/Pydantic stubs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+server = [
+    "fastapi>=0.100.0",
+    "pydantic>=2.0.0",
+]
 dev = [
     "black>=23.0.0",
     "flake8>=6.0.0",

--- a/src/vulcan/runtime/app.py
+++ b/src/vulcan/runtime/app.py
@@ -3,46 +3,20 @@ from __future__ import annotations
 import asyncio, json
 from contextlib import asynccontextmanager
 from uuid import uuid4
-try:
-    from fastapi import FastAPI, HTTPException, Request
-    from fastapi.responses import JSONResponse
-except Exception:  # dependency-light route-manifest diagnostics
-    class HTTPException(Exception):
-        def __init__(self, status_code:int, detail:str='', headers=None): self.status_code=status_code; self.detail=detail; self.headers=headers or {}; super().__init__(detail)
-    class JSONResponse(dict):
-        def __init__(self, status_code:int=200, content=None, headers=None): super().__init__(content or {}); self.status_code=status_code; self.headers=headers or {}
-    class Request: pass
-    class _State: pass
-    class _Route:
-        def __init__(self,path,endpoint): self.path=path; self.endpoint=endpoint
-    class FastAPI:
-        def __init__(self, *a, **k): self.routes=[]; self.state=_State()
-        def get(self,path):
-            def deco(fn): self.routes.append(_Route(path,fn)); return fn
-            return deco
-        def post(self,path):
-            def deco(fn): self.routes.append(_Route(path,fn)); return fn
-            return deco
-        def patch(self,path):
-            def deco(fn): self.routes.append(_Route(path,fn)); return fn
-            return deco
-        def delete(self,path):
-            def deco(fn): self.routes.append(_Route(path,fn)); return fn
-            return deco
-        def middleware(self, _kind):
-            def deco(fn): return fn
-            return deco
-try:
-    from pydantic import BaseModel, ConfigDict, Field, StrictStr, StrictInt
-except Exception:  # pragma: no cover
-    BaseModel=object; ConfigDict=dict; Field=lambda *a,**k: None; StrictStr=str; StrictInt=int
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
+
 from .auth import AuthConfig, AuthError, AuthorizationError, authenticate_bearer
 from .case import CognitiveCase
 from .composition import compose_runtime
-from .settings import load_runtime_settings
+from .settings import SettingsError, load_runtime_settings
 from .kernel import KernelRequest
 from .semantic import Utterance
 from vulcan.memory.governed import MemoryActorContext, MemoryKind, MemoryReadRequest, MemoryWriteProposal, MemoryReason
+from .errors import StartupErrorCategory, StartupFailure
+from .route_manifest import generate_route_manifest
 
 MAX_BODY=16_384
 ABSENT_ETAG='"absent"'
@@ -52,17 +26,27 @@ ABSENT_ETAG='"absent"'
 async def lifespan(app: FastAPI):
     app.state.ready=False; app.state.runtime=None; app.state.auth_config=None; app.state.runtime_settings=None; runtime=None
     try:
-        settings=load_runtime_settings()
+        try:
+            settings=load_runtime_settings()
+        except SettingsError as exc:
+            app.state.startup_error = StartupFailure(StartupErrorCategory.SETTINGS_INVALID, "runtime settings invalid", exc)
+            raise app.state.startup_error from exc
         app.state.runtime_settings=settings
         app.state.auth_config=settings.auth_config()
         runtime=await asyncio.to_thread(compose_runtime, settings)
         await runtime.readiness(); app.state.runtime=runtime; app.state.ready=True
         yield
-    except BaseException:
+    except BaseException as exc:
         app.state.ready=False; app.state.runtime=None
+        if isinstance(exc, StartupFailure):
+            app.state.startup_error = exc
+        else:
+            app.state.startup_error = StartupFailure(StartupErrorCategory.RUNTIME_UNHEALTHY, "runtime startup failed", exc)
         if runtime is not None:
-            try: await runtime.close()
-            except BaseException: pass
+            try:
+                await runtime.close()
+            except BaseException as close_exc:
+                exc.add_note(f"runtime close failed during startup cleanup: {type(close_exc).__name__}")
         raise
     finally:
         app.state.ready=False
@@ -116,12 +100,9 @@ class BundleBody(BaseModel):
     bundle: dict
     model_config=ConfigDict(extra='forbid', strict=True)
 
-def generate_route_manifest():
-    return tuple({'path':p,'method':m,'classification':'public' if p.startswith('/health/') else 'protected'} for p,m in [('/health/live','GET'),('/health/ready','GET'),('/v1/capabilities','GET'),('/v1/chat','POST'),('/v1/admin/domains','POST'),('/v1/admin/alignment','POST'),('/v1/audit/cases/{case_id}','GET'),('/v1/admin/improvements','GET'),('/v1/admin/improvements/{proposal_id}','GET'),('/v1/admin/improvements/{proposal_id}/approve','POST'),('/v1/admin/improvements/{proposal_id}/reject','POST'),('/v1/admin/improvements/{proposal_id}/resume','POST'),('/v1/admin/improvements/{proposal_id}/status','GET'),('/v1/audit/improvements/{proposal_digest}','GET'),('/v1/memory/preferences','POST'),('/v1/memory/preferences/{key}','GET'),('/v1/memory/preferences/{record_id}','PATCH'),('/v1/memory/preferences/{record_id}','DELETE')])
-
 def create_app()->FastAPI:
     app=FastAPI(title='VULCAN canonical runtime', version='7.0', lifespan=lifespan)
-    app.state.route_manifest=generate_route_manifest(); app.state.ready=False; app.state.runtime=None
+    app.state.route_manifest=generate_route_manifest(); app.state.ready=False; app.state.runtime=None; app.state.startup_error=None
     @app.middleware('http')
     async def bounds(request, call_next):
         resp=await call_next(request); resp.headers.setdefault('Cache-Control','no-store'); resp.headers.setdefault('X-Content-Type-Options','nosniff'); return resp
@@ -133,7 +114,9 @@ def create_app()->FastAPI:
             rt=await _runtime(request)
             diagnostics = rt.settings.public_dict() if rt.settings.public_diagnostics else {'environment': rt.settings.environment.value, 'settings_schema': rt.settings.schema()['schema_version']}
             return {'status':'ready','runtime_id':rt.runtime_id,'diagnostics':diagnostics,'learning_owner_id':rt.learning_owner.owner_id,'learning_status':rt.learning_owner.capability.value,'capabilities':list(rt.capabilities()),'learning_capabilities':[c.__dict__ | {'status': c.status.value, 'readiness_state': c.readiness_state.value} for c in rt.learning_owner.capability_matrix()]}
-        except HTTPException: return JSONResponse(status_code=503, content={'status':'not_ready'})
+        except HTTPException:
+            err=getattr(request.app.state,'startup_error',None); code=err.public_code if isinstance(err,StartupFailure) else 'runtime_not_ready'
+            return JSONResponse(status_code=503, content={'status':'not_ready','code':code})
     @app.get('/v1/capabilities')
     async def capabilities():
         from vulcan.runtime.capabilities import public_capability_response

--- a/src/vulcan/runtime/capabilities.py
+++ b/src/vulcan/runtime/capabilities.py
@@ -10,7 +10,7 @@ CONFIG_PATH = ROOT / "config" / "capabilities.yaml"
 
 
 def composed_runtime_ports() -> set[str]:
-    from vulcan.runtime.app import generate_route_manifest
+    from vulcan.runtime.route_manifest import generate_route_manifest
     return {f"{item['method']} {item['path']}" for item in generate_route_manifest()}
 
 

--- a/src/vulcan/runtime/composition.py
+++ b/src/vulcan/runtime/composition.py
@@ -1,31 +1,82 @@
 """Single composition function for the production runtime."""
 from __future__ import annotations
-from types import SimpleNamespace
-from .container import RuntimeContainer
-from .settings import RuntimeSettings
 
-class _FallbackSafety:
-    def readiness(self): return True
-    def validate(self, *a, **k): return True
-    async def finalize(self, artifact):
-        return SimpleNamespace(decision=SimpleNamespace(value='allowed'), public_text=getattr(artifact,'text',str(artifact)))
-    def close(self): pass
-class _FallbackWorld:
-    snapshot_id='fallback-world'
-    def readiness(self): return True
-    def close(self): pass
-class _FallbackDeployment:
-    def __init__(self):
-        self.collective=SimpleNamespace(deps=SimpleNamespace(world_model=_FallbackWorld(), safety_validator=_FallbackSafety()))
-    def readiness(self): return True
-    def close(self): pass
+from importlib import import_module, util
+from types import SimpleNamespace
+
+from .container import RuntimeContainer
+from .errors import StartupErrorCategory, StartupFailure
+from .settings import RuntimeSettings, VulcanEnvironment
+
+
+class DevelopmentStubDeployment:
+    """Deliberately named non-production stub; cognitive routes must remain unavailable."""
+
+    production_ready = False
+
+    def __init__(self) -> None:
+        self.collective = SimpleNamespace(deps=SimpleNamespace(world_model=DevelopmentStubWorld(), safety_validator=DevelopmentStubSafety()))
+
+    def readiness(self) -> bool:
+        return False
+
+    def close(self) -> None:
+        return None
+
+
+class DevelopmentStubWorld:
+    production_ready = False
+    snapshot_id = "development-stub-world"
+
+    def readiness(self) -> bool:
+        return False
+
+
+class DevelopmentStubSafety:
+    production_ready = False
+
+    def readiness(self) -> bool:
+        return False
+
+
+def _startup_failure(category: StartupErrorCategory, message: str, exc: BaseException | None = None) -> StartupFailure:
+    return StartupFailure(category, message, exc)
+
+
+def _module_available(name: str) -> bool:
+    try:
+        return util.find_spec(name) is not None
+    except ValueError:
+        return True
+
 
 def compose_runtime(settings: RuntimeSettings) -> RuntimeContainer:
     """Construct the deployment graph from the already-parsed settings authority."""
+    if settings.development_stub_mode:
+        if settings.environment is VulcanEnvironment.production:
+            raise _startup_failure(StartupErrorCategory.SETTINGS_INVALID, "development stub mode is forbidden in production")
+        return RuntimeContainer.new(deployment=DevelopmentStubDeployment(), settings=settings)
+    if not _module_available("vulcan.config") or not _module_available("vulcan.orchestrator.deployment"):
+        raise _startup_failure(StartupErrorCategory.DEPLOYMENT_IMPORT_FAILED, "production deployment dependency import failed")
     try:
-        from vulcan.config import get_config
-        from vulcan.orchestrator.deployment import ProductionDeployment
-        deployment=ProductionDeployment(get_config())
-    except Exception:
-        deployment=_FallbackDeployment()
-    return RuntimeContainer.new(deployment=deployment, settings=settings)
+        config_module = import_module("vulcan.config")
+        deployment_module = import_module("vulcan.orchestrator.deployment")
+        deployment = deployment_module.ProductionDeployment(config_module.get_config())
+    except BaseException as exc:
+        raise _startup_failure(StartupErrorCategory.DEPLOYMENT_CONSTRUCTION_FAILED, "production deployment construction failed", exc) from exc
+    try:
+        return RuntimeContainer.new(deployment=deployment, settings=settings)
+    except StartupFailure:
+        raise
+    except OSError as exc:
+        raise _startup_failure(StartupErrorCategory.FILESYSTEM_UNAVAILABLE, "runtime durable filesystem unavailable", exc) from exc
+    except RuntimeError as exc:
+        text = str(exc).lower()
+        category = StartupErrorCategory.RUNTIME_UNHEALTHY
+        if "world" in text:
+            category = StartupErrorCategory.WORLD_MISSING
+        elif "safety" in text:
+            category = StartupErrorCategory.SAFETY_MISSING
+        elif "kernel" in text or "reason" in text:
+            category = StartupErrorCategory.REASONER_MISSING
+        raise _startup_failure(category, str(exc), exc) from exc

--- a/src/vulcan/runtime/container.py
+++ b/src/vulcan/runtime/container.py
@@ -144,8 +144,8 @@ class RuntimeContainer:
                 meta = self.language_input.readiness()
                 abi = meta["runtime_abi"]
                 result = tuple(dict.fromkeys((*result, "verified-transformer-span", f"language-abi:{abi}")))
-            except Exception:
-                pass
+            except Exception as exc:
+                raise RuntimeError("language interface readiness failed") from exc
         if self.self_improvement is not None:
             result = tuple(dict.fromkeys((*result, *self.self_improvement.capabilities())))
         if self.learning_owner is None:
@@ -161,10 +161,12 @@ class RuntimeContainer:
         deps = getattr(getattr(deployment, "collective", None), "deps", None)
         world_state = getattr(deps, "world_model", None)
         if world_state is None:
-            raise RuntimeError("required canonical World State is unavailable")
+            from .errors import StartupErrorCategory, StartupFailure
+            raise StartupFailure(StartupErrorCategory.WORLD_MISSING, "required canonical World State is unavailable")
         safety = getattr(deps, "safety_validator", None)
         if safety is None:
-            raise RuntimeError("required safety finalization service is unavailable")
+            from .errors import StartupErrorCategory, StartupFailure
+            raise StartupFailure(StartupErrorCategory.SAFETY_MISSING, "required safety finalization service is unavailable")
         config = (language_config or LanguageRuntimeConfig(settings.language_mode.value, str(settings.language_release_path) if settings.language_release_path else None)).validated()
         # Deterministic remains default/fallback; transformer mode is admitted only after strict release verification.
         language_input: LanguageInputPort = DeterministicLanguageInput()

--- a/src/vulcan/runtime/errors.py
+++ b/src/vulcan/runtime/errors.py
@@ -1,0 +1,30 @@
+"""Typed startup failures for the canonical runtime."""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class StartupErrorCategory(str, Enum):
+    SETTINGS_INVALID = "settings_invalid"
+    SERVER_DEPENDENCY_MISSING = "server_dependency_missing"
+    DEPLOYMENT_IMPORT_FAILED = "deployment_import_failed"
+    DEPLOYMENT_CONSTRUCTION_FAILED = "deployment_construction_failed"
+    WORLD_MISSING = "world_missing"
+    SAFETY_MISSING = "safety_missing"
+    REASONER_MISSING = "reasoner_missing"
+    FILESYSTEM_UNAVAILABLE = "filesystem_unavailable"
+    RUNTIME_UNHEALTHY = "runtime_unhealthy"
+
+
+class StartupFailure(RuntimeError):
+    """Operator-visible startup failure with safe public readiness code."""
+
+    def __init__(self, category: StartupErrorCategory, operator_message: str, cause: BaseException | None = None) -> None:
+        super().__init__(operator_message)
+        self.category = category
+        self.operator_message = operator_message
+        self.cause = cause
+
+    @property
+    def public_code(self) -> str:
+        return self.category.value

--- a/src/vulcan/runtime/route_manifest.py
+++ b/src/vulcan/runtime/route_manifest.py
@@ -1,0 +1,34 @@
+"""Dependency-light static route manifest for diagnostics and capability inventory."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+RouteMethod = Literal["GET", "POST", "PATCH", "DELETE"]
+RouteClassification = Literal["public", "protected"]
+
+@dataclass(frozen=True)
+class RouteManifestEntry:
+    path: str
+    method: RouteMethod
+    classification: RouteClassification
+
+    def public_dict(self) -> dict[str, str]:
+        return {"path": self.path, "method": self.method, "classification": self.classification}
+
+_ROUTES: tuple[tuple[str, RouteMethod], ...] = (
+    ("/health/live", "GET"), ("/health/ready", "GET"), ("/v1/capabilities", "GET"),
+    ("/v1/chat", "POST"), ("/v1/admin/domains", "POST"), ("/v1/admin/alignment", "POST"),
+    ("/v1/audit/cases/{case_id}", "GET"), ("/v1/admin/improvements", "GET"),
+    ("/v1/admin/improvements/{proposal_id}", "GET"), ("/v1/admin/improvements/{proposal_id}/approve", "POST"),
+    ("/v1/admin/improvements/{proposal_id}/reject", "POST"), ("/v1/admin/improvements/{proposal_id}/resume", "POST"),
+    ("/v1/admin/improvements/{proposal_id}/status", "GET"), ("/v1/audit/improvements/{proposal_digest}", "GET"),
+    ("/v1/memory/preferences", "POST"), ("/v1/memory/preferences/{key}", "GET"),
+    ("/v1/memory/preferences/{record_id}", "PATCH"), ("/v1/memory/preferences/{record_id}", "DELETE"),
+)
+
+def route_manifest() -> tuple[RouteManifestEntry, ...]:
+    return tuple(RouteManifestEntry(path, method, "public" if path.startswith("/health/") else "protected") for path, method in _ROUTES)
+
+def generate_route_manifest() -> tuple[dict[str, str], ...]:
+    return tuple(entry.public_dict() for entry in route_manifest())

--- a/src/vulcan/runtime/settings.py
+++ b/src/vulcan/runtime/settings.py
@@ -64,6 +64,7 @@ class RuntimeSettings:
     replicas: int = 1
     request_timeout_seconds: float = 30.0
     public_diagnostics: bool = False
+    development_stub_mode: bool = False
     deprecation_warnings: tuple[str,...] = ()
 
     def auth_config(self):
@@ -93,6 +94,7 @@ ALIASES={
  "VULCAN_RUNTIME_REPLICAS": ("VULCAN_RUNTIME_REPLICAS",),
  "VULCAN_REQUEST_TIMEOUT_SECONDS": ("VULCAN_REQUEST_TIMEOUT_SECONDS","HYBRID_EXECUTOR_TIMEOUT"),
  "VULCAN_PUBLIC_DIAGNOSTICS": ("VULCAN_PUBLIC_DIAGNOSTICS",),
+ "VULCAN_DEVELOPMENT_STUB_MODE": ("VULCAN_DEVELOPMENT_STUB_MODE",),
 }
 DEPRECATED={"GRAPHIX_JWT_SECRET":"VULCAN_JWT_SECRET","JWT_SECRET_KEY":"VULCAN_JWT_SECRET","JWT_SECRET":"VULCAN_JWT_SECRET","ENABLE_SELF_IMPROVEMENT":"VULCAN_ENABLE_SELF_IMPROVEMENT","HYBRID_EXECUTOR_TIMEOUT":"VULCAN_REQUEST_TIMEOUT_SECONDS","INTRINSIC_CSIU_OFF":"VULCAN_CSIU_ENABLED","VULCAN_TEXT_MODEL_REVISION":"VULCAN_LANGUAGE_RELEASE_PATH"}
 
@@ -225,6 +227,8 @@ def load_runtime_settings(env:Mapping[str,str]|None=None)->RuntimeSettings:
     replicas=_int(get("VULCAN_RUNTIME_REPLICAS"),"VULCAN_RUNTIME_REPLICAS",1,1,1)
     self_imp=_bool(get("VULCAN_ENABLE_SELF_IMPROVEMENT"),"VULCAN_ENABLE_SELF_IMPROVEMENT",False)
     csiu_val=get("VULCAN_CSIU_ENABLED"); csiu = (not _bool(csiu_val,"VULCAN_CSIU_ENABLED",False)) if "INTRINSIC_CSIU_OFF" in env and "VULCAN_CSIU_ENABLED" not in env else _bool(csiu_val,"VULCAN_CSIU_ENABLED",True)
+    dev_stub=_bool(get("VULCAN_DEVELOPMENT_STUB_MODE"),"VULCAN_DEVELOPMENT_STUB_MODE",False)
+    if environment is VulcanEnvironment.production and dev_stub: raise SettingsError("development stub mode is forbidden in production")
     if environment is VulcanEnvironment.production and (not csiu or not _bool(get("VULCAN_AUDIT_ENABLED"),"VULCAN_AUDIT_ENABLED",True)):
         raise SettingsError("production requires audit and CSIU")
     if self_imp and approval is None: raise SettingsError("self-improvement requires approval HMAC secret")
@@ -234,7 +238,7 @@ def load_runtime_settings(env:Mapping[str,str]|None=None)->RuntimeSettings:
     mem_path=_path(get("VULCAN_MEMORY_SQLITE_PATH") or (str(paths.governed_memory/"memory.sqlite") if mem_enabled else None),"VULCAN_MEMORY_SQLITE_PATH", mem_enabled)
     validation=validate_durable_root(durable)
     if environment is VulcanEnvironment.production and validation.category != "ok": raise SettingsError(validation.public_message)
-    return RuntimeSettings(environment,_text(get("VULCAN_JWT_ISSUER"),"VULCAN_JWT_ISSUER","vulcan"),_text(get("VULCAN_JWT_AUDIENCE"),"VULCAN_JWT_AUDIENCE","vulcan-runtime"),jwt,durable,paths,lang,release,get("OPENAI_API_KEY") is not None,get("ANTHROPIC_API_KEY") is not None,mem_enabled,mem_backend,mem_path,_bool(get("VULCAN_AUDIT_ENABLED"),"VULCAN_AUDIT_ENABLED",True),csiu,_bool(get("VULCAN_LEARNING_ENABLED"),"VULCAN_LEARNING_ENABLED",True),self_imp,approval,replicas,_float(get("VULCAN_REQUEST_TIMEOUT_SECONDS"),"VULCAN_REQUEST_TIMEOUT_SECONDS",30.0,0.1,300.0),_bool(get("VULCAN_PUBLIC_DIAGNOSTICS"),"VULCAN_PUBLIC_DIAGNOSTICS",False),tuple(warnings[:16]))
+    return RuntimeSettings(environment,_text(get("VULCAN_JWT_ISSUER"),"VULCAN_JWT_ISSUER","vulcan"),_text(get("VULCAN_JWT_AUDIENCE"),"VULCAN_JWT_AUDIENCE","vulcan-runtime"),jwt,durable,paths,lang,release,get("OPENAI_API_KEY") is not None,get("ANTHROPIC_API_KEY") is not None,mem_enabled,mem_backend,mem_path,_bool(get("VULCAN_AUDIT_ENABLED"),"VULCAN_AUDIT_ENABLED",True),csiu,_bool(get("VULCAN_LEARNING_ENABLED"),"VULCAN_LEARNING_ENABLED",True),self_imp,approval,replicas,_float(get("VULCAN_REQUEST_TIMEOUT_SECONDS"),"VULCAN_REQUEST_TIMEOUT_SECONDS",30.0,0.1,300.0),_bool(get("VULCAN_PUBLIC_DIAGNOSTICS"),"VULCAN_PUBLIC_DIAGNOSTICS",False),dev_stub,tuple(warnings[:16]))
 
 def _public(v):
     if isinstance(v,OpaqueSecret): return v.to_public()

--- a/tests/architecture/test_no_production_mocks.py
+++ b/tests/architecture/test_no_production_mocks.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+PRODUCTION_RUNTIME = Path("src/vulcan/runtime")
+BANNED = ("MagicMock", "_FallbackDeployment", "_FallbackWorld", "_FallbackSafety", "class FastAPI", "class BaseModel")
+
+
+def test_no_magicmock_or_fallback_classes_in_runtime_import_closure():
+    offenders = []
+    for path in PRODUCTION_RUNTIME.rglob("*.py"):
+        if path.name == "route_manifest.py":
+            text = path.read_text()
+            assert "fastapi" not in text.lower()
+            assert "pydantic" not in text.lower()
+        text = path.read_text()
+        for banned in BANNED:
+            if banned in text:
+                offenders.append(f"{path}:{banned}")
+    assert offenders == []

--- a/tests/runtime/test_production_composition.py
+++ b/tests/runtime/test_production_composition.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from vulcan.runtime.composition import DevelopmentStubDeployment, compose_runtime
+from vulcan.runtime.errors import StartupErrorCategory, StartupFailure
+from vulcan.runtime.settings import RuntimeSettings, VulcanEnvironment, durable_root_paths, OpaqueSecret, SecretSource
+
+
+def settings(tmp_path: Path, *, env: VulcanEnvironment = VulcanEnvironment.production, stub: bool = False) -> RuntimeSettings:
+    root = (tmp_path / "durable").resolve()
+    root.mkdir()
+    return RuntimeSettings(
+        environment=env,
+        jwt_issuer="vulcan",
+        jwt_audience="vulcan-runtime",
+        jwt_secret=OpaqueSecret(SecretSource.direct, "A" * 40 + "1!bcdefgh", "VULCAN_JWT_SECRET"),
+        durable_root=root,
+        durable_paths=durable_root_paths(root),
+        approval_hmac_secret=OpaqueSecret(SecretSource.direct, "B" * 40 + "1!cdefghi", "VULCAN_APPROVAL_HMAC_SECRET"),
+        memory_sqlite_path=root / "memory" / "memory.sqlite",
+        development_stub_mode=stub,
+    )
+
+
+class DummyOwner:
+    owner_id = "dummy-owner"
+    capability = SimpleNamespace(value="shadow")
+    def readiness(self): return True
+    def close(self): return None
+    def capabilities(self): return ()
+    def capability_matrix(self): return ()
+
+
+def lightweight_container(monkeypatch: pytest.MonkeyPatch) -> None:
+    import vulcan.runtime.container as container
+    monkeypatch.setattr(container, "compose_governed_memory", lambda config: DummyOwner())
+    monkeypatch.setattr(container, "CanonicalAudit", lambda path: DummyOwner())
+    monkeypatch.setattr(container, "AlignmentRegistry", lambda path, audit=None: DummyOwner())
+    monkeypatch.setattr(container, "PersistentDomainRegistry", lambda path, audit=None: DummyOwner())
+    monkeypatch.setattr(container, "compose_self_improvement_runtime", lambda **kwargs: SimpleNamespace(drive=DummyOwner(), capabilities=lambda: (), close=lambda: None))
+    monkeypatch.setattr(container, "ShadowLinUCBToolBandit", lambda: DummyOwner())
+    monkeypatch.setattr(container, "LearningOwner", lambda **kwargs: DummyOwner())
+
+
+class GoodWorld:
+    def readiness(self):
+        return True
+
+
+class GoodSafety:
+    def readiness(self):
+        return True
+
+    def validate(self, *args, **kwargs):
+        return True
+
+
+class Deployment:
+    def __init__(self, config=None, *, world=GoodWorld(), safety=GoodSafety()):
+        self.collective = SimpleNamespace(deps=SimpleNamespace(world_model=world, safety_validator=safety, continual=None))
+
+    def readiness(self):
+        return True
+
+
+def install_deployment(monkeypatch: pytest.MonkeyPatch, deployment_cls=Deployment) -> None:
+    config = types.ModuleType("vulcan.config")
+    config.get_config = lambda: {"authoritative": True}
+    deployment = types.ModuleType("vulcan.orchestrator.deployment")
+    deployment.ProductionDeployment = deployment_cls
+    monkeypatch.setitem(sys.modules, "vulcan.config", config)
+    monkeypatch.setitem(sys.modules, "vulcan.orchestrator.deployment", deployment)
+
+
+@pytest.mark.asyncio
+async def test_real_composition_contains_no_fallback_types(monkeypatch, tmp_path):
+    install_deployment(monkeypatch)
+    lightweight_container(monkeypatch)
+    runtime = compose_runtime(settings(tmp_path))
+    try:
+        assert "Fallback" not in type(runtime.deployment).__name__
+        assert "Fallback" not in type(runtime.world_state).__name__
+        assert "Fallback" not in type(runtime.safety).__name__
+        await runtime.readiness()
+    finally:
+        await runtime.close()
+
+
+def test_missing_world_fails_with_original_category(monkeypatch, tmp_path):
+    class MissingWorld(Deployment):
+        def __init__(self, config=None):
+            super().__init__(config, world=None)
+
+    install_deployment(monkeypatch, MissingWorld)
+    lightweight_container(monkeypatch)
+    with pytest.raises(StartupFailure) as excinfo:
+        compose_runtime(settings(tmp_path))
+    assert excinfo.value.category is StartupErrorCategory.WORLD_MISSING
+    assert excinfo.value.public_code == "world_missing"
+
+
+def test_missing_safety_fails_with_original_category(monkeypatch, tmp_path):
+    class MissingSafety(Deployment):
+        def __init__(self, config=None):
+            super().__init__(config, safety=None)
+
+    install_deployment(monkeypatch, MissingSafety)
+    lightweight_container(monkeypatch)
+    with pytest.raises(StartupFailure) as excinfo:
+        compose_runtime(settings(tmp_path))
+    assert excinfo.value.category is StartupErrorCategory.SAFETY_MISSING
+
+
+def test_deployment_constructor_failure_preserves_cause(monkeypatch, tmp_path):
+    class Broken:
+        def __init__(self, config=None):
+            raise ValueError("malicious constructor escalation")
+
+    install_deployment(monkeypatch, Broken)
+    with pytest.raises(StartupFailure) as excinfo:
+        compose_runtime(settings(tmp_path))
+    assert excinfo.value.category is StartupErrorCategory.DEPLOYMENT_CONSTRUCTION_FAILED
+    assert isinstance(excinfo.value.cause, ValueError)
+
+
+def test_development_stub_is_explicit_and_not_production_ready(monkeypatch, tmp_path):
+    lightweight_container(monkeypatch)
+    runtime = compose_runtime(settings(tmp_path, env=VulcanEnvironment.development, stub=True))
+    assert isinstance(runtime.deployment, DevelopmentStubDeployment)
+    assert runtime.deployment.production_ready is False
+    with pytest.raises(RuntimeError):
+        import asyncio
+        asyncio.run(runtime.readiness())
+
+
+def test_production_forbids_development_stub_setting(tmp_path):
+    from vulcan.runtime.settings import SettingsError, load_runtime_settings
+    root = (tmp_path / "prod-root").resolve()
+    env = {
+        "VULCAN_ENV": "production",
+        "VULCAN_RUNTIME_DURABLE_ROOT": str(root),
+        "VULCAN_JWT_SECRET": "Abcd1234!" * 5,
+        "VULCAN_APPROVAL_HMAC_SECRET": "Bcde1234!" * 5,
+        "VULCAN_DEVELOPMENT_STUB_MODE": "true",
+    }
+    with pytest.raises(SettingsError, match="development stub mode"):
+        load_runtime_settings(env)
+
+
+def test_server_dependency_absence_fails_import_without_fake_frameworks():
+    import os
+    import subprocess
+    import sys
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "src"
+    result = subprocess.run(
+        [sys.executable, "-c", "import vulcan.runtime.app"],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+    if result.returncode == 0:
+        pytest.skip("server dependencies are installed in this environment")
+    assert "ModuleNotFoundError" in result.stderr
+    assert "fastapi" in result.stderr or "pydantic" in result.stderr


### PR DESCRIPTION
### Motivation
- Prevent silent downgrade in production by eliminating fabricated fallback services and fake framework shims that hide import/startup failures.
- Provide clear, typed startup failure categories that preserve causal exceptions for operator evidence while returning a safe public readiness code.
- Keep a dependency-light static route manifest for diagnostics while requiring real server dependencies for runtime startup.

### Description
- Removed `_FallbackDeployment`, `_FallbackWorld`, and `_FallbackSafety` and replaced silent fallbacks with typed `StartupFailure` categories in `src/vulcan/runtime/composition.py` and `src/vulcan/runtime/errors.py` so production imports and construction fail closed and preserve the causal exception internally.
- Added an explicit, deliberately-named non-production `DevelopmentStubDeployment` with `production_ready=False` and forbade enabling it in production via `VULCAN_DEVELOPMENT_STUB_MODE` in `src/vulcan/runtime/settings.py` so any stub mode is explicit and non-production-ready.
- Eliminated fake FastAPI/Pydantic shim classes from `src/vulcan/runtime/app.py`, made real `fastapi`/`pydantic` imports required, and moved the dependency-light route manifest into a new `src/vulcan/runtime/route_manifest.py` that is used by the app and capability registry.
- Hardened `RuntimeContainer` startup to raise typed `StartupFailure` for missing world/safety owners and surface language-interface readiness errors as original causes, and added a `server` optional extra in `pyproject.toml` for explicit server dependencies.
- Added regression tests that assert no fallback/fake framework classes are present in the production runtime import closure and tests covering missing world/safety, deployment construction failure preservation, explicit dev-stub behavior, and server-dependency import failure: `tests/runtime/test_production_composition.py` and `tests/architecture/test_no_production_mocks.py`.

### Testing
- Ran `python -m pytest -q tests/runtime/test_production_composition.py` and it passed (all tests in that file succeeded).
- Ran `python -m pytest -q tests/architecture/test_no_production_mocks.py` and it passed.
- Ran `python -m pytest -q tests/runtime/test_settings_contract.py` and it passed.
- Verified `python -m compileall -q src` completed without errors and ran `git diff --check` with no issues.
- The server-import absence test executes an isolated subprocess import of `vulcan.runtime.app` and asserts a `ModuleNotFoundError` for `fastapi`/`pydantic` when server extras are not installed (the test is skipped automatically if those dependencies are present in the environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d7ec79a1c832fbef30b0e69a79902)