### PR TITLE
Introduce authoritative CognitiveEpisode contract and lifecycle

### DIFF
--- a/docs/architecture/cognitive-episode.md
+++ b/docs/architecture/cognitive-episode.md
@@ -1,0 +1,17 @@
+# Authoritative CognitiveEpisode contract
+
+`vulcan.microkernel.episode.CognitiveEpisode` is the immutable request-scoped aggregate for chat, reasoning, tools, learning, CSIU, and improvement. Legacy `CognitiveCase` remains as a compatibility adapter and must not become a second authority.
+
+## Lifecycle
+
+Episodes move only through typed transitions in `vulcan.microkernel.state_machine`: `PERCEIVED`, `INTERPRETED`, `GROUNDED`, `DELIBERATING`, `EPISTEMICALLY_COMMITTED`, `NORMATIVELY_AUTHORIZED`, `EXECUTED`, `OBSERVED`, `COMMUNICATED`, and `CONSOLIDATED`. Terminal failure outcomes are `ABSTAINED`, `BLOCKED`, `FAILED`, and `CANCELLED`.
+
+Every transition records an event with the prior episode digest, transition reason, authority, snapshot identifiers, and evidence references. Canonical JSON uses sorted keys and compact separators; the episode digest is the SHA-256 digest of the canonical payload excluding the digest field.
+
+## Durable retention policy
+
+Raw request bytes may exist only in working memory long enough to compute a digest and approved projection digest. Durable episode and audit stores persist `input_digest`, optional approved `projection_digest`, references, and canonical digests; they must not persist raw prompts, raw provider text, secrets, hidden prompts, or private reasoning traces.
+
+## Migration and rollback
+
+`vulcan.runtime.case.episode_from_case` is the single explicit adapter from legacy `CognitiveCase` to `CognitiveEpisode`. Rollback keeps the adapter while callers continue using `CognitiveCase`; no durable schema may introduce a separate cognitive authority.

--- a/src/vulcan/microkernel/__init__.py
+++ b/src/vulcan/microkernel/__init__.py
@@ -1,0 +1,3 @@
+"""Cognitive microkernel contracts."""
+
+from .episode import *

--- a/src/vulcan/microkernel/episode.py
+++ b/src/vulcan/microkernel/episode.py
@@ -1,0 +1,219 @@
+"""Immutable, versioned CognitiveEpisode aggregate.
+
+The episode is the authoritative request-scoped cognitive contract. Raw input is
+accepted only at construction time for digesting and is never retained in the
+serialized aggregate.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from hashlib import sha256
+import json
+from types import MappingProxyType
+from typing import Mapping, Protocol, Sequence
+from uuid import uuid4
+
+from .state_machine import EpisodeState, EpisodeTransitionError, ensure_transition
+
+SCHEMA_VERSION = "cognitive-episode.v1"
+GENESIS_DIGEST = "0" * 64
+
+
+class Clock(Protocol):
+    def __call__(self) -> datetime: ...
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _digest_bytes(value: bytes) -> str:
+    return sha256(value).hexdigest()
+
+
+def digest_text(text: str) -> str:
+    return _digest_bytes(text.encode("utf-8"))
+
+
+def _canon(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def canonical_digest(value: object) -> str:
+    return _digest_bytes(_canon(value).encode("utf-8"))
+
+
+def _freeze_mapping(value: Mapping[str, str] | None) -> Mapping[str, str]:
+    return MappingProxyType(dict(value or {}))
+
+
+@dataclass(frozen=True)
+class ActorBinding:
+    actor_id: str
+    principal_digest: str
+    authority: str
+
+    def to_json(self) -> dict[str, str]:
+        return {"actor_id": self.actor_id, "authority": self.authority, "principal_digest": self.principal_digest}
+
+
+@dataclass(frozen=True)
+class RequestBinding:
+    request_id: str
+    input_digest: str
+    projection_digest: str | None = None
+    retention_policy: str = "raw-request-working-memory-only; durable-episode-digests-and-approved-projections"
+
+    def to_json(self) -> dict[str, str | None]:
+        return {"input_digest": self.input_digest, "projection_digest": self.projection_digest, "request_id": self.request_id, "retention_policy": self.retention_policy}
+
+
+@dataclass(frozen=True)
+class SnapshotBundleRef:
+    bundle_id: str
+    state_digest: str
+
+    def to_json(self) -> dict[str, str]:
+        return {"bundle_id": self.bundle_id, "state_digest": self.state_digest}
+
+
+@dataclass(frozen=True)
+class EpisodeRef:
+    episode_id: str
+    digest: str
+
+    def to_json(self) -> dict[str, str]:
+        return {"digest": self.digest, "episode_id": self.episode_id}
+
+
+@dataclass(frozen=True)
+class ArtifactRef:
+    artifact_id: str
+    digest: str
+    kind: str
+
+    def to_json(self) -> dict[str, str]:
+        return {"artifact_id": self.artifact_id, "digest": self.digest, "kind": self.kind}
+
+
+@dataclass(frozen=True)
+class TransitionEvent:
+    event_id: str
+    from_state: EpisodeState
+    to_state: EpisodeState
+    at: datetime
+    reason: str
+    authority: str
+    prior_digest: str
+    snapshot_ids: tuple[str, ...] = ()
+    evidence_refs: tuple[ArtifactRef, ...] = ()
+    event_digest: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "snapshot_ids", tuple(self.snapshot_ids))
+        object.__setattr__(self, "evidence_refs", tuple(self.evidence_refs))
+        object.__setattr__(self, "event_digest", canonical_digest(self.to_json(include_digest=False)))
+
+    def to_json(self, *, include_digest: bool = True) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "at": self.at.astimezone(timezone.utc).isoformat(),
+            "authority": self.authority,
+            "event_id": self.event_id,
+            "evidence_refs": [ref.to_json() for ref in self.evidence_refs],
+            "from_state": self.from_state.value,
+            "prior_digest": self.prior_digest,
+            "reason": self.reason,
+            "snapshot_ids": list(self.snapshot_ids),
+            "to_state": self.to_state.value,
+        }
+        if include_digest:
+            payload["event_digest"] = self.event_digest
+        return payload
+
+
+@dataclass(frozen=True)
+class CognitiveEpisode:
+    episode_id: str
+    actor: ActorBinding
+    request: RequestBinding
+    state: EpisodeState = EpisodeState.PERCEIVED
+    schema_version: str = SCHEMA_VERSION
+    conversation_id: str | None = None
+    parent: EpisodeRef | None = None
+    snapshot_bundle: SnapshotBundleRef | None = None
+    interpretation: Mapping[str, str] = field(default_factory=dict)
+    claims: tuple[ArtifactRef, ...] = ()
+    evidence: tuple[ArtifactRef, ...] = ()
+    derivations: tuple[ArtifactRef, ...] = ()
+    candidate_plans: tuple[ArtifactRef, ...] = ()
+    authorization: ArtifactRef | None = None
+    effects: tuple[ArtifactRef, ...] = ()
+    response: ArtifactRef | None = None
+    consolidation_refs: tuple[ArtifactRef, ...] = ()
+    transitions: tuple[TransitionEvent, ...] = ()
+    digest: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "interpretation", _freeze_mapping(self.interpretation))
+        for name in ("claims", "evidence", "derivations", "candidate_plans", "effects", "consolidation_refs", "transitions"):
+            object.__setattr__(self, name, tuple(getattr(self, name)))
+        object.__setattr__(self, "digest", canonical_digest(self.to_json(include_digest=False)))
+
+    @classmethod
+    def create(cls, *, actor: ActorBinding, request_id: str, input_digest: str | None = None, raw_request: bytes | str | None = None,
+               conversation_id: str | None = None, parent: EpisodeRef | None = None, snapshot_bundle: SnapshotBundleRef | None = None,
+               projection_digest: str | None = None, clock: Clock = utc_now) -> "CognitiveEpisode":
+        if input_digest is None:
+            if raw_request is None:
+                raise ValueError("input_digest or raw_request is required")
+            raw = raw_request.encode("utf-8") if isinstance(raw_request, str) else raw_request
+            input_digest = _digest_bytes(raw)
+        episode = cls(episode_id=str(uuid4()), actor=actor, request=RequestBinding(request_id, input_digest, projection_digest), conversation_id=conversation_id, parent=parent, snapshot_bundle=snapshot_bundle)
+        return episode._append_event(EpisodeState.PERCEIVED, reason="created", authority=actor.authority, clock=clock)
+
+    def transition(self, target: EpisodeState, *, reason: str, authority: str, clock: Clock = utc_now,
+                   snapshot_ids: Sequence[str] = (), evidence_refs: Sequence[ArtifactRef] = (),
+                   interpretation: Mapping[str, str] | None = None, claims: Sequence[ArtifactRef] = (), evidence: Sequence[ArtifactRef] = (),
+                   derivations: Sequence[ArtifactRef] = (), candidate_plans: Sequence[ArtifactRef] = (), authorization: ArtifactRef | None = None,
+                   effects: Sequence[ArtifactRef] = (), response: ArtifactRef | None = None, consolidation_refs: Sequence[ArtifactRef] = ()) -> "CognitiveEpisode":
+        if not authority:
+            raise EpisodeTransitionError("transition authority is required")
+        ensure_transition(self.state, target)
+        prior_digest = self.digest
+        updated = replace(
+            self,
+            state=target,
+            interpretation=_freeze_mapping(interpretation) if interpretation is not None else self.interpretation,
+            claims=(*self.claims, *tuple(claims)),
+            evidence=(*self.evidence, *tuple(evidence)),
+            derivations=(*self.derivations, *tuple(derivations)),
+            candidate_plans=(*self.candidate_plans, *tuple(candidate_plans)),
+            authorization=authorization if authorization is not None else self.authorization,
+            effects=(*self.effects, *tuple(effects)),
+            response=response if response is not None else self.response,
+            consolidation_refs=(*self.consolidation_refs, *tuple(consolidation_refs)),
+        )
+        return updated._append_event(target, reason=reason, authority=authority, clock=clock, snapshot_ids=tuple(snapshot_ids), evidence_refs=tuple(evidence_refs), prior_digest=prior_digest)
+
+    def _append_event(self, target: EpisodeState, *, reason: str, authority: str, clock: Clock, snapshot_ids: Sequence[str] = (), evidence_refs: Sequence[ArtifactRef] = (), prior_digest: str | None = None) -> "CognitiveEpisode":
+        event = TransitionEvent(str(uuid4()), self.state, target, clock(), reason, authority, prior_digest or (self.digest if self.transitions else GENESIS_DIGEST), tuple(snapshot_ids), tuple(evidence_refs))
+        return replace(self, transitions=(*self.transitions, event))
+
+    def to_json(self, *, include_digest: bool = True) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "actor": self.actor.to_json(), "authorization": self.authorization.to_json() if self.authorization else None,
+            "candidate_plans": [x.to_json() for x in self.candidate_plans], "claims": [x.to_json() for x in self.claims],
+            "consolidation_refs": [x.to_json() for x in self.consolidation_refs], "conversation_id": self.conversation_id,
+            "derivations": [x.to_json() for x in self.derivations], "effects": [x.to_json() for x in self.effects],
+            "episode_id": self.episode_id, "evidence": [x.to_json() for x in self.evidence], "interpretation": dict(self.interpretation),
+            "parent": self.parent.to_json() if self.parent else None, "request": self.request.to_json(), "response": self.response.to_json() if self.response else None,
+            "schema_version": self.schema_version, "snapshot_bundle": self.snapshot_bundle.to_json() if self.snapshot_bundle else None,
+            "state": self.state.value, "transitions": [event.to_json() for event in self.transitions],
+        }
+        if include_digest:
+            payload["digest"] = self.digest
+        return payload
+
+    def canonical_json(self) -> str:
+        return _canon(self.to_json())

--- a/src/vulcan/microkernel/state_machine.py
+++ b/src/vulcan/microkernel/state_machine.py
@@ -1,0 +1,60 @@
+"""Authoritative CognitiveEpisode lifecycle state machine."""
+from __future__ import annotations
+
+from enum import Enum
+
+
+class EpisodeState(str, Enum):
+    PERCEIVED = "perceived"
+    INTERPRETED = "interpreted"
+    GROUNDED = "grounded"
+    DELIBERATING = "deliberating"
+    EPISTEMICALLY_COMMITTED = "epistemically_committed"
+    NORMATIVELY_AUTHORIZED = "normatively_authorized"
+    EXECUTED = "executed"
+    OBSERVED = "observed"
+    COMMUNICATED = "communicated"
+    CONSOLIDATED = "consolidated"
+    ABSTAINED = "abstained"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+    @property
+    def is_terminal(self) -> bool:
+        return self in TERMINAL_STATES
+
+
+TERMINAL_STATES = frozenset({
+    EpisodeState.CONSOLIDATED,
+    EpisodeState.ABSTAINED,
+    EpisodeState.BLOCKED,
+    EpisodeState.FAILED,
+    EpisodeState.CANCELLED,
+})
+
+ALLOWED_TRANSITIONS: dict[EpisodeState, frozenset[EpisodeState]] = {
+    EpisodeState.PERCEIVED: frozenset({EpisodeState.INTERPRETED, EpisodeState.ABSTAINED, EpisodeState.BLOCKED, EpisodeState.FAILED, EpisodeState.CANCELLED}),
+    EpisodeState.INTERPRETED: frozenset({EpisodeState.GROUNDED, EpisodeState.ABSTAINED, EpisodeState.BLOCKED, EpisodeState.FAILED, EpisodeState.CANCELLED}),
+    EpisodeState.GROUNDED: frozenset({EpisodeState.DELIBERATING, EpisodeState.ABSTAINED, EpisodeState.BLOCKED, EpisodeState.FAILED, EpisodeState.CANCELLED}),
+    EpisodeState.DELIBERATING: frozenset({EpisodeState.EPISTEMICALLY_COMMITTED, EpisodeState.ABSTAINED, EpisodeState.BLOCKED, EpisodeState.FAILED, EpisodeState.CANCELLED}),
+    EpisodeState.EPISTEMICALLY_COMMITTED: frozenset({EpisodeState.NORMATIVELY_AUTHORIZED, EpisodeState.ABSTAINED, EpisodeState.BLOCKED, EpisodeState.FAILED, EpisodeState.CANCELLED}),
+    EpisodeState.NORMATIVELY_AUTHORIZED: frozenset({EpisodeState.EXECUTED, EpisodeState.ABSTAINED, EpisodeState.BLOCKED, EpisodeState.FAILED, EpisodeState.CANCELLED}),
+    EpisodeState.EXECUTED: frozenset({EpisodeState.OBSERVED, EpisodeState.FAILED, EpisodeState.CANCELLED}),
+    EpisodeState.OBSERVED: frozenset({EpisodeState.COMMUNICATED, EpisodeState.FAILED, EpisodeState.CANCELLED}),
+    EpisodeState.COMMUNICATED: frozenset({EpisodeState.CONSOLIDATED, EpisodeState.FAILED, EpisodeState.CANCELLED}),
+    EpisodeState.CONSOLIDATED: frozenset(),
+    EpisodeState.ABSTAINED: frozenset(),
+    EpisodeState.BLOCKED: frozenset(),
+    EpisodeState.FAILED: frozenset(),
+    EpisodeState.CANCELLED: frozenset(),
+}
+
+
+class EpisodeTransitionError(ValueError):
+    """Raised when an episode transition violates the authoritative lifecycle."""
+
+
+def ensure_transition(current: EpisodeState, target: EpisodeState) -> None:
+    if target not in ALLOWED_TRANSITIONS[current]:
+        raise EpisodeTransitionError(f"invalid CognitiveEpisode transition {current.value} -> {target.value}")

--- a/src/vulcan/runtime/case.py
+++ b/src/vulcan/runtime/case.py
@@ -13,6 +13,9 @@ if TYPE_CHECKING:
                            EvidenceArtifact, InterpretationBundle, ResponseIR)
 from uuid import uuid4
 
+from vulcan.microkernel.episode import ActorBinding, CognitiveEpisode
+from vulcan.microkernel.state_machine import ALLOWED_TRANSITIONS, EpisodeState
+
 
 class CognitiveCaseStatus(str, Enum):
     OPEN = "open"
@@ -55,6 +58,7 @@ class CognitiveCase:
     finalization_status: str | None = None
     render_artifact: object | None = field(default=None, repr=False)
     events: list[CaseEvent] = field(default_factory=list)
+    episode: CognitiveEpisode | None = field(default=None, repr=False)
 
     @classmethod
     def create(cls, *, request_id: str, conversation_id: str | None, input_digest: str | None = None,
@@ -65,7 +69,17 @@ class CognitiveCase:
             if message is None:
                 raise ValueError("input_digest is required")
             input_digest = sha256(message.encode("utf-8")).hexdigest()
-        case = cls(request_id=request_id, conversation_id=conversation_id, input_hash=input_digest)
+        episode = CognitiveEpisode.create(
+            actor=ActorBinding(
+                actor_id="legacy-runtime",
+                principal_digest=sha256(request_id.encode("utf-8")).hexdigest(),
+                authority="CognitiveCaseAdapter",
+            ),
+            request_id=request_id,
+            input_digest=input_digest,
+            conversation_id=conversation_id,
+        )
+        case = cls(request_id=request_id, conversation_id=conversation_id, input_hash=input_digest, case_id=episode.episode_id, episode=episode)
         case.record("created")
         return case
 
@@ -113,3 +127,32 @@ class CognitiveCase:
         self.failure_kind = failure_kind
         self.record("terminal", status.value)
         self.terminal_status = status
+        if self.episode is not None:
+            target = {
+                CognitiveCaseStatus.SUCCESS: EpisodeState.COMMUNICATED,
+                CognitiveCaseStatus.ABSTAINED: EpisodeState.ABSTAINED,
+                CognitiveCaseStatus.BLOCKED: EpisodeState.BLOCKED,
+                CognitiveCaseStatus.FINALIZATION_ERROR: EpisodeState.FAILED,
+                CognitiveCaseStatus.FAILED: EpisodeState.FAILED,
+                CognitiveCaseStatus.CANCELLED: EpisodeState.CANCELLED,
+            }.get(status)
+            if target is not None and target in ALLOWED_TRANSITIONS[self.episode.state]:
+                self.episode = self.episode.transition(
+                    target, reason=failure_kind or status.value, authority="CognitiveCaseAdapter"
+                )
+
+
+def episode_from_case(case: CognitiveCase) -> CognitiveEpisode:
+    """Compatibility adapter exposing the authoritative episode for a legacy case."""
+    if case.episode is not None:
+        return case.episode
+    return CognitiveEpisode.create(
+        actor=ActorBinding(
+            actor_id="legacy-runtime",
+            principal_digest=sha256(case.request_id.encode("utf-8")).hexdigest(),
+            authority="CognitiveCaseAdapter",
+        ),
+        request_id=case.request_id,
+        input_digest=case.input_hash,
+        conversation_id=case.conversation_id,
+    )

--- a/tests/microkernel/test_episode.py
+++ b/tests/microkernel/test_episode.py
@@ -1,0 +1,72 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from vulcan.microkernel.episode import ActorBinding, ArtifactRef, CognitiveEpisode, canonical_digest, digest_text
+from vulcan.microkernel.state_machine import EpisodeState, EpisodeTransitionError
+from vulcan.runtime.case import CognitiveCase, episode_from_case
+
+
+def fixed_clock():
+    return datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def actor():
+    return ActorBinding("user:1", "a" * 64, "microkernel")
+
+
+def ref(kind="evidence"):
+    return ArtifactRef(f"{kind}:1", "b" * 64, kind)
+
+
+def test_episode_does_not_persist_raw_input_and_serializes_canonically():
+    ep = CognitiveEpisode.create(actor=actor(), request_id="r1", raw_request="secret token", clock=fixed_clock)
+    encoded = ep.canonical_json()
+    assert "secret token" not in encoded
+    assert ep.request.input_digest == digest_text("secret token")
+    assert ep.to_json()["schema_version"] == "cognitive-episode.v1"
+    assert ep.digest == canonical_digest(ep.to_json(include_digest=False))
+
+
+def test_digest_chain_binds_transition_to_prior_episode_digest():
+    ep = CognitiveEpisode.create(actor=actor(), request_id="r1", input_digest="c" * 64, clock=fixed_clock)
+    prior = ep.digest
+    ep2 = ep.transition(EpisodeState.INTERPRETED, reason="schema-valid", authority="microkernel", clock=fixed_clock, interpretation={"intent": "chat"}, evidence_refs=[ref()])
+    assert ep2.transitions[-1].prior_digest == prior
+    assert ep2.transitions[-1].event_digest == canonical_digest(ep2.transitions[-1].to_json(include_digest=False))
+    assert ep2.digest != prior
+
+
+def test_invalid_transition_and_missing_authority_fail_closed():
+    ep = CognitiveEpisode.create(actor=actor(), request_id="r1", input_digest="c" * 64, clock=fixed_clock)
+    with pytest.raises(EpisodeTransitionError):
+        ep.transition(EpisodeState.EXECUTED, reason="skip", authority="microkernel", clock=fixed_clock)
+    with pytest.raises(EpisodeTransitionError):
+        ep.transition(EpisodeState.INTERPRETED, reason="no-authority", authority="", clock=fixed_clock)
+
+
+def test_episode_is_immutable_and_collections_are_not_externally_mutable():
+    ep = CognitiveEpisode.create(actor=actor(), request_id="r1", input_digest="c" * 64, clock=fixed_clock)
+    with pytest.raises(Exception):
+        ep.state = EpisodeState.FAILED
+    with pytest.raises(TypeError):
+        ep.interpretation["x"] = "y"
+    assert isinstance(ep.transitions, tuple)
+
+
+def test_lifecycle_success_path_property():
+    ep = CognitiveEpisode.create(actor=actor(), request_id="r1", input_digest="c" * 64, clock=fixed_clock)
+    for state in [EpisodeState.INTERPRETED, EpisodeState.GROUNDED, EpisodeState.DELIBERATING, EpisodeState.EPISTEMICALLY_COMMITTED, EpisodeState.NORMATIVELY_AUTHORIZED, EpisodeState.EXECUTED, EpisodeState.OBSERVED, EpisodeState.COMMUNICATED, EpisodeState.CONSOLIDATED]:
+        ep = ep.transition(state, reason=state.value, authority="microkernel", clock=fixed_clock, snapshot_ids=["snap-1"], evidence_refs=[ref()])
+    assert ep.state is EpisodeState.CONSOLIDATED
+    with pytest.raises(EpisodeTransitionError):
+        ep.transition(EpisodeState.FAILED, reason="late", authority="microkernel", clock=fixed_clock)
+
+
+def test_legacy_cognitive_case_adapter_preserves_request_ledger_identity():
+    case = CognitiveCase.create(request_id="request", conversation_id="conversation", input_digest="d" * 64)
+    ep = episode_from_case(case)
+    assert ep.episode_id == case.case_id
+    assert ep.request.request_id == case.request_id
+    assert ep.conversation_id == case.conversation_id
+    assert ep.request.input_digest == case.input_hash


### PR DESCRIPTION
### Motivation
- Replace the mutable, request-local `CognitiveCase` with an authoritative, immutable, versioned `CognitiveEpisode` aggregate to centralize cognitive authority, provide append-only transitions, and enable canonical digest chaining for audit and reconciliation.
- Enforce an explicit microkernel lifecycle (`PERCEIVED`, `INTERPRETED`, `GROUNDED`, `DELIBERATING`, `EPISTEMICALLY_COMMITTED`, `NORMATIVELY_AUTHORIZED`, `EXECUTED`, `OBSERVED`, `COMMUNICATED`, `CONSOLIDATED` plus typed failure terminals) so transitions are validated and fail-closed when authority is missing or illegal.
- Maintain backward compatibility via a single adapter path from `CognitiveCase` to `CognitiveEpisode` and minimize durable retention of raw request bytes (durable stores persist digests and approved projections only). 

### Description
- Add `src/vulcan/microkernel/episode.py` implementing `CognitiveEpisode`, typed `ActorBinding`/`RequestBinding`/`ArtifactRef`/`EpisodeRef`, immutable tuple-backed collections, `TransitionEvent` that records prior digest/authority/reason/snapshots/evidence and computes an event digest, canonical JSON serialization, and append-only `transition` APIs.  
- Add `src/vulcan/microkernel/state_machine.py` defining `EpisodeState`, the `ALLOWED_TRANSITIONS` map, terminal states, and `ensure_transition`/`EpisodeTransitionError` to validate lifecycle moves.  
- Add a single compatibility adapter in `src/vulcan/runtime/case.py` that binds new `CognitiveCase` instances to an authoritative `CognitiveEpisode` (adds `episode` field, constructs an episode on `create`, mirrors `close` into a compatible episode transition when allowed, and exposes `episode_from_case`).  
- Add documentation `docs/architecture/cognitive-episode.md` describing the contract, retention policy, migration and rollback guidance, and add focused tests in `tests/microkernel/test_episode.py` covering serialization, raw-input nonpersistence, digest chains, invalid transitions, immutability, lifecycle success path, and compatibility. 

### Testing
- Ran `pytest -q tests/microkernel/test_episode.py` and all tests passed (`6 passed`).
- Ran `python -m compileall -q src` and compilation succeeded.
- Executed a broader security/integration test set while validating the change and observed unrelated environment/precondition failures (11 failing tests) caused by missing runtime preconditions or test fixtures such as a required `settings` argument, missing `fastapi`, and missing audit files; these failures are environment- or precondition-related and not introduced by this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e02caf008832fb1c61a368362113b)