### PR TITLE
Add safety-aware terminal case states and expose safety release semantics

### DIFF
--- a/src/vulcan/runtime/case.py
+++ b/src/vulcan/runtime/case.py
@@ -18,6 +18,8 @@ class CognitiveCaseStatus(str, Enum):
     OPEN = "open"
     SUCCESS = "success"
     ABSTAINED = "abstained"
+    BLOCKED = "blocked"
+    FINALIZATION_ERROR = "finalization_error"
     FAILED = "failed"
     CANCELLED = "cancelled"
 

--- a/src/vulcan/runtime/kernel.py
+++ b/src/vulcan/runtime/kernel.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from vulcan.memory.governed import GovernedMemoryPort
 from .case import CognitiveCase, CognitiveCaseStatus
-from .finalization import ResponseFinalizerPort
+from .finalization import FinalizationDecision, ResponseFinalizerPort
 from vulcan.safety.safety_types import ResponseSafetyContext
 from .semantic import (ClarificationRequest, DeterministicLanguageInput, LanguageInputPort, RESPONSE_IR_VERSION, ResponseIR, ResponseMode, Utterance, accept, build_graphix_plan, compile_graphix_plan, execute, execute_graphix_plan, render_strict, validate_proposal)
 from .output import DeterministicLanguageOutput, LanguageOutputPort, SemanticFirewall, project
@@ -24,7 +24,20 @@ class KernelResult:
     status: CognitiveCaseStatus
     finalization: str
     def transport(self, *, case_id: str, runtime_id: str, snapshot_id: str | None) -> dict[str, object]:
-        return {"response": self.response, "metadata": {"case_id":case_id,"runtime_id":runtime_id,"state_snapshot_id":snapshot_id,"semantic_schema_version":self.response_ir.schema_version,"finalized":True,"finalization_safety_decision":self.finalization}}
+        released = self.finalization == FinalizationDecision.ALLOW.value
+        return {
+            "response": self.response,
+            "metadata": {
+                "case_id": case_id,
+                "runtime_id": runtime_id,
+                "state_snapshot_id": snapshot_id,
+                "semantic_schema_version": self.response_ir.schema_version,
+                "terminal_status": self.status.value,
+                "response_released": released,
+                "finalized": True,
+                "finalization_safety_decision": self.finalization,
+            },
+        }
 class CognitiveKernel:
     def __init__(self, *, state_authority: Any, finalizer: ResponseFinalizerPort, language_input: LanguageInputPort | None = None, language_output: LanguageOutputPort | None = None, memory: "GovernedMemoryPort | None" = None, audit: Any = None, alignment: Any = None) -> None:
         # The kernel owns the only memory port exposed to the production path.
@@ -35,8 +48,7 @@ class CognitiveKernel:
         caps=["bounded-arithmetic"]
         mem_caps=getattr(self._memory, "capabilities", None)
         if callable(mem_caps):
-            try: caps.extend(mem_caps())
-            except Exception: pass
+            caps.extend(mem_caps())
         return tuple(caps)
     async def handle(self, request: KernelRequest, case: CognitiveCase) -> KernelResult:
         if case.terminal_status is not CognitiveCaseStatus.OPEN: raise RuntimeError("kernel received a closed cognitive case")
@@ -109,9 +121,17 @@ class CognitiveKernel:
             else:
                 finalization=await finalize(artifact, final_context)
             case.record_finalization(finalization.decision.value)
-            if self._audit: self._audit.append("case.finalized", {"case_id":case.case_id,"request_id":case.request_id,"request_digest":case.input_hash,"finalization":finalization.decision.value,"rendered_response_digest":artifact.ir_digest})
+            if finalization.decision is FinalizationDecision.BLOCK:
+                status = CognitiveCaseStatus.BLOCKED
+            elif finalization.decision is FinalizationDecision.ERROR:
+                status = CognitiveCaseStatus.FINALIZATION_ERROR
+            elif finalization.decision is FinalizationDecision.CANCELLED:
+                status = CognitiveCaseStatus.CANCELLED
+            if self._audit: self._audit.append("case.finalized", {"case_id":case.case_id,"request_id":case.request_id,"request_digest":case.input_hash,"finalization":finalization.decision.value,"terminal_status":status.value,"rendered_response_digest":artifact.ir_digest})
             case.close(status)
-            if self._audit: self._audit.append("case.completed" if status is CognitiveCaseStatus.SUCCESS else "case.abstained", {"case_id":case.case_id,"request_id":case.request_id,"request_digest":case.input_hash,"status":status.value,"rendered_response_digest":artifact.ir_digest})
+            if self._audit:
+                event_type = "case.completed" if status is CognitiveCaseStatus.SUCCESS else f"case.{status.value}"
+                self._audit.append(event_type, {"case_id":case.case_id,"request_id":case.request_id,"request_digest":case.input_hash,"status":status.value,"rendered_response_digest":artifact.ir_digest})
             return KernelResult(finalization.public_text,response_ir,status,finalization.decision.value)
         except asyncio.CancelledError:
             if case.terminal_status is CognitiveCaseStatus.OPEN: case.close(CognitiveCaseStatus.CANCELLED,"cancelled")

--- a/tests/security/test_real_response_safety_composition.py
+++ b/tests/security/test_real_response_safety_composition.py
@@ -6,8 +6,8 @@ from types import SimpleNamespace
 import pytest
 
 from vulcan.runtime.case import CognitiveCase, CognitiveCaseStatus
-from vulcan.runtime.finalization import FinalizationDecision, SafetyResponseFinalizer
-from vulcan.runtime.kernel import CognitiveKernel, KernelRequest
+from vulcan.runtime.finalization import FinalizationDecision, FinalizationResult, SafetyResponseFinalizer
+from vulcan.runtime.kernel import CognitiveKernel, KernelRequest, KernelResult
 from vulcan.runtime.semantic import Utterance
 from vulcan.safety.response_adapter import EnhancedSafetyResponseAdapter
 from vulcan.safety.safety_types import ResponseSafetyContext, ResponseSafetyStatus, SafetyReport, SafetyValidator
@@ -122,3 +122,50 @@ async def test_modified_text_is_not_allowed_through():
     result = await SafetyResponseFinalizer(EnhancedSafetyResponseAdapter(ModifyingValidator(config=None))).finalize(artifact, ctx())
     assert result.decision is FinalizationDecision.BLOCK
     assert result.public_text != "changed"
+
+
+class _Finalizer:
+    def __init__(self, decision: FinalizationDecision) -> None:
+        self._decision = decision
+
+    async def finalize(self, artifact, context):
+        text = artifact.text if self._decision is FinalizationDecision.ALLOW else "safe fallback"
+        return FinalizationResult(self._decision, artifact, text)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("decision", "expected"),
+    [
+        (FinalizationDecision.BLOCK, CognitiveCaseStatus.BLOCKED),
+        (FinalizationDecision.ERROR, CognitiveCaseStatus.FINALIZATION_ERROR),
+        (FinalizationDecision.CANCELLED, CognitiveCaseStatus.CANCELLED),
+    ],
+)
+async def test_case_terminal_status_reflects_final_response_safety_decision(decision, expected):
+    utterance = Utterance.from_text("2 + 2")
+    case = CognitiveCase.create(request_id="episode", conversation_id=None, input_digest=utterance.digest)
+    result = await CognitiveKernel(state_authority=SimpleNamespace(version="1"), finalizer=_Finalizer(decision)).handle(KernelRequest(utterance, None), case)
+
+    assert case.terminal_status is expected
+    assert result.status is expected
+    assert case.finalization_status == decision.value
+
+
+def test_transport_exposes_terminal_and_release_semantics_without_second_authority():
+    from vulcan.runtime.semantic import ResponseIR, ResponseMode
+
+    response_ir = ResponseIR("1", "response-1", "case-1", None, "snapshot-1", ResponseMode.STRICT, ("claim-1",))
+    result = KernelResult(
+        "safe fallback",
+        response_ir,
+        CognitiveCaseStatus.BLOCKED,
+        FinalizationDecision.BLOCK.value,
+    )
+
+    envelope = result.transport(case_id="case-1", runtime_id="runtime-1", snapshot_id="snapshot-1")
+
+    assert envelope["response"] == "safe fallback"
+    assert envelope["metadata"]["terminal_status"] == "blocked"
+    assert envelope["metadata"]["response_released"] is False
+    assert envelope["metadata"]["finalization_safety_decision"] == "block"


### PR DESCRIPTION
### Motivation
- Ensure final response-safety decisions are represented as explicit case terminal states so safety blocks/errors cannot be misinterpreted as successful completions.
- Surface whether a finalized response was actually released (fail-closed semantics) in the transport envelope without introducing a second authority.
- Tighten audit metadata so finalization outcomes are recorded with clear terminal status for downstream consumers and observability.

### Description
- Added `BLOCKED` and `FINALIZATION_ERROR` to `CognitiveCaseStatus` in `src/vulcan/runtime/case.py` and preserved existing states. 
- Mapped finalizer outcomes to terminal case states in `src/vulcan/runtime/kernel.py` so `FinalizationDecision.BLOCK` → `CognitiveCaseStatus.BLOCKED`, `FinalizationDecision.ERROR` → `CognitiveCaseStatus.FINALIZATION_ERROR`, and `FinalizationDecision.CANCELLED` → `CognitiveCaseStatus.CANCELLED`.
- Extended `KernelResult.transport()` to include `terminal_status`, `response_released` (boolean derived from the finalization decision), and keep `finalization_safety_decision` in the returned metadata so callers can observe release semantics without a second authority.
- Updated audit event emission to record the terminal status and changed the appended event type to `case.completed` or `case.<status>` for clarity, and removed a swallowed exception in memory capability probing to avoid silent downgrades.
- Added/updated tests in `tests/security/test_real_response_safety_composition.py` to validate terminal mapping and transport metadata behavior.

### Testing
- Ran `python -m compileall -q src` and `git diff --check` with no errors reported.
- Ran `pytest -q tests/security/test_real_response_safety_composition.py tests/security/test_semantic_runtime.py tests/security/test_persistent_audit_alignment.py` which completed with `22 passed, 1 skipped`.
- Executed the new parametrized safety-to-terminal mapping and transport envelope tests in `tests/security/test_real_response_safety_composition.py` and they passed.
- Note: `tests/security/test_runtime_convergence.py` still fails in this environment due to a pre-existing API mismatch requiring `settings` in `RuntimeContainer.new()` and a missing `fastapi` dependency, which is unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d8398b6bc832fba161f540b37fb99)