### PR TITLE
Require canonical audit before composing governed memory and inject borrowed audit ownership

### DIFF
--- a/src/vulcan/memory/composition.py
+++ b/src/vulcan/memory/composition.py
@@ -1,0 +1,12 @@
+"""Composition adapter for governed memory.
+
+This module is the single backward-compatible composition authority.  It keeps
+environment parsing outside the repository and requires callers that enable
+memory to provide the already-created canonical audit owner as a borrowed
+resource.
+"""
+from __future__ import annotations
+
+from .governed import AuditPort, BorrowedAudit, GovernedMemoryPort, MemoryRuntimeConfig, compose_governed_memory
+
+__all__ = ["AuditPort", "BorrowedAudit", "GovernedMemoryPort", "MemoryRuntimeConfig", "compose_governed_memory"]

--- a/src/vulcan/memory/governed.py
+++ b/src/vulcan/memory/governed.py
@@ -61,6 +61,34 @@ class MemoryRuntimeConfig:
             raise RuntimeError("governed-memory database escapes durable root")
         return self
 
+
+class AuditPort(Protocol):
+    owner_id: str
+    def append(self, event_type: str, data: dict[str, object]): ...
+    def readiness(self) -> object: ...
+
+@dataclass(frozen=True)
+class BorrowedAudit:
+    owner_id: str
+    port: AuditPort
+
+    @classmethod
+    def bind(cls, audit: AuditPort) -> "BorrowedAudit":
+        owner_id = getattr(audit, "owner_id", None)
+        if not isinstance(owner_id, str) or not owner_id.startswith("audit:"):
+            raise RuntimeError("canonical memory requires a canonical audit owner")
+        if not callable(getattr(audit, "append", None)) or not callable(getattr(audit, "readiness", None)):
+            raise RuntimeError("canonical memory requires an appendable audit owner")
+        return cls(owner_id, audit)
+
+    def readiness(self) -> None:
+        if getattr(self.port, "_closed", False):
+            raise RuntimeError("canonical memory audit owner is closed")
+        self.port.readiness()
+
+    def append(self, event_type: str, data: dict[str, object]):
+        return self.port.append(event_type, data)
+
 class MemoryKind(str, Enum): EXPLICIT_PREFERENCE = "explicit_preference"
 class MemoryLifecycle(str, Enum): ACTIVE="active"; SUPERSEDED="superseded"; TOMBSTONED="tombstoned"; PURGED="purged"
 class MemoryOperation(str, Enum): CREATE="create"; READ="read"; CORRECT="correct"; FORGET="forget"; LIST="list"; EXPORT="export"; MIGRATE="migrate"
@@ -155,7 +183,7 @@ class GovernedMemoryPort(Protocol):
 
 class SQLiteMemoryRepository:
     """Serialized SQLite repository with immutable revisions and authoritative heads."""
-    def __init__(self,path:str,*,policy:MemoryPolicyPort|None=None,clock:Callable[[],datetime]|None=None, durable_root: str | None = None, audit=None)->None:
+    def __init__(self,path:str,*,policy:MemoryPolicyPort|None=None,clock:Callable[[],datetime]|None=None, durable_root: str | None = None, audit: BorrowedAudit | AuditPort | None = None)->None:
         if not path or path==":memory:": raise ValueError("durable memory requires an explicit filesystem path")
         raw_path=Path(path)
         if raw_path.is_symlink() or Path(str(raw_path)+".lock").is_symlink(): raise RuntimeError("governed-memory symlink path rejected")
@@ -168,7 +196,7 @@ class SQLiteMemoryRepository:
         self._ownership=open(str(self._path)+".lock", "a+", encoding="utf-8")
         try: fcntl.flock(self._ownership.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
         except BlockingIOError as exc: self._ownership.close(); raise RuntimeError("governed-memory writer is already owned") from exc
-        self._lock=threading.RLock(); self._closed=False; self._policy=policy or DefaultMemoryPolicy(); self._clock=clock or (lambda:datetime.now(timezone.utc)); self._audit=audit
+        self._lock=threading.RLock(); self._closed=False; self._policy=policy or DefaultMemoryPolicy(); self._clock=clock or (lambda:datetime.now(timezone.utc)); self._owner_id=f"memory:{self._path}"; self._audit=BorrowedAudit.bind(audit) if audit is not None and not isinstance(audit, BorrowedAudit) else audit
         try:
             self._db=sqlite3.connect(str(self._path),check_same_thread=False,isolation_level=None); self._db.execute("PRAGMA foreign_keys=ON"); self._db.execute("PRAGMA busy_timeout=5000"); self._db.execute("PRAGMA journal_mode=WAL"); self._migrate(); self.readiness()
         except Exception:
@@ -193,6 +221,8 @@ class SQLiteMemoryRepository:
     def readiness(self)->None:
         with self._lock:
             if self._closed: raise RuntimeError("memory repository is closed")
+            if self._audit is None: raise RuntimeError("canonical memory requires canonical audit")
+            self._audit.readiness()
             if self._db.execute("PRAGMA integrity_check").fetchone() != ("ok",): raise RuntimeError("memory repository integrity check failed")
             expected={
                 "memory_schema":{"version"},
@@ -264,8 +294,8 @@ class SQLiteMemoryRepository:
         self._db.execute("INSERT INTO memory_revisions VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",tuple(data[k] for k in ("record_id","revision","tenant_id","subject_id","actor_id","purpose","namespace","key","value","kind","lifecycle","policy_version","created_at","expires_at","deletion_epoch","digest","supersedes")))
     def _journal(self,op,data,digest): self._db.execute("INSERT INTO memory_journal(operation,record_id,revision,tenant_id,subject_id,request_digest,committed_at) VALUES(?,?,?,?,?,?,?)",(op.value,data["record_id"],data["revision"],data["tenant_id"],data["subject_id"],digest,_time(self._clock)))
     def _audit_payload(self,event_type,op,row):
-        h=lambda x: hashlib.sha256(str(x).encode()).hexdigest()[:32]
-        return {"operation_id":row[0],"operation_type":op,"tenant_digest":h(row[5]),"subject_digest":h(row[6]),"purpose":row[7],"namespace":row[8],"key":row[9],"record_id":row[3],"revision":row[4],"prior_record_digest":row[10],"new_record_digest":row[11],"policy_identity":self._policy.version,"policy_revision":self._policy.version,"deletion_epoch":row[12],"result_category":event_type.rsplit("_",1)[-1]}
+        h=lambda x: hashlib.sha256(str(x).encode()).hexdigest()
+        return {"transaction_id":row[0],"operation_id":row[0],"actor_digest":h(row[5]+":"+row[6]),"operation_type":op,"tenant_digest":h(row[5]),"subject_digest":h(row[6]),"purpose":row[7],"namespace":row[8],"key":row[9],"record_id":row[3],"revision":row[4],"prior_record_digest":row[10],"new_record_digest":row[11],"record_digest":row[11],"policy_identity":self._policy.version,"policy_revision":self._policy.version,"deletion_epoch":row[12],"result_category":event_type.rsplit("_",1)[-1]}
     def _audit_event(self,*a,**k): return None
     def _outbox(self,event_type,op,data,digest,prior=None):
         self._db.execute("INSERT OR IGNORE INTO memory_audit_outbox VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,0)",(digest,event_type,op.value,data["record_id"],data["revision"],data["tenant_id"],data["subject_id"],data["purpose"],data["namespace"],data["key"],prior,data["digest"],data["deletion_epoch"],digest))
@@ -273,10 +303,11 @@ class SQLiteMemoryRepository:
         with self._lock:
             rows=self._db.execute("SELECT operation_id,event_type,operation,record_id,revision,tenant_id,subject_id,purpose,namespace,key_name,prior_record_digest,new_record_digest,deletion_epoch,request_digest,audit_complete FROM memory_audit_outbox WHERE audit_complete=0 ORDER BY rowid").fetchall()
             for row in rows:
-                if self._audit is not None:
-                    payload=self._audit_payload(row[1], row[2], row)
-                    self._audit.append('memory.write_prepared', {**payload, 'result_category':'prepared'})
-                    self._audit.append(row[1], payload)
+                if self._audit is None:
+                    raise RuntimeError("canonical memory audit owner is absent")
+                payload=self._audit_payload(row[1], row[2], row)
+                self._audit.append('memory.write_prepared', {**payload, 'result_category':'prepared'})
+                self._audit.append(row[1], payload)
                 self._db.execute("BEGIN IMMEDIATE")
                 try:
                     if row[2]=='create':
@@ -359,6 +390,8 @@ class GovernedMemoryService:
     def close(self):self._repository.close()
     def capabilities(self):
         self.readiness(); return ("governed-preference-memory",)
+    def diagnostics(self):
+        return {"memory_owner_id": self._repository._owner_id, "audit_owner_id": self._repository._audit.owner_id if self._repository._audit else None}
 class DisabledMemoryService:
     def remember(self,*args,**kwargs):return MemoryCommitResult(MemoryReason.MEMORY_DISABLED)
     def retrieve(self,*args,**kwargs):return ()
@@ -368,8 +401,11 @@ class DisabledMemoryService:
     def capabilities(self):return ()
     def close(self):return None
 
-def compose_governed_memory(config: MemoryRuntimeConfig | None = None)->GovernedMemoryPort:
-    config = (config or MemoryRuntimeConfig.from_environment()).validated()
+def compose_governed_memory(config: MemoryRuntimeConfig, *, audit: AuditPort | BorrowedAudit | None = None)->GovernedMemoryPort:
+    config = config.validated()
     if not config.enabled:return DisabledMemoryService()
-    assert config.path is not None and config.durable_root is not None
-    return GovernedMemoryService(SQLiteMemoryRepository(str(config.path), durable_root=str(config.durable_root)))
+    if config.path is None or config.durable_root is None:
+        raise RuntimeError("governed-memory paths must be configured")
+    if audit is None:
+        raise RuntimeError("canonical memory cannot be enabled without canonical audit")
+    return GovernedMemoryService(SQLiteMemoryRepository(str(config.path), durable_root=str(config.durable_root), audit=audit))

--- a/src/vulcan/runtime/container.py
+++ b/src/vulcan/runtime/container.py
@@ -8,7 +8,7 @@ from typing import Any, Literal
 from uuid import uuid4
 from pathlib import Path
 
-from vulcan.memory.governed import GovernedMemoryPort, MemoryRuntimeConfig, compose_governed_memory
+from vulcan.memory.composition import GovernedMemoryPort, MemoryRuntimeConfig, compose_governed_memory
 from vulcan.learning_owner import LearningCapabilityStatus, LearningOwner
 from vulcan.learning_bandit import ShadowLinUCBToolBandit
 
@@ -221,13 +221,13 @@ class RuntimeContainer:
             from vulcan.local_language import build_verified_adapter
             language_input = build_verified_adapter(release_root=config.release_path or "", provider_factory=config.provider_factory)
         language_output: LanguageOutputPort = DeterministicLanguageOutput()
-        memory = compose_governed_memory(MemoryRuntimeConfig(settings.memory_enabled, settings.memory_sqlite_path, settings.durable_root, settings.replicas, settings.memory_backend.value))
         root = str(settings.durable_root)
         Path(root).mkdir(parents=True, exist_ok=True)
-        audit = alignment = domain_registry = self_improvement = None
+        memory = audit = alignment = domain_registry = self_improvement = None
         try:
-            memory.readiness()
             audit = CanonicalAudit(f"{root}/audit/events.jsonl")
+            memory = compose_governed_memory(MemoryRuntimeConfig(settings.memory_enabled, settings.memory_sqlite_path, settings.durable_root, settings.replicas, settings.memory_backend.value), audit=audit)
+            memory.readiness()
             alignment = AlignmentRegistry(f"{root}/alignment/active.json", audit=audit)
             domain_registry = PersistentDomainRegistry(f"{root}/domains", audit=audit)
             self_improvement = compose_self_improvement_runtime(durable_root=Path(root), audit=audit, alignment=alignment, world_model=world_state, approval_hmac_secret=settings.approval_hmac_secret.reveal() if settings.approval_hmac_secret else None)

--- a/tests/integration/test_memory_audit_composition.py
+++ b/tests/integration/test_memory_audit_composition.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+from types import SimpleNamespace
+import pytest
+from vulcan.memory.composition import MemoryRuntimeConfig, compose_governed_memory
+from vulcan.memory.governed import MemoryActorContext, MemoryKind, MemoryReadRequest, MemoryReason, MemoryWriteProposal, SQLiteMemoryRepository
+from vulcan.runtime.audit import CanonicalAudit
+from vulcan.runtime.container import RuntimeContainer
+from vulcan.runtime.settings import RuntimeSettings, VulcanEnvironment, durable_root_paths, OpaqueSecret, SecretSource
+class World:
+    def readiness(self): return True
+class Safety:
+    def readiness(self): return True
+    def validate(self,*args,**kwargs): return True
+    def validate_response(self,*args,**kwargs): return True
+def settings(tmp_path):
+    root=(tmp_path/'durable').resolve(); root.mkdir(exist_ok=True)
+    return RuntimeSettings(environment=VulcanEnvironment.production,jwt_issuer='vulcan',jwt_audience='vulcan-runtime',jwt_secret=OpaqueSecret(SecretSource.direct,'A'*40+'1!bcdefgh','VULCAN_JWT_SECRET'),durable_root=root,durable_paths=durable_root_paths(root),approval_hmac_secret=OpaqueSecret(SecretSource.direct,'B'*40+'1!cdefghi','VULCAN_APPROVAL_HMAC_SECRET'),memory_enabled=True,memory_sqlite_path=root/'memory'/'memory.sqlite')
+def deployment(): return SimpleNamespace(collective=SimpleNamespace(deps=SimpleNamespace(world_model=World(), safety_validator=Safety(), continual=None)))
+def actor(): return MemoryActorContext('tenant','subject','actor', request_id='req')
+def proposal(key='idem'): return MemoryWriteProposal(MemoryKind.EXPLICIT_PREFERENCE,'profile','response_style','concise',key)
+class Owner:
+    owner_id='owner:test'
+    capability=SimpleNamespace(value='shadow')
+    def readiness(self): return True
+    def close(self): return None
+    def capabilities(self): return ()
+
+@pytest.mark.asyncio
+async def test_runtime_memory_audits_closes_restarts_and_borrows_audit(monkeypatch, tmp_path):
+    import vulcan.runtime.container as container
+    monkeypatch.setattr(container, 'compose_self_improvement_runtime', lambda **kwargs: SimpleNamespace(drive=Owner(), capabilities=lambda: (), close=lambda: None))
+    monkeypatch.setattr(container, 'ShadowLinUCBToolBandit', lambda: Owner())
+    monkeypatch.setattr(container, 'LearningOwner', lambda **kwargs: Owner())
+    monkeypatch.setattr(container, 'EnhancedSafetyResponseAdapter', lambda safety: Owner())
+    monkeypatch.setattr(container, 'SafetyResponseFinalizer', lambda response_safety: Owner())
+    c=RuntimeContainer.new(deployment=deployment(), settings=settings(tmp_path)); audit=c.audit; memory=c.memory
+    res=memory.remember(actor(), proposal()); assert res.reason is MemoryReason.COMMITTED
+    assert memory.retrieve(MemoryReadRequest(actor(),'profile','response_style',1))[0].value == 'concise'
+    memory.close(); assert audit is not None; audit.readiness()
+    await c.close()
+    c2=RuntimeContainer.new(deployment=deployment(), settings=settings(tmp_path))
+    try: assert c2.memory.retrieve(MemoryReadRequest(actor(),'profile','response_style',1))[0].value == 'concise'
+    finally: await c2.close()
+def test_memory_enabled_requires_audit(tmp_path):
+    cfg=MemoryRuntimeConfig(True, tmp_path/'m.sqlite', tmp_path)
+    with pytest.raises(RuntimeError, match='audit'): compose_governed_memory(cfg)
+class WrongAudit:
+    owner_id='memory:pretender'
+    def readiness(self): return True
+    def append(self,event_type,data): return None
+def test_wrong_audit_owner_rejected(tmp_path):
+    cfg=MemoryRuntimeConfig(True, tmp_path/'m.sqlite', tmp_path)
+    with pytest.raises(RuntimeError, match='canonical audit owner'): compose_governed_memory(cfg, audit=WrongAudit())
+def test_duplicate_composition_and_close_ordering_fail_closed(tmp_path):
+    audit=CanonicalAudit(tmp_path/'audit/events.jsonl'); cfg=MemoryRuntimeConfig(True, tmp_path/'m.sqlite', tmp_path); first=compose_governed_memory(cfg, audit=audit)
+    try:
+        with pytest.raises(RuntimeError, match='already owned'): compose_governed_memory(cfg, audit=audit)
+        audit.close()
+        with pytest.raises(RuntimeError, match='audit'): first.readiness()
+    finally: first.close()
+def test_repository_does_not_close_borrowed_audit(tmp_path):
+    audit=CanonicalAudit(tmp_path/'audit/events.jsonl'); repo=SQLiteMemoryRepository(str(tmp_path/'m.sqlite'), durable_root=str(tmp_path), audit=audit)
+    repo.close(); audit.readiness(); audit.close()
+def test_disabled_memory_is_null_port(tmp_path):
+    mem=compose_governed_memory(MemoryRuntimeConfig(False), audit=None)
+    assert mem.capabilities() == (); assert mem.remember(actor(), proposal()).reason is MemoryReason.MEMORY_DISABLED

--- a/tests/runtime/test_production_composition.py
+++ b/tests/runtime/test_production_composition.py
@@ -39,13 +39,15 @@ class DummyOwner:
 
 def lightweight_container(monkeypatch: pytest.MonkeyPatch) -> None:
     import vulcan.runtime.container as container
-    monkeypatch.setattr(container, "compose_governed_memory", lambda config: DummyOwner())
+    monkeypatch.setattr(container, "compose_governed_memory", lambda config, **kwargs: DummyOwner())
     monkeypatch.setattr(container, "CanonicalAudit", lambda path: DummyOwner())
     monkeypatch.setattr(container, "AlignmentRegistry", lambda path, audit=None: DummyOwner())
     monkeypatch.setattr(container, "PersistentDomainRegistry", lambda path, audit=None: DummyOwner())
     monkeypatch.setattr(container, "compose_self_improvement_runtime", lambda **kwargs: SimpleNamespace(drive=DummyOwner(), capabilities=lambda: (), close=lambda: None))
     monkeypatch.setattr(container, "ShadowLinUCBToolBandit", lambda: DummyOwner())
     monkeypatch.setattr(container, "LearningOwner", lambda **kwargs: DummyOwner())
+    monkeypatch.setattr(container, "EnhancedSafetyResponseAdapter", lambda safety: DummyOwner())
+    monkeypatch.setattr(container, "SafetyResponseFinalizer", lambda response_safety: DummyOwner())
 
 
 class GoodWorld:

--- a/tests/security/test_governed_memory.py
+++ b/tests/security/test_governed_memory.py
@@ -1,18 +1,24 @@
 """Hard invariants for the small supported governed-memory surface."""
 from datetime import datetime, timedelta, timezone
 
+from vulcan.runtime.audit import CanonicalAudit
 from vulcan.memory.governed import (
     MemoryActor, MemoryKind, MemoryReadRequest, MemoryReason,
     MemoryWriteProposal, SQLiteMemoryRepository,
 )
 
 
+def _repo(tmp_path, **kwargs):
+    audit = CanonicalAudit(tmp_path / "audit" / "events.jsonl")
+    repo = SQLiteMemoryRepository(str(tmp_path / "memory.sqlite"), audit=audit, **kwargs)
+    return repo, audit
+
 def _proposal(value: str, key: str = "idem") -> MemoryWriteProposal:
     return MemoryWriteProposal(MemoryKind.EXPLICIT_PREFERENCE, "profile", "color", value, key)
 
 
 def test_correction_is_immutable_and_stale_revision_conflicts(tmp_path):
-    repo = SQLiteMemoryRepository(str(tmp_path / "memory.sqlite"))
+    repo, audit = _repo(tmp_path)
     actor = MemoryActor("tenant", "subject", "actor")
     first = repo.commit(actor, _proposal("blue")).record
     assert first is not None
@@ -20,11 +26,11 @@ def test_correction_is_immutable_and_stale_revision_conflicts(tmp_path):
     assert corrected.record is not None and corrected.record.revision == 2
     assert repo.correct(actor, first.record_id, 1, _proposal("green", "stale")).reason is MemoryReason.CONFLICT
     assert [record.value for record in repo.read(MemoryReadRequest(actor, "profile", "color"))] == ["red"]
-    repo.close()
+    repo.close(); audit.close()
 
 
 def test_tombstone_is_a_new_revision_and_denies_reads(tmp_path):
-    repo = SQLiteMemoryRepository(str(tmp_path / "memory.sqlite"))
+    repo, audit = _repo(tmp_path)
     actor = MemoryActor("tenant", "subject", "actor")
     first = repo.commit(actor, _proposal("blue")).record
     assert first is not None
@@ -32,17 +38,17 @@ def test_tombstone_is_a_new_revision_and_denies_reads(tmp_path):
     assert deleted.record is not None and deleted.record.revision == 2
     assert repo.read(MemoryReadRequest(actor, "profile", "color")) == ()
     assert repo.tombstone(actor, first.record_id, first.revision).reason is MemoryReason.CONFLICT
-    repo.close()
+    repo.close(); audit.close()
 
 
 def test_scope_and_expiry_are_enforced(tmp_path):
     now = datetime(2026, 1, 1, tzinfo=timezone.utc)
     clock = lambda: now
-    repo = SQLiteMemoryRepository(str(tmp_path / "memory.sqlite"), clock=clock)
+    repo, audit = _repo(tmp_path, clock=clock)
     owner = MemoryActor("tenant", "subject", "actor")
     other = MemoryActor("tenant", "other", "actor")
     assert repo.commit(owner, _proposal("blue")).reason is MemoryReason.COMMITTED
     assert repo.read(MemoryReadRequest(other, "profile", "color")) == ()
     repo._clock = lambda: now + timedelta(days=366)  # controlled clock boundary
     assert repo.read(MemoryReadRequest(owner, "profile", "color")) == ()
-    repo.close()
+    repo.close(); audit.close()

--- a/tests/security/test_governed_memory_architecture.py
+++ b/tests/security/test_governed_memory_architecture.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 import pytest
 from vulcan.memory.governed import MemoryRuntimeConfig, SQLiteMemoryRepository
+from vulcan.runtime.audit import CanonicalAudit
 
 ROOT = Path(__file__).resolve().parents[2]
 
@@ -12,10 +13,11 @@ def test_runtime_does_not_import_legacy_memory_writers():
     assert not any(token in text for token in forbidden)
 
 def test_second_repository_cannot_own_the_same_sqlite_store(tmp_path):
-    first = SQLiteMemoryRepository(str(tmp_path / "preferences.sqlite"))
+    audit = CanonicalAudit(tmp_path / "audit" / "events.jsonl")
+    first = SQLiteMemoryRepository(str(tmp_path / "preferences.sqlite"), audit=audit)
     with pytest.raises(RuntimeError, match="already owned"):
-        SQLiteMemoryRepository(str(tmp_path / "preferences.sqlite"))
-    first.close()
+        SQLiteMemoryRepository(str(tmp_path / "preferences.sqlite"), audit=audit)
+    first.close(); audit.close()
 
 def test_governed_config_rejects_unsafe_or_multi_replica_topology(tmp_path):
     with pytest.raises(RuntimeError):

--- a/tests/security/test_phase7_auth_outbox.py
+++ b/tests/security/test_phase7_auth_outbox.py
@@ -44,7 +44,11 @@ def test_auth_rejects_duplicate_keys_algorithms_key_selection_times_and_mismatch
     with pytest.raises(AuthorizationError): p.require('domains:write')
 
 class FailingAudit:
+    owner_id = "audit:test"
     def __init__(self): self.events=[]; self.fail=False; self.fail_after=False
+    def readiness(self):
+        if self.fail: raise RuntimeError('audit down')
+        return True
     def append(self, et, payload):
         if self.fail: raise RuntimeError('audit down')
         self.events.append((et,payload['operation_id']))


### PR DESCRIPTION
### Motivation
- Prevent enabling canonical memory without an explicit canonical audit owner and remove ambiguous ownership semantics between memory and audit. 
- Fail closed at the memory/audit trust boundary so no authoritative memory write can succeed without a canonical audit present and open. 
- Keep memory disabled as a safe null port while preserving backward compatibility via a single composition adapter.

### Description
- Add `AuditPort` protocol and immutable `BorrowedAudit` contract that validate canonical owner identity and detect closed audits so memory borrows but does not close the audit. (`src/vulcan/memory/governed.py`)
- Harden `SQLiteMemoryRepository` to require a borrowed audit on readiness, perform audit readiness checks, and fail closed when the audit is absent, non-canonical, or closed; preserve repository lock ownership semantics. (`src/vulcan/memory/governed.py`)
- Move environment parsing out of repository construction and create a small composition adapter `src/vulcan/memory/composition.py` that requires callers to inject the already-created audit owner. (`src/vulcan/memory/composition.py`, `src/vulcan/runtime/container.py`)
- Change `RuntimeContainer` composition order to construct the durable root and `CanonicalAudit` before composing governed memory and pass the audit as a borrowed dependency. (`src/vulcan/runtime/container.py`)
- Strengthen audit payload fields and make outbox flush fail closed when the audit owner is absent; add internal diagnostics exposing `memory_owner_id` and `audit_owner_id` only for internal diagnostics APIs. (`src/vulcan/memory/governed.py`)
- Add integration tests exercising runtime composition, borrow semantics, restart reconciliation, absent/wrong audit owner rejection, duplicate composition, close-ordering, and disabled-memory null-port behavior. (`tests/integration/test_memory_audit_composition.py`) and small adjustments to existing tests to use/close the audit where appropriate.

### Testing
- Ran `python -m pytest -q tests/integration/test_memory_audit_composition.py` and observed all tests in that file passed (`6 passed`).
- Ran `python -m pytest -q tests/security/test_governed_memory.py tests/security/test_governed_memory_architecture.py tests/runtime/test_production_composition.py` and observed the targeted suites passed after test updates (`13 passed`).
- Ran focused outbox checks `python -m pytest -q tests/security/test_phase7_auth_outbox.py::test_outbox_pending_excluded_retry_reopen_and_no_duplicate_event tests/security/test_phase7_auth_outbox.py::test_outbox_audit_success_ack_failure_is_idempotent` and those tests passed (`2 passed`).
- Ran `python -m compileall -q src` and `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5dfaf26654832f8782854a409b18fe)