### PR TITLE
Draft: Implement microkernel principals, authority lattice, and in-process capability tokens

### DIFF
--- a/docs/architecture/adr-005-cognitive-authority.md
+++ b/docs/architecture/adr-005-cognitive-authority.md
@@ -30,3 +30,24 @@ Only the cognitive microkernel may commit beliefs, authorize plans, publish effe
 ## Current owner and transaction boundary
 
 At this prompt's baseline, ADR-003 identifies `RuntimeContainer` and its `CognitiveKernel` as the current production owner. The exact transaction boundary for this architectural decision is the git commit containing these ADRs and `ami-invariants.yaml`; runtime durable transaction code is out of scope for P00 and must cite these invariants when implemented.
+
+## P26 implementation note: principals and capabilities
+
+P26 adds typed principal identities for human, system kernel, language provider,
+reasoner, retriever, tool, policy authority, operator, auditor, and external
+provider actors. Principal metadata is descriptive only and never grants
+authority. The microkernel remains the only principal kind allowed to promote an
+artifact through the authority lattice, and promotion records bind the promoted
+level to validation, policy, validator, and evidence digests.
+
+Privileged operations are separated into proposal creation, authority reads,
+belief commitment, plan authorization, effect execution, memory mutation, and
+policy activation. Unknown operations fail closed. High-risk grants and denials
+are audited with principal and resource digests rather than raw resource content,
+secrets, or personal data.
+
+In-process capability tokens are intentionally non-serializable authority
+objects. They bind principal identity, release digest, operation, episode,
+resource digest, expiry, and nonce; replay is denied by the issuer. Persisted
+approval signatures remain a future migration and these object tokens are not a
+cryptographic proof across process or persistence boundaries.

--- a/src/vulcan/microkernel/__init__.py
+++ b/src/vulcan/microkernel/__init__.py
@@ -1,3 +1,6 @@
 """Cognitive microkernel contracts."""
 
 from .episode import *
+from .principals import *
+from .authority import *
+from .capability_tokens import *

--- a/src/vulcan/microkernel/authority.py
+++ b/src/vulcan/microkernel/authority.py
@@ -1,0 +1,129 @@
+"""Authority lattice, operations, and audited authorization decisions."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+
+from .principals import Principal, digest
+
+
+class AuthorityLevel(str, Enum):
+    UNTRUSTED_PROPOSAL = "untrusted_proposal"
+    VALIDATED_CANDIDATE = "validated_candidate"
+    COMMITTED_BELIEF = "committed_belief"
+    AUTHORIZED_PLAN = "authorized_plan"
+    EXECUTED_EFFECT = "executed_effect"
+
+
+_AUTHORITY_ORDER = {
+    AuthorityLevel.UNTRUSTED_PROPOSAL: 0,
+    AuthorityLevel.VALIDATED_CANDIDATE: 1,
+    AuthorityLevel.COMMITTED_BELIEF: 2,
+    AuthorityLevel.AUTHORIZED_PLAN: 3,
+    AuthorityLevel.EXECUTED_EFFECT: 4,
+}
+
+
+class Operation(str, Enum):
+    PROPOSE = "proposal.create"
+    READ = "authority.read"
+    COMMIT_BELIEF = "belief.commit"
+    AUTHORIZE_PLAN = "plan.authorize"
+    EXECUTE_EFFECT = "effect.execute"
+    MUTATE_MEMORY = "memory.mutate"
+    ACTIVATE_POLICY = "policy.activate"
+
+
+_OPERATION_MINIMUM = {
+    Operation.PROPOSE: AuthorityLevel.UNTRUSTED_PROPOSAL,
+    Operation.READ: AuthorityLevel.VALIDATED_CANDIDATE,
+    Operation.COMMIT_BELIEF: AuthorityLevel.COMMITTED_BELIEF,
+    Operation.AUTHORIZE_PLAN: AuthorityLevel.AUTHORIZED_PLAN,
+    Operation.EXECUTE_EFFECT: AuthorityLevel.EXECUTED_EFFECT,
+    Operation.MUTATE_MEMORY: AuthorityLevel.COMMITTED_BELIEF,
+    Operation.ACTIVATE_POLICY: AuthorityLevel.AUTHORIZED_PLAN,
+}
+
+_HIGH_RISK = frozenset({Operation.COMMIT_BELIEF, Operation.AUTHORIZE_PLAN, Operation.EXECUTE_EFFECT, Operation.MUTATE_MEMORY, Operation.ACTIVATE_POLICY})
+
+
+class AuthorityError(PermissionError):
+    """Raised when authority validation fails closed."""
+
+
+@dataclass(frozen=True)
+class EvidenceRecord:
+    validator_principal_digest: str
+    validation_digest: str
+    policy_digest: str
+    observed_at: datetime
+    evidence_refs: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        for name in ("validator_principal_digest", "validation_digest", "policy_digest"):
+            value = getattr(self, name)
+            if len(value) != 64 or any(c not in "0123456789abcdef" for c in value):
+                raise ValueError(f"{name} must be a lowercase sha256 hex digest")
+        object.__setattr__(self, "evidence_refs", tuple(self.evidence_refs))
+
+    def to_json(self) -> dict[str, object]:
+        return {"evidence_refs": list(self.evidence_refs), "observed_at": self.observed_at.astimezone(timezone.utc).isoformat(), "policy_digest": self.policy_digest, "validation_digest": self.validation_digest, "validator_principal_digest": self.validator_principal_digest}
+
+
+@dataclass(frozen=True)
+class AuthorityGrant:
+    principal_digest: str
+    level: AuthorityLevel
+    evidence_digest: str
+
+
+@dataclass(frozen=True)
+class AuditEvent:
+    decision: str
+    principal_digest: str
+    operation: str
+    authority_level: str
+    episode_id: str
+    resource_digest: str
+    reason: str
+    at: datetime
+
+    def to_json(self) -> dict[str, str]:
+        return {"at": self.at.astimezone(timezone.utc).isoformat(), "authority_level": self.authority_level, "decision": self.decision, "episode_id": self.episode_id, "operation": self.operation, "principal_digest": self.principal_digest, "reason": self.reason, "resource_digest": self.resource_digest}
+
+
+@dataclass
+class AuditSink:
+    events: list[AuditEvent] = field(default_factory=list)
+
+    def record(self, event: AuditEvent) -> None:
+        self.events.append(event)
+
+
+def promote_authority(*, current: AuthorityLevel, target: AuthorityLevel, principal: Principal, evidence: EvidenceRecord) -> AuthorityGrant:
+    if not principal.is_kernel:
+        raise AuthorityError("only SYSTEM_KERNEL may promote authority")
+    if _AUTHORITY_ORDER[target] < _AUTHORITY_ORDER[current]:
+        raise AuthorityError("authority promotion must be monotonic")
+    return AuthorityGrant(principal.identity_digest, target, digest(evidence.to_json()))
+
+
+def operation_from_value(value: object) -> Operation:
+    if isinstance(value, Operation):
+        return value
+    if isinstance(value, str):
+        try:
+            return Operation(value)
+        except ValueError as exc:
+            raise AuthorityError("unknown operation denied") from exc
+    raise AuthorityError("operation must be an Operation")
+
+
+def require_authority(*, principal: Principal, grant: AuthorityGrant, operation: Operation | str, episode_id: str, resource_digest: str, audit: AuditSink, clock) -> None:
+    op = operation_from_value(operation)
+    granted = grant.principal_digest == principal.identity_digest and _AUTHORITY_ORDER[grant.level] >= _AUTHORITY_ORDER[_OPERATION_MINIMUM[op]]
+    if op in _HIGH_RISK:
+        audit.record(AuditEvent("granted" if granted else "denied", principal.identity_digest, op.value, grant.level.value, episode_id, resource_digest, "capability_authorization", clock()))
+    if not granted:
+        raise AuthorityError("capability denied")

--- a/src/vulcan/microkernel/capability_tokens.py
+++ b/src/vulcan/microkernel/capability_tokens.py
@@ -1,0 +1,67 @@
+"""In-process capability tokens bound to exact principal and operation context."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from secrets import token_hex
+from threading import Lock
+
+from .authority import AuthorityError, AuthorityGrant, Operation, require_authority, AuditSink
+from .principals import Principal, digest
+
+
+@dataclass(frozen=True)
+class CapabilityToken:
+    principal_digest: str
+    release_digest: str
+    operation: Operation
+    episode_id: str
+    resource_digest: str
+    expires_at: datetime
+    nonce: str = field(default_factory=lambda: token_hex(32))
+    token_digest: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if len(self.nonce) < 32:
+            raise ValueError("nonce is too short")
+        object.__setattr__(self, "token_digest", digest(self.to_json(include_digest=False)))
+
+    def to_json(self, *, include_digest: bool = True) -> dict[str, str]:
+        payload = {"episode_id": self.episode_id, "expires_at": self.expires_at.astimezone(timezone.utc).isoformat(), "nonce": self.nonce, "operation": self.operation.value, "principal_digest": self.principal_digest, "release_digest": self.release_digest, "resource_digest": self.resource_digest}
+        if include_digest:
+            payload["token_digest"] = self.token_digest
+        return payload
+
+    @classmethod
+    def from_json(cls, _payload: object) -> "CapabilityToken":
+        raise AuthorityError("serialized capability tokens are not accepted in-process")
+
+
+class CapabilityTokenIssuer:
+    def __init__(self) -> None:
+        self._issued: set[str] = set()
+        self._used: set[str] = set()
+        self._lock = Lock()
+
+    def issue(self, *, principal: Principal, grant: AuthorityGrant, operation: Operation, episode_id: str, resource_digest: str, expires_at: datetime, audit: AuditSink, clock) -> CapabilityToken:
+        require_authority(principal=principal, grant=grant, operation=operation, episode_id=episode_id, resource_digest=resource_digest, audit=audit, clock=clock)
+        token = CapabilityToken(principal.identity_digest, principal.release_digest, operation, episode_id, resource_digest, expires_at)
+        with self._lock:
+            self._issued.add(token.token_digest)
+        return token
+
+    def consume(self, *, token: CapabilityToken, principal: Principal, operation: Operation, episode_id: str, resource_digest: str, now: datetime) -> None:
+        if not isinstance(token, CapabilityToken):
+            raise AuthorityError("capability object required")
+        if token.principal_digest != principal.identity_digest or token.release_digest != principal.release_digest:
+            raise AuthorityError("capability principal mismatch")
+        if token.operation is not operation or token.episode_id != episode_id or token.resource_digest != resource_digest:
+            raise AuthorityError("capability scope mismatch")
+        if now.astimezone(timezone.utc) >= token.expires_at.astimezone(timezone.utc):
+            raise AuthorityError("capability expired")
+        with self._lock:
+            if token.token_digest not in self._issued:
+                raise AuthorityError("capability was not issued by this issuer")
+            if token.token_digest in self._used:
+                raise AuthorityError("capability replay denied")
+            self._used.add(token.token_digest)

--- a/src/vulcan/microkernel/principals.py
+++ b/src/vulcan/microkernel/principals.py
@@ -1,0 +1,70 @@
+"""Principal identities for the cognitive microkernel authority boundary."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from hashlib import sha256
+import json
+from types import MappingProxyType
+from typing import Mapping
+
+
+class PrincipalKind(str, Enum):
+    HUMAN = "human"
+    SYSTEM_KERNEL = "system_kernel"
+    LANGUAGE_PROVIDER = "language_provider"
+    REASONER = "reasoner"
+    RETRIEVER = "retriever"
+    TOOL = "tool"
+    POLICY_AUTHORITY = "policy_authority"
+    OPERATOR = "operator"
+    AUDITOR = "auditor"
+    EXTERNAL_PROVIDER = "external_provider"
+
+
+def canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def digest(value: object) -> str:
+    return sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _freeze_metadata(value: Mapping[str, str] | None) -> Mapping[str, str]:
+    return MappingProxyType(dict(value or {}))
+
+
+@dataclass(frozen=True)
+class Principal:
+    """Immutable principal identity; metadata never grants authority."""
+
+    kind: PrincipalKind
+    principal_id: str
+    release_digest: str
+    display_name: str = ""
+    metadata: Mapping[str, str] = field(default_factory=dict)
+    identity_digest: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not self.principal_id:
+            raise ValueError("principal_id is required")
+        if len(self.release_digest) != 64 or any(c not in "0123456789abcdef" for c in self.release_digest):
+            raise ValueError("release_digest must be a lowercase sha256 hex digest")
+        object.__setattr__(self, "metadata", _freeze_metadata(self.metadata))
+        object.__setattr__(self, "identity_digest", digest(self.to_json(include_digest=False)))
+
+    @property
+    def is_kernel(self) -> bool:
+        return self.kind is PrincipalKind.SYSTEM_KERNEL
+
+    def to_json(self, *, include_digest: bool = True) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "display_name": self.display_name,
+            "kind": self.kind.value,
+            "metadata": dict(self.metadata),
+            "principal_id": self.principal_id,
+            "release_digest": self.release_digest,
+        }
+        if include_digest:
+            payload["identity_digest"] = self.identity_digest
+        return payload

--- a/tests/microkernel/test_authority.py
+++ b/tests/microkernel/test_authority.py
@@ -1,0 +1,115 @@
+from datetime import datetime, timedelta, timezone
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from vulcan.microkernel.authority import AuthorityError, AuthorityLevel, AuditSink, EvidenceRecord, Operation, promote_authority, require_authority
+from vulcan.microkernel.capability_tokens import CapabilityToken, CapabilityTokenIssuer
+from vulcan.microkernel.principals import Principal, PrincipalKind
+
+RELEASE = "a" * 64
+RESOURCE = "b" * 64
+POLICY = "c" * 64
+VALIDATION = "d" * 64
+
+
+def now():
+    return datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def principal(kind=PrincipalKind.SYSTEM_KERNEL, pid="kernel"):
+    return Principal(kind=kind, principal_id=pid, release_digest=RELEASE, metadata={"role": "admin"})
+
+
+def evidence(p=None):
+    p = p or principal()
+    return EvidenceRecord(p.identity_digest, VALIDATION, POLICY, now(), ("artifact:validation",))
+
+
+def grant(level=AuthorityLevel.EXECUTED_EFFECT, p=None):
+    p = p or principal()
+    return promote_authority(current=AuthorityLevel.UNTRUSTED_PROPOSAL, target=level, principal=p, evidence=evidence(p))
+
+
+def test_principal_kinds_are_explicit_and_metadata_does_not_grant_authority():
+    assert {kind.name for kind in PrincipalKind} == {"HUMAN", "SYSTEM_KERNEL", "LANGUAGE_PROVIDER", "REASONER", "RETRIEVER", "TOOL", "POLICY_AUTHORITY", "OPERATOR", "AUDITOR", "EXTERNAL_PROVIDER"}
+    attacker = principal(PrincipalKind.LANGUAGE_PROVIDER, "llm")
+    with pytest.raises(AuthorityError):
+        promote_authority(current=AuthorityLevel.UNTRUSTED_PROPOSAL, target=AuthorityLevel.EXECUTED_EFFECT, principal=attacker, evidence=evidence())
+
+
+def test_monotonic_promotion_and_complete_evidence_required():
+    p = principal()
+    g = promote_authority(current=AuthorityLevel.VALIDATED_CANDIDATE, target=AuthorityLevel.COMMITTED_BELIEF, principal=p, evidence=evidence(p))
+    assert g.level is AuthorityLevel.COMMITTED_BELIEF
+    with pytest.raises(AuthorityError):
+        promote_authority(current=AuthorityLevel.AUTHORIZED_PLAN, target=AuthorityLevel.COMMITTED_BELIEF, principal=p, evidence=evidence(p))
+    with pytest.raises(ValueError):
+        EvidenceRecord(p.identity_digest, "bad", POLICY, now())
+
+
+def test_default_deny_unknown_operation_and_low_authority_effect():
+    p = principal()
+    audit = AuditSink()
+    with pytest.raises(AuthorityError):
+        require_authority(principal=p, grant=grant(AuthorityLevel.VALIDATED_CANDIDATE, p), operation=Operation.EXECUTE_EFFECT, episode_id="e1", resource_digest=RESOURCE, audit=audit, clock=now)
+    assert audit.events[-1].decision == "denied"
+    with pytest.raises(AuthorityError):
+        require_authority(principal=p, grant=grant(AuthorityLevel.EXECUTED_EFFECT, p), operation="metadata.says.admin", episode_id="e1", resource_digest=RESOURCE, audit=audit, clock=now)
+
+
+def test_high_risk_grants_are_audited_without_raw_resource_or_secret():
+    p = principal()
+    audit = AuditSink()
+    require_authority(principal=p, grant=grant(AuthorityLevel.EXECUTED_EFFECT, p), operation=Operation.EXECUTE_EFFECT, episode_id="episode-1", resource_digest=RESOURCE, audit=audit, clock=now)
+    event = audit.events[-1].to_json()
+    assert event["decision"] == "granted"
+    assert event["resource_digest"] == RESOURCE
+    assert "secret" not in str(event).lower()
+
+
+def test_token_scope_expiry_replay_and_serialization_rejection():
+    p = principal()
+    issuer = CapabilityTokenIssuer()
+    audit = AuditSink()
+    token = issuer.issue(principal=p, grant=grant(AuthorityLevel.EXECUTED_EFFECT, p), operation=Operation.EXECUTE_EFFECT, episode_id="e1", resource_digest=RESOURCE, expires_at=now() + timedelta(minutes=5), audit=audit, clock=now)
+    with pytest.raises(AuthorityError):
+        CapabilityToken.from_json(token.to_json())
+    with pytest.raises(AuthorityError):
+        issuer.consume(token=token, principal=p, operation=Operation.EXECUTE_EFFECT, episode_id="wrong", resource_digest=RESOURCE, now=now())
+    with pytest.raises(AuthorityError):
+        issuer.consume(token=token, principal=p, operation=Operation.EXECUTE_EFFECT, episode_id="e1", resource_digest="e" * 64, now=now())
+    issuer.consume(token=token, principal=p, operation=Operation.EXECUTE_EFFECT, episode_id="e1", resource_digest=RESOURCE, now=now())
+    with pytest.raises(AuthorityError):
+        issuer.consume(token=token, principal=p, operation=Operation.EXECUTE_EFFECT, episode_id="e1", resource_digest=RESOURCE, now=now())
+    expired = issuer.issue(principal=p, grant=grant(AuthorityLevel.EXECUTED_EFFECT, p), operation=Operation.EXECUTE_EFFECT, episode_id="e1", resource_digest=RESOURCE, expires_at=now(), audit=audit, clock=now)
+    with pytest.raises(AuthorityError):
+        issuer.consume(token=expired, principal=p, operation=Operation.EXECUTE_EFFECT, episode_id="e1", resource_digest=RESOURCE, now=now())
+
+
+def test_principal_spoofing_and_confused_deputy_denied():
+    kernel = principal()
+    spoof = principal(PrincipalKind.TOOL, "kernel")
+    issuer = CapabilityTokenIssuer()
+    audit = AuditSink()
+    token = issuer.issue(principal=kernel, grant=grant(AuthorityLevel.EXECUTED_EFFECT, kernel), operation=Operation.EXECUTE_EFFECT, episode_id="e1", resource_digest=RESOURCE, expires_at=now() + timedelta(minutes=1), audit=audit, clock=now)
+    with pytest.raises(AuthorityError):
+        issuer.consume(token=token, principal=spoof, operation=Operation.EXECUTE_EFFECT, episode_id="e1", resource_digest=RESOURCE, now=now())
+
+
+def test_concurrent_token_consume_allows_exactly_one_effect_owner():
+    p = principal()
+    issuer = CapabilityTokenIssuer()
+    token = issuer.issue(principal=p, grant=grant(AuthorityLevel.EXECUTED_EFFECT, p), operation=Operation.EXECUTE_EFFECT, episode_id="e1", resource_digest=RESOURCE, expires_at=now() + timedelta(minutes=1), audit=AuditSink(), clock=now)
+
+    def consume_once():
+        try:
+            issuer.consume(token=token, principal=p, operation=Operation.EXECUTE_EFFECT, episode_id="e1", resource_digest=RESOURCE, now=now())
+            return True
+        except AuthorityError:
+            return False
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(lambda _: consume_once(), range(16)))
+    assert results.count(True) == 1
+    assert results.count(False) == 15


### PR DESCRIPTION
### Motivation
- Make authority explicit and fail-closed at the cognition trust boundary so LLMs, reasoners, tools, and humans cannot be mistaken for the microkernel authority.
- Enforce the P00/P26 authority lattice and prevent confused-deputy, spoofing, replay, and unauthorized effect execution attacks by binding identity, evidence, and operation context.

### Description
- Add typed, immutable principal identities and digest-bound identity semantics in `src/vulcan/microkernel/principals.py`, where metadata is descriptive only and cannot grant authority.
- Implement the monotonic authority lattice, operation-to-minimum-level mapping, evidence records, audited authorization decisions, and default-deny behavior in `src/vulcan/microkernel/authority.py`.
- Provide in-process, non-serializable capability tokens with exact principal/release/operation/episode/resource/expiry/nonce bindings and issuer-side replay protection in `src/vulcan/microkernel/capability_tokens.py`.
- Export new contracts through the microkernel package, add adversarial/unit tests in `tests/microkernel/test_authority.py`, and update ADR-005 with a P26 implementation note describing non-persistent tokens and audit minimization.

### Testing
- Ran `pytest -q tests/microkernel/test_authority.py`, which passed (7 tests, all green).
- Ran `pytest -q tests/microkernel/test_authority.py tests/microkernel/test_episode.py`, which passed (13 tests total, all green), exercising transitions, audit recording, token expiry/replay, spoofing, and concurrency.
- Verified Python compilation with `python -m compileall -q src`, which succeeded, and ran repository lint/check `git diff --check` with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e044649e0832fa114e808b92579d4)