### PR TITLE
Split runtime admission, shallow readiness, and deep integrity with health state machine

### DIFF
--- a/src/vulcan/runtime/app.py
+++ b/src/vulcan/runtime/app.py
@@ -34,7 +34,7 @@ async def lifespan(app: FastAPI):
         app.state.runtime_settings=settings
         app.state.auth_config=settings.auth_config()
         runtime=await asyncio.to_thread(compose_runtime, settings)
-        await runtime.readiness(); app.state.runtime=runtime; app.state.ready=True
+        await runtime.deep_integrity(); app.state.runtime=runtime; app.state.ready=True
         yield
     except BaseException as exc:
         app.state.ready=False; app.state.runtime=None
@@ -82,7 +82,7 @@ async def _runtime(request:Request):
     if not getattr(request.app.state,'ready',False) or rt is None or rt.closed: raise HTTPException(503,'runtime not ready')
     try: await rt.admission()
     except Exception:
-        request.app.state.ready=False; raise HTTPException(503,'runtime not ready') from None
+        raise HTTPException(503,'runtime not ready') from None
     return rt
 
 async def _ready_runtime(request:Request):
@@ -90,7 +90,7 @@ async def _ready_runtime(request:Request):
     if not getattr(request.app.state,'ready',False) or rt is None or rt.closed: raise HTTPException(503,'runtime not ready')
     try: await rt.shallow_readiness()
     except Exception:
-        request.app.state.ready=False; raise HTTPException(503,'runtime not ready') from None
+        raise HTTPException(503,'runtime not ready') from None
     return rt
 
 async def _integrity_runtime(request:Request):
@@ -128,16 +128,19 @@ def create_app()->FastAPI:
     async def ready(request:Request):
         try:
             rt=await _ready_runtime(request)
-            diagnostics = rt.settings.public_dict() if rt.settings.public_diagnostics else {'environment': rt.settings.environment.value, 'settings_schema': rt.settings.schema()['schema_version']}
-            return {'status':'ready','runtime_id':rt.runtime_id,'diagnostics':diagnostics,'learning_owner_id':rt.learning_owner.owner_id,'learning_status':rt.learning_owner.capability.value,'capabilities':list(rt.capabilities()),'learning_capabilities':[c.__dict__ | {'status': c.status.value, 'readiness_state': c.readiness_state.value} for c in rt.learning_owner.capability_matrix()]}
+            state = rt.health.state.value if rt.health is not None else 'ready'
+            return {'status':'ready' if state == 'ready' else state}
         except HTTPException:
             err=getattr(request.app.state,'startup_error',None); code=err.public_code if isinstance(err,StartupFailure) else 'runtime_not_ready'
             return JSONResponse(status_code=503, content={'status':'not_ready','code':code})
     @app.get('/health/integrity')
     async def integrity(request:Request):
+        _principal(request,'operator:read')
         try:
             rt=await _integrity_runtime(request)
-            return {'status':'passed','runtime_id':rt.runtime_id}
+            snap = rt.health.snapshot() if rt.health is not None else None
+            last = None if snap is None or snap.last_integrity is None else {'ok':snap.last_integrity.ok,'category':None if snap.last_integrity.category is None else snap.last_integrity.category.value,'checked_at':snap.last_integrity.checked_at.isoformat(),'last_success_at':None if snap.last_integrity.last_success_at is None else snap.last_integrity.last_success_at.isoformat()}
+            return {'status':'passed','runtime_id':rt.runtime_id,'state':rt.health.state.value if rt.health is not None else 'ready','last_integrity':last}
         except HTTPException:
             return JSONResponse(status_code=503, content={'status':'failed','code':'runtime_integrity_failed'})
     @app.get('/v1/capabilities')

--- a/src/vulcan/runtime/container.py
+++ b/src/vulcan/runtime/container.py
@@ -1,6 +1,7 @@
 """Typed owner for the one production cognitive object graph."""
 from __future__ import annotations
 
+import asyncio
 import inspect
 from dataclasses import dataclass
 from typing import Any, Literal
@@ -21,6 +22,7 @@ from .output import DeterministicLanguageOutput, LanguageOutputPort
 from .semantic import DeterministicLanguageInput, LanguageInputPort
 from .self_improvement import SelfImprovementRuntime, compose_self_improvement_runtime
 from .settings import RuntimeSettings
+from .health import HealthFailureCategory, HealthStateMachine, ProcessState, bounded_disk_check, categorize_failure
 
 
 LanguageMode = Literal["disabled", "deterministic_only", "transformer_proposal"]
@@ -61,6 +63,7 @@ class RuntimeContainer:
     learning_owner: LearningOwner | None = None
     settings: RuntimeSettings | None = None
     closed: bool = False
+    health: HealthStateMachine | None = None
 
     async def close(self) -> None:
         """Release every owned resource once, preserving the first failure.
@@ -73,6 +76,8 @@ class RuntimeContainer:
         if self.closed:
             return
         self.closed = True
+        if self.health is not None:
+            self.health.close()
         first_error: BaseException | None = None
         seen: set[int] = set()
         for resource in (
@@ -122,29 +127,52 @@ class RuntimeContainer:
         }
 
     async def admission(self) -> None:
-        """Fast traffic gate: the composed runtime exists and is not closing."""
-        if self.closed:
+        """Traffic gate: admitted runtime exists and is not draining/closing."""
+        if self.closed or (self.health is not None and self.health.state in {ProcessState.DRAINING, ProcessState.CLOSED, ProcessState.FAILED}):
             raise RuntimeError("canonical runtime is closed")
 
     async def shallow_readiness(self) -> None:
         """Fast readiness: verify mandatory owners are present without deep I/O."""
         await self.admission()
-        for name, owner in self._required_owners().items():
-            if owner is None:
-                raise RuntimeError(f"required canonical {name} is unavailable")
+        try:
+            for name, owner in self._required_owners().items():
+                if owner is None:
+                    raise RuntimeError(f"required canonical {name} is unavailable")
+            if isinstance(self.durable_root, (str, Path)):
+                await bounded_disk_check(Path(self.durable_root))
+            if self.health is not None:
+                self.health.ready()
+        except Exception as exc:
+            if self.health is not None:
+                self.health.degrade(categorize_failure(exc))
+            raise
 
     async def deep_integrity(self) -> None:
         """Deep integrity: execute every owner-provided readiness/health check."""
-        await self.shallow_readiness()
+        await self.admission()
+        for name, owner in self._required_owners().items():
+            if owner is None:
+                if self.health is not None: self.health.record_integrity(ok=False, category=HealthFailureCategory.MISSING_OWNER)
+                raise RuntimeError(f"required canonical {name} is unavailable")
+        if isinstance(self.durable_root, (str, Path)):
+            await bounded_disk_check(Path(self.durable_root))
         required = self._required_owners()
-        for name, owner in required.items():
-            check = getattr(owner, "readiness", None) or getattr(owner, "healthcheck", None)
-            if check is not None:
-                result = check()
-                if inspect.isawaitable(result):
-                    result = await result
-                if result is False:
-                    raise RuntimeError(f"required canonical {name} is unhealthy")
+        try:
+            for name, owner in required.items():
+                check = getattr(owner, "readiness", None) or getattr(owner, "healthcheck", None)
+                if check is not None:
+                    result = await asyncio.to_thread(check)
+                    if inspect.isawaitable(result):
+                        result = await result
+                    if result is False:
+                        raise RuntimeError(f"required canonical {name} is unhealthy")
+            if self.health is not None:
+                self.health.record_integrity(ok=True)
+        except Exception as exc:
+            category = categorize_failure(exc)
+            if self.health is not None:
+                self.health.record_integrity(ok=False, category=category)
+            raise
 
     async def readiness(self) -> None:
         """Backward-compatible deep readiness adapter; not used for liveness."""
@@ -221,8 +249,10 @@ class RuntimeContainer:
             response_safety.readiness()
             kernel = CognitiveKernel(state_authority=world_state, finalizer=SafetyResponseFinalizer(response_safety),
                                      language_input=language_input, language_output=language_output, memory=memory, audit=audit, alignment=alignment)
-            return cls(str(uuid4()), deployment, world_state, kernel, safety, memory,
-                       language_input, language_output, config, audit, alignment, domain_registry, Path(root), self_improvement, learning_owner, settings)
+            container = cls(str(uuid4()), deployment, world_state, kernel, safety, memory,
+                       language_input, language_output, config, audit, alignment, domain_registry, Path(root), self_improvement, learning_owner, settings, False, HealthStateMachine())
+            container.health.admit()
+            return container
         except Exception:
             for r in (locals().get("learning_owner"), self_improvement, domain_registry, alignment, audit, memory, language_output, language_input):
                 if r is not None:

--- a/src/vulcan/runtime/health.py
+++ b/src/vulcan/runtime/health.py
@@ -1,0 +1,126 @@
+"""Runtime health state machine and bounded probe contracts."""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import shutil
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Callable, Iterable
+
+
+class ProcessState(str, Enum):
+    STARTING = "starting"
+    ADMITTED = "admitted"
+    READY = "ready"
+    DEGRADED = "degraded"
+    FAILED = "failed"
+    DRAINING = "draining"
+    CLOSED = "closed"
+
+
+class HealthFailureCategory(str, Enum):
+    TRANSIENT_READINESS = "transient_readiness"
+    CORRUPTION = "corruption"
+    MISSING_OWNER = "missing_owner"
+    CLOSED = "closed"
+    DEPENDENCY = "dependency"
+    DISK_SPACE = "disk_space"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class IntegrityResult:
+    ok: bool
+    category: HealthFailureCategory | None
+    checked_at: datetime
+    last_success_at: datetime | None
+
+
+@dataclass(frozen=True)
+class HealthSnapshot:
+    state: ProcessState
+    last_integrity: IntegrityResult | None
+
+
+_TERMINAL = {ProcessState.FAILED, ProcessState.CLOSED}
+
+
+class HealthStateMachine:
+    def __init__(self, *, clock: Callable[[], datetime] | None = None) -> None:
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._state = ProcessState.STARTING
+        self._last_integrity: IntegrityResult | None = None
+
+    @property
+    def state(self) -> ProcessState:
+        return self._state
+
+    def snapshot(self) -> HealthSnapshot:
+        return HealthSnapshot(self._state, self._last_integrity)
+
+    def admit(self) -> None:
+        self._transition({ProcessState.STARTING}, ProcessState.ADMITTED)
+
+    def ready(self) -> None:
+        self._transition({ProcessState.ADMITTED, ProcessState.DEGRADED, ProcessState.READY}, ProcessState.READY)
+
+    def degrade(self, category: HealthFailureCategory = HealthFailureCategory.TRANSIENT_READINESS) -> None:
+        if self._state in _TERMINAL or self._state is ProcessState.DRAINING:
+            return
+        self._state = ProcessState.DEGRADED
+
+    def fail(self, category: HealthFailureCategory = HealthFailureCategory.CORRUPTION) -> None:
+        if self._state is not ProcessState.CLOSED:
+            self._state = ProcessState.FAILED
+
+    def drain(self) -> None:
+        if self._state not in _TERMINAL:
+            self._state = ProcessState.DRAINING
+
+    def close(self) -> None:
+        self._state = ProcessState.CLOSED
+
+    def record_integrity(self, *, ok: bool, category: HealthFailureCategory | None = None) -> IntegrityResult:
+        now = self._clock()
+        last_success = now if ok else (self._last_integrity.last_success_at if self._last_integrity else None)
+        result = IntegrityResult(ok=ok, category=None if ok else (category or HealthFailureCategory.UNKNOWN), checked_at=now, last_success_at=last_success)
+        self._last_integrity = result
+        if ok and self._state in {ProcessState.ADMITTED, ProcessState.DEGRADED}:
+            self.ready()
+        elif not ok and result.category is HealthFailureCategory.CORRUPTION:
+            self.fail(result.category)
+        return result
+
+    def _transition(self, allowed: set[ProcessState], target: ProcessState) -> None:
+        if self._state not in allowed:
+            raise RuntimeError(f"invalid health transition {self._state.value}->{target.value}")
+        self._state = target
+
+
+def categorize_failure(exc: BaseException) -> HealthFailureCategory:
+    text = str(exc).lower()
+    if "corruption" in text or "hash mismatch" in text or "integrity" in text:
+        return HealthFailureCategory.CORRUPTION
+    if "unavailable" in text or "missing" in text:
+        return HealthFailureCategory.MISSING_OWNER
+    if "disk" in text or "space" in text:
+        return HealthFailureCategory.DISK_SPACE
+    if "closed" in text:
+        return HealthFailureCategory.CLOSED
+    return HealthFailureCategory.TRANSIENT_READINESS
+
+
+async def maybe_await_call(fn):
+    value = fn()
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+async def bounded_disk_check(root: Path, *, minimum_free_bytes: int = 1_048_576) -> None:
+    usage = await asyncio.to_thread(shutil.disk_usage, root)
+    if usage.free < minimum_free_bytes:
+        raise RuntimeError("runtime disk-space check failed")

--- a/tests/runtime/test_health_state_machine.py
+++ b/tests/runtime/test_health_state_machine.py
@@ -1,0 +1,99 @@
+from types import SimpleNamespace
+
+import pytest
+
+from vulcan.runtime.container import RuntimeContainer
+from vulcan.runtime.health import HealthStateMachine, ProcessState
+
+
+class Owner:
+    def __init__(self, healthy=True, message="transient dependency unavailable"):
+        self.healthy = healthy
+        self.message = message
+        self.readiness_calls = 0
+    def readiness(self):
+        self.readiness_calls += 1
+        if self.healthy is True:
+            return True
+        if self.healthy is False:
+            return False
+        raise RuntimeError(self.message)
+    def capabilities(self):
+        return ()
+    def capability_matrix(self):
+        return ()
+
+
+def runtime_with_owner(owner, *, root=None):
+    h = HealthStateMachine(); h.admit()
+    return RuntimeContainer(
+        runtime_id="runtime-1",
+        deployment=owner,
+        world_state=owner,
+        kernel=SimpleNamespace(capabilities=lambda: ("bounded-arithmetic",)),
+        safety=owner,
+        memory=owner,
+        language_input=owner,
+        language_output=owner,
+        language_config=SimpleNamespace(mode="deterministic_only"),
+        audit=owner,
+        alignment=owner,
+        domain_registry=owner,
+        durable_root=root,
+        self_improvement=SimpleNamespace(capabilities=lambda: (), readiness=lambda: True),
+        learning_owner=SimpleNamespace(owner_id="learning", capability=SimpleNamespace(value="shadow"), readiness=owner.readiness, capability_matrix=lambda: ()),
+        settings=SimpleNamespace(public_diagnostics=False, environment=SimpleNamespace(value="production"), schema=lambda: {"schema_version":"test"}),
+        health=h,
+    )
+
+
+@pytest.mark.asyncio
+async def test_transient_readiness_degrades_and_recovers(tmp_path):
+    owner = Owner(healthy=True)
+    rt = runtime_with_owner(owner, root=tmp_path)
+    await rt.shallow_readiness()
+    assert rt.health.state is ProcessState.READY
+    rt.memory = None
+    with pytest.raises(RuntimeError, match="memory is unavailable"):
+        await rt.shallow_readiness()
+    assert rt.health.state is ProcessState.DEGRADED
+    rt.memory = owner
+    await rt.shallow_readiness()
+    assert rt.health.state is ProcessState.READY
+    assert owner.readiness_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_irreversible_corruption_fails_closed(tmp_path):
+    owner = Owner(healthy=None, message="audit hash mismatch corruption")
+    rt = runtime_with_owner(owner, root=tmp_path)
+    with pytest.raises(RuntimeError, match="hash mismatch"):
+        await rt.deep_integrity()
+    assert rt.health.state is ProcessState.FAILED
+    with pytest.raises(RuntimeError, match="closed"):
+        await rt.admission()
+
+
+@pytest.mark.asyncio
+async def test_drain_and_shutdown_are_not_reopened(tmp_path):
+    owner = Owner(healthy=True)
+    rt = runtime_with_owner(owner, root=tmp_path)
+    await rt.shallow_readiness()
+    rt.health.drain()
+    with pytest.raises(RuntimeError, match="closed"):
+        await rt.admission()
+    await rt.close()
+    assert rt.health.state is ProcessState.CLOSED
+    with pytest.raises(RuntimeError, match="closed"):
+        await rt.shallow_readiness()
+
+
+@pytest.mark.asyncio
+async def test_readiness_cost_does_not_scale_with_deep_history(tmp_path):
+    owner = Owner(healthy=True)
+    rt = runtime_with_owner(owner, root=tmp_path)
+    for _ in range(50):
+        await rt.shallow_readiness()
+    assert owner.readiness_calls == 0
+    await rt.deep_integrity()
+    assert owner.readiness_calls > 0


### PR DESCRIPTION
### Motivation
- Prevent deep historical integrity checks from running on every request and ensure transient readiness failures do not permanently poison runtime availability.
- Provide explicit runtime-state semantics (STARTING, ADMITTED, READY, DEGRADED, FAILED, DRAINING, CLOSED) and bounded failure categories to drive safe recovery and operator diagnostics.
- Expose only coarse public liveness/readiness while restricting detailed integrity diagnostics to operator scope.

### Description
- Added a new health contract and state machine in `src/vulcan/runtime/health.py` including `ProcessState`, `HealthFailureCategory`, `HealthStateMachine`, `IntegrityResult`, and `bounded_disk_check`.
- Updated `RuntimeContainer` (`src/vulcan/runtime/container.py`) to include a `health` field, use the state machine to gate admission, implement `shallow_readiness()` (owner presence + bounded disk check, non-blocking) and `deep_integrity()` (offloaded owner readiness checks, cached integrity result, categorized failures), and record integrity outcomes; moved blocking owner checks off the event loop via `asyncio.to_thread`.
- Modified ASGI app behavior in `src/vulcan/runtime/app.py` to run deep integrity at startup, simplify the public `/health/ready` response to a coarse status, and restrict `/health/integrity` diagnostics to operator-scoped requests while returning the cached integrity snapshot.
- Added tests `tests/runtime/test_health_state_machine.py` to cover transient degradation and recovery, irreversible corruption (fail-closed), drain/close semantics, and readiness latency regression ensuring repeated shallow readiness does not call deep owner checks.

### Testing
- Ran targeted unit tests with `python -m pytest -q tests/runtime/test_health_state_machine.py tests/runtime/test_readiness_boundaries.py` and observed all tests passed locally (`6 passed, 1 skipped`).
- Ensured bytecode compilation with `python -m compileall -q src` which completed without errors.
- Ran `git diff --check` locally (no whitespace/errors found) and committed the change; remote baseline ancestry could not be validated because the `origin` remote is not configured in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5d870f9e6c832f96043f099ff6a450)