### PR TITLE
Implement Graphix Epistemic v1 and authoritative claim ledger

### DIFF
--- a/docs/graphix/epistemic.md
+++ b/docs/graphix/epistemic.md
@@ -1,0 +1,19 @@
+# Graphix Epistemic v1
+
+Graphix Epistemic is the typed authority boundary for claims. The authoritative owner is `EpistemicCommit`: claims become citable only after a commit has validated its episode, case, snapshot, evidence integrity, temporal validity, provenance identifiers, and authority principal.
+
+## Status invariants
+
+Statuses are semantic categories, not a scalar confidence field: `PROVEN`, `DISPROVEN`, `COMPUTED`, `OBSERVED`, `RETRIEVED`, `ESTIMATED`, `HYPOTHESIS`, `CONTESTED`, `UNKNOWN`, and `ERROR` remain distinct. Estimated claims use `UncertaintyDescriptor` with a distribution digest, interval, calibration identity, or unknown marker.
+
+## Evidence and reuse
+
+Evidence is bound to an episode and snapshot. Cross-episode reuse must be represented by an explicit `EvidenceArtifact.source_episode_id`; claim objects are not shared across episodes. `PROVEN` requires proof evidence. `RETRIEVED` requires cited retrieval evidence. Expired evidence fails closed at commit time.
+
+## Ledger boundary
+
+`AuthoritativeClaimLedger` is append-only and idempotent by commit id and digest. `require_committed_claim` rejects uncommitted claims so response generation or learning-positive outcomes cannot cite proposal-only claims. Append failpoints surround the externally observable mutation, and `reconcile()` rebuilds claim indexes after restart.
+
+## Compatibility
+
+`project_semantic_claim` is the single compatibility adapter for legacy semantic claim shapes. It projects legacy values into typed `Claim` instances without granting committed authority.

--- a/schemas/graphix/epistemic-v1.json
+++ b/schemas/graphix/epistemic-v1.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://vulcan.example/schemas/graphix/epistemic-v1.json",
+  "title": "Graphix Epistemic v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "commit_id", "episode_id", "case_id", "snapshot_digest", "authority_principal_id", "committed_at", "claims", "evidence", "derivations", "prior_commit_digest", "commit_digest"],
+  "properties": {
+    "schema_version": {"const": "graphix.epistemic/1"},
+    "commit_id": {"$ref": "#/$defs/id"},
+    "episode_id": {"$ref": "#/$defs/id"},
+    "case_id": {"$ref": "#/$defs/id"},
+    "snapshot_digest": {"$ref": "#/$defs/digest"},
+    "authority_principal_id": {"$ref": "#/$defs/id"},
+    "committed_at": {"type": "string", "format": "date-time"},
+    "prior_commit_digest": {"anyOf": [{"$ref": "#/$defs/digest"}, {"type": "null"}]},
+    "commit_digest": {"$ref": "#/$defs/digest"},
+    "claims": {"type": "array", "minItems": 1, "maxItems": 32, "items": {"$ref": "#/$defs/claim"}},
+    "evidence": {"type": "array", "maxItems": 32, "items": {"$ref": "#/$defs/evidence"}},
+    "derivations": {"type": "array", "maxItems": 32, "items": {"$ref": "#/$defs/derivation"}}
+  },
+  "$defs": {
+    "id": {"type": "string", "pattern": "^[A-Za-z0-9][A-Za-z0-9_.:-]{2,127}$"},
+    "digest": {"type": "string", "pattern": "^sha256:[0-9a-f]{64}$"},
+    "status": {"enum": ["PROVEN", "DISPROVEN", "COMPUTED", "OBSERVED", "RETRIEVED", "ESTIMATED", "HYPOTHESIS", "CONTESTED", "UNKNOWN", "ERROR"]},
+    "evidence_kind": {"enum": ["PROOF", "OBSERVATION", "RETRIEVAL", "COMPUTATION", "CITATION", "COUNTEREXAMPLE"]},
+    "claim": {"type": "object", "additionalProperties": false, "required": ["claim_id", "proposition_id", "status", "episode_id", "snapshot_digest", "evidence_ids", "derivation_ids", "contested_by"], "properties": {"claim_id": {"$ref": "#/$defs/id"}, "proposition_id": {"$ref": "#/$defs/id"}, "status": {"$ref": "#/$defs/status"}, "episode_id": {"$ref": "#/$defs/id"}, "snapshot_digest": {"$ref": "#/$defs/digest"}, "evidence_ids": {"type": "array", "maxItems": 32, "items": {"$ref": "#/$defs/id"}}, "derivation_ids": {"type": "array", "maxItems": 32, "items": {"$ref": "#/$defs/id"}}, "contested_by": {"type": "array", "maxItems": 32, "items": {"$ref": "#/$defs/id"}}}},
+    "evidence": {"type": "object", "additionalProperties": false, "required": ["evidence_id", "kind", "episode_id", "snapshot_digest", "content_digest", "provenance_id", "observed_at", "valid_until", "citations", "source_episode_id"], "properties": {"evidence_id": {"$ref": "#/$defs/id"}, "kind": {"$ref": "#/$defs/evidence_kind"}, "episode_id": {"$ref": "#/$defs/id"}, "snapshot_digest": {"$ref": "#/$defs/digest"}, "content_digest": {"$ref": "#/$defs/digest"}, "provenance_id": {"$ref": "#/$defs/id"}, "observed_at": {"type": "string", "format": "date-time"}, "valid_until": {"anyOf": [{"type": "string", "format": "date-time"}, {"type": "null"}]}, "citations": {"type": "array", "maxItems": 32, "items": {"$ref": "#/$defs/id"}}, "source_episode_id": {"anyOf": [{"$ref": "#/$defs/id"}, {"type": "null"}]}}},
+    "derivation": {"type": "object", "additionalProperties": false, "required": ["derivation_id", "input_claim_ids", "evidence_ids", "rule_id", "output_claim_id"], "properties": {"derivation_id": {"$ref": "#/$defs/id"}, "input_claim_ids": {"type": "array", "maxItems": 32, "items": {"$ref": "#/$defs/id"}}, "evidence_ids": {"type": "array", "maxItems": 32, "items": {"$ref": "#/$defs/id"}}, "rule_id": {"$ref": "#/$defs/id"}, "output_claim_id": {"$ref": "#/$defs/id"}}}
+  }
+}

--- a/src/vulcan/graphix/epistemic.py
+++ b/src/vulcan/graphix/epistemic.py
@@ -1,0 +1,156 @@
+"""Graphix Epistemic v1: typed claims, evidence, derivations, and commits."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+import hashlib
+import re
+from types import MappingProxyType
+from typing import Mapping, Sequence
+
+from vulcan.graphix.codec import canonical_json, validate_json_value
+from vulcan.graphix.core import GraphixCoreError
+
+EPISTEMIC_SCHEMA_VERSION = "graphix.epistemic/1"
+_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{2,127}$")
+_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+MAX_REFS = 32
+
+class EpistemicContractError(GraphixCoreError): pass
+class ReferenceValidationError(EpistemicContractError): pass
+class AuthorityValidationError(EpistemicContractError): pass
+class EvidenceIntegrityError(EpistemicContractError): pass
+class TemporalValidityError(EpistemicContractError): pass
+class CircularDerivationError(EpistemicContractError): pass
+
+class ClaimStatus(str, Enum):
+    PROVEN="PROVEN"; DISPROVEN="DISPROVEN"; COMPUTED="COMPUTED"; OBSERVED="OBSERVED"; RETRIEVED="RETRIEVED"; ESTIMATED="ESTIMATED"; HYPOTHESIS="HYPOTHESIS"; CONTESTED="CONTESTED"; UNKNOWN="UNKNOWN"; ERROR="ERROR"
+class EvidenceKind(str, Enum): PROOF="PROOF"; OBSERVATION="OBSERVATION"; RETRIEVAL="RETRIEVAL"; COMPUTATION="COMPUTATION"; CITATION="CITATION"; COUNTEREXAMPLE="COUNTEREXAMPLE"
+class UncertaintyKind(str, Enum): UNKNOWN="UNKNOWN"; PROBABILITY_DISTRIBUTION="PROBABILITY_DISTRIBUTION"; INTERVAL="INTERVAL"; CALIBRATION_IDENTITY="CALIBRATION_IDENTITY"
+
+@dataclass(frozen=True, slots=True)
+class Proposition:
+    proposition_id: str; subject: str; predicate: str; object_value: str; qualifiers: Mapping[str, object] = field(default_factory=dict)
+    def __post_init__(self) -> None:
+        _id("proposition_id", self.proposition_id)
+        for n in ("subject","predicate","object_value"):
+            if not (1 <= len(getattr(self,n)) <= 512): raise EpistemicContractError(f"invalid {n}")
+        validate_json_value(self.qualifiers); object.__setattr__(self,"qualifiers",MappingProxyType(dict(self.qualifiers)))
+
+@dataclass(frozen=True, slots=True)
+class Citation:
+    citation_id: str; uri: str | None = None; title: str | None = None; artifact_id: str | None = None; artifact_digest: str | None = None
+    def __post_init__(self) -> None:
+        _id("citation_id", self.citation_id)
+        if self.uri is None and self.artifact_id is None: raise EpistemicContractError("citation requires uri or artifact_id")
+        if self.artifact_id is not None: _id("citation.artifact_id", self.artifact_id)
+        if self.artifact_digest is not None: _digest("citation.artifact_digest", self.artifact_digest)
+
+@dataclass(frozen=True, slots=True)
+class EvidenceArtifact:
+    evidence_id: str; kind: EvidenceKind; episode_id: str; snapshot_digest: str; content_digest: str; provenance_id: str; observed_at: datetime; valid_until: datetime | None = None; citations: tuple[Citation,...] = (); source_episode_id: str | None = None
+    def __post_init__(self) -> None:
+        _id("evidence_id", self.evidence_id); _id("episode_id", self.episode_id); _digest("snapshot_digest", self.snapshot_digest); _digest("content_digest", self.content_digest); _id("provenance_id", self.provenance_id)
+        object.__setattr__(self,"kind",EvidenceKind(self.kind)); _aware(self.observed_at,"observed_at")
+        if self.valid_until is not None: _aware(self.valid_until,"valid_until")
+        if self.source_episode_id is not None and self.source_episode_id == self.episode_id: raise ReferenceValidationError("source_episode_id is only for cross-episode evidence reuse")
+        object.__setattr__(self,"citations",tuple(self.citations))
+
+@dataclass(frozen=True, slots=True)
+class UncertaintyDescriptor:
+    kind: UncertaintyKind; distribution_digest: str | None = None; interval_low: str | None = None; interval_high: str | None = None; calibration_id: str | None = None
+    def __post_init__(self) -> None:
+        object.__setattr__(self,"kind",UncertaintyKind(self.kind))
+        if self.distribution_digest: _digest("distribution_digest", self.distribution_digest)
+        if self.kind is UncertaintyKind.PROBABILITY_DISTRIBUTION and not self.distribution_digest: raise EpistemicContractError("distribution requires digest")
+        if self.kind is UncertaintyKind.INTERVAL and (self.interval_low is None or self.interval_high is None): raise EpistemicContractError("interval requires bounds")
+        if self.kind is UncertaintyKind.CALIBRATION_IDENTITY and not self.calibration_id: raise EpistemicContractError("calibration requires identity")
+
+@dataclass(frozen=True, slots=True)
+class Assumption: assumption_id: str; proposition_id: str
+@dataclass(frozen=True, slots=True)
+class Counterexample: counterexample_id: str; evidence_id: str; target_claim_id: str
+@dataclass(frozen=True, slots=True)
+class Contradiction: contradiction_id: str; claim_ids: tuple[str, ...]
+@dataclass(frozen=True, slots=True)
+class Limitation: limitation_id: str; description: str; affected_claim_ids: tuple[str, ...] = ()
+
+@dataclass(frozen=True, slots=True)
+class Derivation:
+    derivation_id: str; input_claim_ids: tuple[str,...]; evidence_ids: tuple[str,...]; rule_id: str; output_claim_id: str
+    def __post_init__(self) -> None:
+        _id("derivation_id", self.derivation_id); _id("rule_id", self.rule_id); _id("output_claim_id", self.output_claim_id)
+        object.__setattr__(self,"input_claim_ids",tuple(self.input_claim_ids)); object.__setattr__(self,"evidence_ids",tuple(self.evidence_ids))
+        if self.output_claim_id in self.input_claim_ids: raise CircularDerivationError("derivation cannot directly depend on its output")
+
+@dataclass(frozen=True, slots=True)
+class Claim:
+    claim_id: str; proposition: Proposition; status: ClaimStatus; episode_id: str; snapshot_digest: str; evidence_ids: tuple[str,...] = (); derivation_ids: tuple[str,...] = (); uncertainty: UncertaintyDescriptor = field(default_factory=lambda: UncertaintyDescriptor(UncertaintyKind.UNKNOWN)); contested_by: tuple[str,...] = (); limitations: tuple[Limitation,...] = ()
+    def __post_init__(self) -> None:
+        _id("claim_id", self.claim_id); _id("episode_id", self.episode_id); _digest("snapshot_digest", self.snapshot_digest); object.__setattr__(self,"status",ClaimStatus(self.status))
+        object.__setattr__(self,"evidence_ids",tuple(self.evidence_ids)); object.__setattr__(self,"derivation_ids",tuple(self.derivation_ids)); object.__setattr__(self,"contested_by",tuple(self.contested_by))
+
+@dataclass(frozen=True, slots=True)
+class EpistemicCommit:
+    commit_id: str; episode_id: str; case_id: str; snapshot_digest: str; authority_principal_id: str; committed_at: datetime; claims: tuple[Claim,...]; evidence: tuple[EvidenceArtifact,...] = (); derivations: tuple[Derivation,...] = (); assumptions: tuple[Assumption,...] = (); counterexamples: tuple[Counterexample,...] = (); contradictions: tuple[Contradiction,...] = (); prior_commit_digest: str | None = None; commit_digest: str = ""
+    def __post_init__(self) -> None:
+        _id("commit_id", self.commit_id); _id("episode_id", self.episode_id); _id("case_id", self.case_id); _digest("snapshot_digest", self.snapshot_digest); _id("authority_principal_id", self.authority_principal_id); _aware(self.committed_at,"committed_at")
+        if self.prior_commit_digest: _digest("prior_commit_digest", self.prior_commit_digest)
+        for name in ("claims","evidence","derivations","assumptions","counterexamples","contradictions"): object.__setattr__(self,name,tuple(getattr(self,name)))
+        _validate_commit(self)
+        expected = digest_commit(self, include_digest=False)
+        object.__setattr__(self,"commit_digest", self.commit_digest or expected)
+        if self.commit_digest != expected: raise EvidenceIntegrityError("commit digest mismatch")
+
+def _validate_commit(c: EpistemicCommit) -> None:
+    if not c.claims: raise EpistemicContractError("commit requires at least one claim")
+    ev = {e.evidence_id:e for e in c.evidence}; claims={cl.claim_id:cl for cl in c.claims}; deriv={d.derivation_id:d for d in c.derivations}
+    if len(ev)!=len(c.evidence) or len(claims)!=len(c.claims) or len(deriv)!=len(c.derivations): raise ReferenceValidationError("duplicate ids")
+    for e in c.evidence:
+        if e.episode_id != c.episode_id and e.source_episode_id is None: raise ReferenceValidationError("cross-episode evidence requires explicit source_episode_id")
+        if e.snapshot_digest != c.snapshot_digest: raise ReferenceValidationError("evidence snapshot mismatch")
+        if e.valid_until is not None and e.valid_until <= c.committed_at: raise TemporalValidityError("expired evidence")
+    for cl in c.claims:
+        if cl.episode_id != c.episode_id or cl.snapshot_digest != c.snapshot_digest: raise ReferenceValidationError("claim binding mismatch")
+        for i in cl.evidence_ids:
+            if i not in ev: raise ReferenceValidationError("dangling evidence reference")
+        for i in cl.derivation_ids:
+            if i not in deriv: raise ReferenceValidationError("dangling derivation reference")
+        if cl.status is ClaimStatus.PROVEN and not any(ev[i].kind is EvidenceKind.PROOF for i in cl.evidence_ids): raise EvidenceIntegrityError("PROVEN claim requires proof artifact")
+        if cl.status is ClaimStatus.RETRIEVED and (not cl.evidence_ids or not any(ev[i].citations for i in cl.evidence_ids)): raise EvidenceIntegrityError("RETRIEVED claim requires evidence citation")
+        if cl.status is ClaimStatus.CONTESTED and not cl.contested_by: raise ReferenceValidationError("CONTESTED claim requires contested_by")
+    for d in c.derivations:
+        if d.output_claim_id not in claims: raise ReferenceValidationError("dangling derivation output")
+        for i in d.input_claim_ids:
+            if i not in claims: raise ReferenceValidationError("dangling derivation input")
+        for i in d.evidence_ids:
+            if i not in ev: raise ReferenceValidationError("dangling derivation evidence")
+    _detect_cycles(c.derivations)
+
+def _detect_cycles(derivations: Sequence[Derivation]) -> None:
+    graph={d.output_claim_id:set(d.input_claim_ids) for d in derivations}; visiting=set(); seen=set()
+    def visit(n: str) -> None:
+        if n in visiting: raise CircularDerivationError("circular derivation")
+        if n in seen: return
+        visiting.add(n)
+        for m in graph.get(n, ()): visit(m)
+        visiting.remove(n); seen.add(n)
+    for n in graph: visit(n)
+
+def commit_to_dict(c: EpistemicCommit, *, include_digest: bool=True) -> dict[str, object]:
+    def dt(x): return x.astimezone(timezone.utc).isoformat().replace("+00:00","Z")
+    out={"schema_version":EPISTEMIC_SCHEMA_VERSION,"commit_id":c.commit_id,"episode_id":c.episode_id,"case_id":c.case_id,"snapshot_digest":c.snapshot_digest,"authority_principal_id":c.authority_principal_id,"committed_at":dt(c.committed_at),"prior_commit_digest":c.prior_commit_digest,"claims":[{"claim_id":cl.claim_id,"proposition_id":cl.proposition.proposition_id,"status":cl.status.value,"episode_id":cl.episode_id,"snapshot_digest":cl.snapshot_digest,"evidence_ids":list(cl.evidence_ids),"derivation_ids":list(cl.derivation_ids),"contested_by":list(cl.contested_by)} for cl in c.claims],"evidence":[{"evidence_id":e.evidence_id,"kind":e.kind.value,"episode_id":e.episode_id,"snapshot_digest":e.snapshot_digest,"content_digest":e.content_digest,"provenance_id":e.provenance_id,"observed_at":dt(e.observed_at),"valid_until":None if e.valid_until is None else dt(e.valid_until),"citations":[ci.citation_id for ci in e.citations],"source_episode_id":e.source_episode_id} for e in c.evidence],"derivations":[{"derivation_id":d.derivation_id,"input_claim_ids":list(d.input_claim_ids),"evidence_ids":list(d.evidence_ids),"rule_id":d.rule_id,"output_claim_id":d.output_claim_id} for d in c.derivations]}
+    if include_digest: out["commit_digest"]=c.commit_digest
+    return out
+
+def digest_commit(c: EpistemicCommit, *, include_digest: bool=True) -> str: return "sha256:"+hashlib.sha256(canonical_json(commit_to_dict(c, include_digest=include_digest))).hexdigest()
+def content_digest(value: object) -> str: return "sha256:"+hashlib.sha256(canonical_json(value)).hexdigest()
+def project_semantic_claim(*, claim_id: str, episode_id: str, snapshot_digest: str, subject: str, predicate: str, object_value: str, evidence_id: str | None = None) -> Claim:
+    return Claim(claim_id, Proposition("prop:"+claim_id.split(":")[-1], subject, predicate, object_value), ClaimStatus.OBSERVED if evidence_id else ClaimStatus.HYPOTHESIS, episode_id, snapshot_digest, () if evidence_id is None else (evidence_id,))
+def _id(name: str, value: str) -> None:
+    if not isinstance(value,str) or _ID_RE.fullmatch(value) is None: raise EpistemicContractError(f"invalid {name}")
+def _digest(name: str, value: str) -> None:
+    if not isinstance(value,str) or _DIGEST_RE.fullmatch(value) is None: raise EvidenceIntegrityError(f"invalid {name}")
+def _aware(value: datetime, name: str) -> None:
+    if not isinstance(value, datetime) or value.tzinfo is None: raise TemporalValidityError(f"{name} must be timezone-aware")

--- a/src/vulcan/microkernel/ledger.py
+++ b/src/vulcan/microkernel/ledger.py
@@ -1,0 +1,53 @@
+"""Authoritative in-memory claim ledger for Graphix Epistemic commits."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+from vulcan.graphix.epistemic import EpistemicCommit, EpistemicContractError
+
+class LedgerError(EpistemicContractError): pass
+class ClaimNotCommittedError(LedgerError): pass
+class FailpointTriggered(LedgerError): pass
+
+@dataclass
+class AuthoritativeClaimLedger:
+    """Single-authority append-only commit ledger.
+
+    Failpoints bracket the externally observable append transition so tests can
+    prove restart reconciliation without simulating success.
+    """
+    _commits: dict[str, EpistemicCommit] = field(default_factory=dict)
+    _claims: dict[str, str] = field(default_factory=dict)
+    failpoint: Callable[[str, EpistemicCommit], None] | None = None
+
+    def append(self, commit: EpistemicCommit) -> str:
+        if commit.commit_id in self._commits:
+            if self._commits[commit.commit_id].commit_digest != commit.commit_digest:
+                raise LedgerError("commit id collision")
+            return commit.commit_digest
+        if commit.prior_commit_digest is not None and commit.prior_commit_digest not in {c.commit_digest for c in self._commits.values()}:
+            raise LedgerError("unknown prior commit")
+        self._trip("before_append", commit)
+        self._commits[commit.commit_id] = commit
+        for claim in commit.claims:
+            self._claims[claim.claim_id] = commit.commit_id
+        self._trip("after_append", commit)
+        return commit.commit_digest
+
+    def require_committed_claim(self, claim_id: str) -> EpistemicCommit:
+        commit_id = self._claims.get(claim_id)
+        if commit_id is None:
+            raise ClaimNotCommittedError("claim is not committed")
+        return self._commits[commit_id]
+
+    def reconcile(self) -> None:
+        rebuilt: dict[str, str] = {}
+        for commit_id, commit in self._commits.items():
+            for claim in commit.claims:
+                rebuilt[claim.claim_id] = commit_id
+        self._claims = rebuilt
+
+    def _trip(self, name: str, commit: EpistemicCommit) -> None:
+        if self.failpoint is not None:
+            self.failpoint(name, commit)

--- a/tests/graphix/test_epistemic_dialect.py
+++ b/tests/graphix/test_epistemic_dialect.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+
+import pytest
+
+from vulcan.graphix.epistemic import *
+from vulcan.microkernel.ledger import AuthoritativeClaimLedger, ClaimNotCommittedError, LedgerError
+
+NOW = datetime(2026, 7, 20, tzinfo=timezone.utc)
+D = "sha256:" + "1" * 64
+D2 = "sha256:" + "2" * 64
+
+def evidence(eid="evidence:one", kind=EvidenceKind.PROOF, *, valid_until=None, citations=()):
+    return EvidenceArtifact(eid, kind, "episode:one", D, D2, "prov:kernel", NOW, valid_until, citations)
+
+def claim(cid="claim:one", status=ClaimStatus.PROVEN, ev=("evidence:one",), deriv=(), contested=()):
+    return Claim(cid, Proposition("prop:" + cid.split(":")[-1], "s", "p", "o"), status, "episode:one", D, ev, deriv, contested_by=contested)
+
+def commit(**kw):
+    base = dict(commit_id="commit:one", episode_id="episode:one", case_id="case:one", snapshot_digest=D, authority_principal_id="principal:kernel", committed_at=NOW, claims=(claim(),), evidence=(evidence(),))
+    base.update(kw)
+    return EpistemicCommit(**base)
+
+def test_valid_commit_digest_and_ledger_authority_boundary():
+    c = commit()
+    ledger = AuthoritativeClaimLedger()
+    with pytest.raises(ClaimNotCommittedError):
+        ledger.require_committed_claim("claim:one")
+    assert ledger.append(c) == c.commit_digest
+    assert ledger.require_committed_claim("claim:one").commit_id == "commit:one"
+
+def test_dangling_and_cross_episode_references_fail_closed():
+    with pytest.raises(ReferenceValidationError):
+        commit(claims=(claim(ev=("missing:evidence",)),))
+    cross = replace(evidence(), episode_id="episode:two")
+    with pytest.raises(ReferenceValidationError):
+        commit(evidence=(cross,))
+    explicit = replace(cross, source_episode_id="episode:two-original")
+    assert commit(evidence=(explicit,)).evidence[0].source_episode_id == "episode:two-original"
+
+def test_circular_derivation_fails_closed():
+    c1 = claim("claim:one", ClaimStatus.COMPUTED, deriv=("deriv:one",), ev=())
+    c2 = claim("claim:two", ClaimStatus.COMPUTED, deriv=("deriv:two",), ev=())
+    d1 = Derivation("deriv:one", ("claim:two",), (), "rule:modus", "claim:one")
+    d2 = Derivation("deriv:two", ("claim:one",), (), "rule:modus", "claim:two")
+    with pytest.raises(CircularDerivationError):
+        commit(claims=(c1,c2), evidence=(), derivations=(d1,d2))
+
+def test_status_specific_evidence_requirements():
+    with pytest.raises(EvidenceIntegrityError):
+        commit(claims=(claim(status=ClaimStatus.PROVEN),), evidence=(evidence(kind=EvidenceKind.OBSERVATION),))
+    retrieved = claim(status=ClaimStatus.RETRIEVED)
+    with pytest.raises(EvidenceIntegrityError):
+        commit(claims=(retrieved,), evidence=(evidence(kind=EvidenceKind.RETRIEVAL),))
+    cited = evidence(kind=EvidenceKind.RETRIEVAL, citations=(Citation("citation:one", uri="https://example.test/source"),))
+    assert commit(claims=(retrieved,), evidence=(cited,)).claims[0].status is ClaimStatus.RETRIEVED
+
+def test_expired_evidence_contested_claims_and_digest_tamper():
+    with pytest.raises(TemporalValidityError):
+        commit(evidence=(evidence(valid_until=NOW - timedelta(seconds=1)),))
+    with pytest.raises(ReferenceValidationError):
+        commit(claims=(claim(status=ClaimStatus.CONTESTED, ev=()),), evidence=())
+    contested = claim(status=ClaimStatus.CONTESTED, ev=(), contested=("claim:other",))
+    assert commit(claims=(contested,), evidence=()).claims[0].status is ClaimStatus.CONTESTED
+    good = commit()
+    with pytest.raises(EvidenceIntegrityError):
+        commit(commit_digest="sha256:" + "f" * 64)
+    assert digest_commit(good, include_digest=False) == good.commit_digest
+
+def test_uncertainty_is_typed_not_scalar_confidence():
+    with pytest.raises(EpistemicContractError):
+        UncertaintyDescriptor(UncertaintyKind.PROBABILITY_DISTRIBUTION)
+    u = UncertaintyDescriptor(UncertaintyKind.INTERVAL, interval_low="1/3", interval_high="2/3")
+    assert u.kind is UncertaintyKind.INTERVAL
+
+def test_failpoints_and_restart_reconciliation():
+    c = commit()
+    ledger = AuthoritativeClaimLedger(failpoint=lambda name, _c: (_ for _ in ()).throw(LedgerError(name)) if name == "after_append" else None)
+    with pytest.raises(LedgerError, match="after_append"):
+        ledger.append(c)
+    ledger.failpoint = None
+    ledger.reconcile()
+    assert ledger.require_committed_claim("claim:one").commit_digest == c.commit_digest
+
+def test_malformed_provider_cannot_escalate_claim_authority():
+    malicious = {"claim_id":"claim:evil", "status":"PROVEN", "authority_level":"COMMITTED_BELIEF", "evidence_ids":[]}
+    with pytest.raises(TypeError):
+        Claim(**malicious)
+
+def test_compatibility_projection_and_schema():
+    projected = project_semantic_claim(claim_id="claim:legacy", episode_id="episode:one", snapshot_digest=D, subject="legacy", predicate="says", object_value="value")
+    assert projected.status is ClaimStatus.HYPOTHESIS
+    schema = json.loads(Path("schemas/graphix/epistemic-v1.json").read_text())
+    assert schema["additionalProperties"] is False
+    assert "confidence" not in json.dumps(schema).lower()


### PR DESCRIPTION
### Motivation

- Provide a typed epistemic dialect to represent claims, propositions, evidence, derivations, uncertainty, contestation, and commit-level authority rather than ad-hoc or scalar claim objects. 
- Enforce fail-closed validation for evidence integrity, episode/snapshot binding, temporal validity, and status-specific evidence requirements to prevent uncommitted or malformed claims from being cited. 
- Expose an explicit single-authority ledger boundary that makes committed claims first-class and provably immutable for downstream authorization and learning flows.

### Description

- Add a new `graphix.epistemic` module implementing `Proposition`, `Citation`, `EvidenceArtifact`, `Derivation`, `Assumption`, `UncertaintyDescriptor`, `Counterexample`, `Contradiction`, `Limitation`, `Claim`, and `EpistemicCommit` with strict typed constructors and validation in `src/vulcan/graphix/epistemic.py`.
- Implement canonical commit serialization and digesting with `commit_to_dict`, `digest_commit`, and a compatibility adapter `project_semantic_claim` that projects legacy claim shapes without granting committed authority.
- Add the `AuthoritativeClaimLedger` in `src/vulcan/microkernel/ledger.py` providing idempotent `append`, `require_committed_claim`, append-level failpoints for restart-reconciliation tests, and an in-memory `reconcile()` to rebuild claim indexes.
- Add a closed JSON schema (`schemas/graphix/epistemic-v1.json`), documentation (`docs/graphix/epistemic.md`), and adversarial/contract tests (`tests/graphix/test_epistemic_dialect.py`) that exercise dangling/cross-episode refs, circular derivations, expired evidence, contested claims, digest tampering, typed uncertainty, and ledger failpoints.

### Testing

- Ran `python -m pytest -q tests/graphix` where the Graphix test suite (including the new epistemic dialect tests) passed successfully (27 tests, all green). 
- Ran `python -m pytest -q tests/graphix/test_epistemic_dialect.py` and the targeted dialect tests passed.
- Compiled the package with `python -m compileall -q src` and local static checks completed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e0a99c950832f9a6f22c3d2165639)