### PR TITLE
Build Graphix compiler pipeline: validation, compilation, migrations, and tests

### DIFF
--- a/docs/graphix/compiler-pipeline.md
+++ b/docs/graphix/compiler-pipeline.md
@@ -1,0 +1,13 @@
+# Graphix compiler pipeline
+
+The Graphix compiler is a staged trust boundary from untrusted dialect artifacts to validated candidates and bounded human projections. The compiler never commits beliefs, authorizes plans, executes tools, or treats raw model text as authority.
+
+Authoritative owner: `vulcan.graphix.validation.validate_graphix` owns compiler ingress validation. Transaction boundary: an immutable `ValidatedGraphixArtifact` digest is the handoff to `vulcan.graphix.compilers.compile_graphix`; later kernel action is required for any committed belief or authorized plan.
+
+Validation stages are mandatory and ordered: structure, identity, source grounding, ontology, reference integrity, temporal validity, privacy/consent, resource bounds, authority, epistemic integrity, deontic constraints, and executable capability admission. Each stage produces typed diagnostics and the pipeline verifies that the immutable input digest is unchanged after every stage.
+
+Migrations are pure and content-addressed. A migration record includes source and target digests, and migrations that silently change authority level are rejected.
+
+Unknown extensions that claim security, authorization, policy, evidence, execution, tool, or capability meaning are rejected unless a future explicit schema admits them.
+
+Rollback: disable callers of the new compiler and keep Graphix artifacts at `UNTRUSTED_PROPOSAL`; no persistent state is mutated by this package.

--- a/src/vulcan/graphix/compilers/__init__.py
+++ b/src/vulcan/graphix/compilers/__init__.py
@@ -1,0 +1,2 @@
+"""Graphix compiler entrypoints."""
+from vulcan.graphix.compilers.pipeline import *

--- a/src/vulcan/graphix/compilers/pipeline.py
+++ b/src/vulcan/graphix/compilers/pipeline.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+from dataclasses import dataclass
+import hashlib
+from types import MappingProxyType
+from typing import Mapping
+from vulcan.graphix.codec import canonical_json
+from vulcan.graphix.core import AuthorityLevel
+from vulcan.graphix.validation import ValidatedGraphixArtifact
+
+@dataclass(frozen=True, slots=True)
+class CompilationRecord:
+    source_validation_digest: str
+    source_dialect: str
+    target_dialect: str
+    output_authority: AuthorityLevel
+    output_digest: str
+    audit_digest: str
+    projection: Mapping[str, object]
+
+class CompilationError(ValueError): pass
+
+def compile_graphix(validated: ValidatedGraphixArtifact, *, target_dialect: str) -> CompilationRecord:
+    if validated.target_dialect != target_dialect:
+        raise CompilationError("target dialect must be explicit and match validation")
+    env = validated.envelope
+    if env.authority_level is not AuthorityLevel.UNTRUSTED_PROPOSAL:
+        raise CompilationError("compiler cannot elevate non-proposal authority")
+    if target_dialect == "graphix.language.candidate":
+        projection = {"kind":"interpretation_candidate","source_artifact_id":env.node_artifact_id,"episode_id":env.episode_id,"authority_level":AuthorityLevel.VALIDATED_CANDIDATE.value,"private_reasoning":"redacted","notes":"validated proposal only; kernel commit required"}
+        authority = AuthorityLevel.VALIDATED_CANDIDATE
+    elif target_dialect == "graphix.response.projection":
+        projection = {"kind":"human_explanation","source_artifact_id":env.node_artifact_id,"max_chars":1024,"summary":"Graphix proposal passed compiler validation. It is not a committed belief or authorized plan.","omitted":["private_reasoning","raw_chain_of_thought"]}
+        authority = AuthorityLevel.VALIDATED_CANDIDATE
+    else:
+        raise CompilationError("unsupported target dialect")
+    out_digest = "sha256:"+hashlib.sha256(canonical_json(projection)).hexdigest()
+    audit = {"source_validation_digest":validated.validation_digest,"source_dialect":env.dialect,"target_dialect":target_dialect,"output_digest":out_digest,"stages":list(validated.stage_digests)}
+    return CompilationRecord(validated.validation_digest, env.dialect, target_dialect, authority, out_digest, "sha256:"+hashlib.sha256(canonical_json(audit)).hexdigest(), MappingProxyType(projection))

--- a/src/vulcan/graphix/migrations/__init__.py
+++ b/src/vulcan/graphix/migrations/__init__.py
@@ -1,0 +1,2 @@
+"""Pure content-addressed Graphix migrations."""
+from vulcan.graphix.migrations.versioned import *

--- a/src/vulcan/graphix/migrations/versioned.py
+++ b/src/vulcan/graphix/migrations/versioned.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from types import MappingProxyType
+import hashlib
+from typing import Callable, Mapping
+from vulcan.graphix.codec import canonical_json
+from vulcan.graphix.core import GraphixEnvelope
+
+@dataclass(frozen=True, slots=True)
+class MigrationRecord:
+    source_digest: str; target_digest: str; from_version: int; to_version: int; artifact: GraphixEnvelope
+
+Migration = Callable[[GraphixEnvelope], GraphixEnvelope]
+
+class MigrationError(ValueError): pass
+
+class MigrationPlan:
+    def __init__(self, migrations: Mapping[tuple[str,int,int], Migration]) -> None:
+        self._migrations = MappingProxyType(dict(migrations))
+    def migrate(self, artifact: GraphixEnvelope, *, to_version: int) -> MigrationRecord:
+        source = _digest(artifact)
+        if artifact.schema_version == to_version:
+            return MigrationRecord(source, source, artifact.schema_version, to_version, artifact)
+        fn = self._migrations.get((artifact.dialect, artifact.schema_version, to_version))
+        if fn is None: raise MigrationError("unsupported or ambiguous Graphix migration")
+        migrated = fn(artifact)
+        if migrated.dialect != artifact.dialect or migrated.schema_version != to_version: raise MigrationError("migration target mismatch")
+        if migrated.authority_level != artifact.authority_level: raise MigrationError("migration cannot silently change authority level")
+        return MigrationRecord(source, _digest(migrated), artifact.schema_version, to_version, migrated)
+
+def identity_v1(envelope: GraphixEnvelope) -> GraphixEnvelope: return envelope
+
+def _digest(envelope: GraphixEnvelope) -> str:
+    from vulcan.graphix.codec import envelope_to_dict
+    return "sha256:"+hashlib.sha256(canonical_json(envelope_to_dict(envelope))).hexdigest()

--- a/src/vulcan/graphix/validation/__init__.py
+++ b/src/vulcan/graphix/validation/__init__.py
@@ -1,0 +1,2 @@
+"""Staged Graphix validation pipeline."""
+from vulcan.graphix.validation.pipeline import *

--- a/src/vulcan/graphix/validation/pipeline.py
+++ b/src/vulcan/graphix/validation/pipeline.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+import hashlib
+from types import MappingProxyType
+from typing import Callable, Mapping, Sequence
+
+from vulcan.graphix.codec import canonical_json, extension_digest
+from vulcan.graphix.core import AuthorityLevel, EpistemicStatus, GraphixEnvelope, PrivacyClass, SourceKind
+
+class DiagnosticSeverity(str, Enum): ERROR="ERROR"; WARNING="WARNING"
+class DiagnosticCode(str, Enum):
+    STAGE_ORDER="STAGE_ORDER"; STRUCTURE="STRUCTURE"; IDENTITY="IDENTITY"; SOURCE="SOURCE"; ONTOLOGY="ONTOLOGY"; REFERENCE="REFERENCE"; TEMPORAL="TEMPORAL"; PRIVACY="PRIVACY"; RESOURCE="RESOURCE"; AUTHORITY="AUTHORITY"; EPISTEMIC="EPISTEMIC"; DEONTIC="DEONTIC"; CAPABILITY="CAPABILITY"; EXTENSION="EXTENSION"
+
+@dataclass(frozen=True, slots=True)
+class ValidationDiagnostic:
+    stage: str; code: DiagnosticCode; severity: DiagnosticSeverity; message: str
+
+@dataclass(frozen=True, slots=True)
+class ValidationPolicy:
+    now: Callable[[], datetime]
+    trusted_principals: frozenset[str]
+    allowed_dialects: frozenset[str]
+    allowed_capabilities: frozenset[str] = frozenset()
+    known_ontology_terms: frozenset[str] = frozenset({"request","arithmetic","lookup","unsupported"})
+    max_sources: int = 16; max_extensions: int = 8; max_canonical_bytes: int = 32768
+
+@dataclass(frozen=True, slots=True)
+class ValidatedGraphixArtifact:
+    envelope: GraphixEnvelope
+    target_dialect: str
+    stage_digests: Mapping[str, str]
+    diagnostics: tuple[ValidationDiagnostic, ...]
+    validation_digest: str
+
+STAGES: tuple[str, ...] = ("structure","identity","source_grounding","ontology","reference_integrity","temporal_validity","privacy_consent","resource_bounds","authority","epistemic_integrity","deontic_constraints","executable_capability_admission")
+SECURITY_EXTENSION_WORDS = frozenset({"security","authorization","authority","policy","evidence","execution","execute","capability","tool"})
+
+class ValidationError(ValueError): pass
+
+def validate_graphix(envelope: GraphixEnvelope, *, target_dialect: str, policy: ValidationPolicy, stages: Sequence[str] = STAGES) -> ValidatedGraphixArtifact:
+    if tuple(stages) != STAGES:
+        raise ValidationError("Graphix validation stages are mandatory and ordered")
+    diagnostics: list[ValidationDiagnostic] = []
+    before = _digest(envelope)
+    stage_digests: dict[str, str] = {}
+    for stage in STAGES:
+        diagnostics.extend(_run_stage(stage, envelope, target_dialect, policy))
+        after = _digest(envelope)
+        if after != before:
+            raise ValidationError(f"validation stage mutated input: {stage}")
+        stage_digests[stage] = after
+    errors = tuple(d for d in diagnostics if d.severity is DiagnosticSeverity.ERROR)
+    if errors:
+        raise ValidationError("; ".join(f"{d.stage}:{d.message}" for d in errors))
+    val_digest = "sha256:" + hashlib.sha256(canonical_json({"envelope": before, "target": target_dialect, "stages": list(STAGES), "stage_digests": stage_digests})).hexdigest()
+    return ValidatedGraphixArtifact(envelope, target_dialect, MappingProxyType(stage_digests), tuple(diagnostics), val_digest)
+
+def _run_stage(stage: str, e: GraphixEnvelope, target: str, p: ValidationPolicy) -> list[ValidationDiagnostic]:
+    err = lambda code, msg: ValidationDiagnostic(stage, code, DiagnosticSeverity.ERROR, msg)
+    out: list[ValidationDiagnostic] = []
+    if stage == "structure":
+        if e.dialect not in p.allowed_dialects or target not in p.allowed_dialects: out.append(err(DiagnosticCode.STRUCTURE,"unsupported source or target dialect"))
+    elif stage == "identity":
+        if e.proposer.principal_id not in p.trusted_principals: out.append(err(DiagnosticCode.IDENTITY,"untrusted proposer release"))
+    elif stage == "source_grounding":
+        if not e.source_references: out.append(err(DiagnosticCode.SOURCE,"source reference required"))
+        if any(s.kind is SourceKind.EXTERNAL and s.digest is None for s in e.source_references): out.append(err(DiagnosticCode.SOURCE,"external source requires digest"))
+    elif stage == "ontology":
+        if e.dialect == "graphix.language" and "graphix.language" not in p.allowed_dialects: out.append(err(DiagnosticCode.ONTOLOGY,"language dialect not admitted"))
+    elif stage == "reference_integrity":
+        ids = [s.reference_id for s in e.source_references]
+        if len(ids) != len(set(ids)): out.append(err(DiagnosticCode.REFERENCE,"duplicate source reference"))
+    elif stage == "temporal_validity":
+        now = p.now().astimezone(timezone.utc)
+        if e.valid_from.astimezone(timezone.utc) > now: out.append(err(DiagnosticCode.TEMPORAL,"artifact is not yet valid"))
+        if e.valid_until and e.valid_until.astimezone(timezone.utc) <= now: out.append(err(DiagnosticCode.TEMPORAL,"artifact is expired"))
+    elif stage == "privacy_consent":
+        if e.privacy_class in {PrivacyClass.PERSONAL, PrivacyClass.SENSITIVE_PERSONAL} and not e.consent_references: out.append(err(DiagnosticCode.PRIVACY,"personal data requires consent reference"))
+    elif stage == "resource_bounds":
+        if len(e.source_references) > p.max_sources or len(e.extensions) > p.max_extensions or len(canonical_json(_view(e))) > p.max_canonical_bytes: out.append(err(DiagnosticCode.RESOURCE,"artifact exceeds validation resource bounds"))
+    elif stage == "authority":
+        if e.authority_level is not AuthorityLevel.UNTRUSTED_PROPOSAL: out.append(err(DiagnosticCode.AUTHORITY,"compiler ingress only accepts untrusted proposals"))
+    elif stage == "epistemic_integrity":
+        if e.epistemic_status is not EpistemicStatus.PROPOSED: out.append(err(DiagnosticCode.EPISTEMIC,"compiler ingress cannot accept committed epistemic status"))
+    elif stage == "deontic_constraints":
+        if any(word in e.purpose.lower() for word in ("bypass","override","ignore policy")): out.append(err(DiagnosticCode.DEONTIC,"purpose requests policy bypass"))
+    elif stage == "executable_capability_admission":
+        for x in e.extensions:
+            parts = frozenset(x.namespace.lower().replace("-",".").split("."))
+            if parts & SECURITY_EXTENSION_WORDS: out.append(err(DiagnosticCode.EXTENSION,"unknown extension claims reserved meaning"))
+            if extension_digest(x.value) != x.digest: out.append(err(DiagnosticCode.EXTENSION,"extension digest mismatch"))
+    return out
+
+def _digest(e: GraphixEnvelope) -> str: return "sha256:" + hashlib.sha256(canonical_json(_view(e))).hexdigest()
+def _view(e: GraphixEnvelope) -> object:
+    from vulcan.graphix.codec import envelope_to_dict
+    return envelope_to_dict(e)

--- a/tests/graphix/test_compiler_pipeline.py
+++ b/tests/graphix/test_compiler_pipeline.py
@@ -1,0 +1,79 @@
+from datetime import datetime, timezone
+from dataclasses import replace
+import pytest
+
+from vulcan.graphix.core import AuthorityLevel, EpistemicStatus, ExtensionDeclaration, GraphixEnvelope, PrincipalRelease, PrivacyClass, SourceKind, SourceReference
+from vulcan.graphix.codec import extension_digest
+from vulcan.graphix.validation import STAGES, ValidationError, ValidationPolicy, validate_graphix
+from vulcan.graphix.compilers import CompilationError, compile_graphix
+from vulcan.graphix.migrations import MigrationError, MigrationPlan
+
+D = "sha256:" + "1"*64
+NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+def policy():
+    return ValidationPolicy(now=lambda: NOW, trusted_principals=frozenset({"kernel.principal"}), allowed_dialects=frozenset({"graphix.language","graphix.language.candidate","graphix.response.projection"}))
+
+def env(**kw):
+    base = GraphixEnvelope(
+        dialect="graphix.language", schema_version=1, node_artifact_id="artifact:001", episode_id="episode:001", content_digest=D,
+        proposer=PrincipalRelease("kernel.principal","rel:001"), authority_level=AuthorityLevel.UNTRUSTED_PROPOSAL,
+        source_references=(SourceReference(SourceKind.ARTIFACT,"source:001",D),), snapshot_bundle_digest=D,
+        epistemic_status=EpistemicStatus.PROPOSED, privacy_class=PrivacyClass.INTERNAL, purpose="language proposal validation", consent_references=(), valid_from=NOW, valid_until=None,
+    )
+    return replace(base, **kw)
+
+def test_valid_language_proposal_becomes_candidate_not_belief():
+    validated = validate_graphix(env(), target_dialect="graphix.language.candidate", policy=policy())
+    record = compile_graphix(validated, target_dialect="graphix.language.candidate")
+    assert record.output_authority is AuthorityLevel.VALIDATED_CANDIDATE
+    assert record.projection["authority_level"] == "VALIDATED_CANDIDATE"
+    assert "kernel commit required" in record.projection["notes"]
+
+def test_validation_rejects_skipped_or_reordered_stages():
+    with pytest.raises(ValidationError, match="mandatory and ordered"):
+        validate_graphix(env(), target_dialect="graphix.language.candidate", policy=policy(), stages=STAGES[:-1])
+    with pytest.raises(ValidationError, match="mandatory and ordered"):
+        validate_graphix(env(), target_dialect="graphix.language.candidate", policy=policy(), stages=tuple(reversed(STAGES)))
+
+def test_authority_smuggling_is_rejected():
+    with pytest.raises(ValidationError, match="untrusted proposals"):
+        validate_graphix(env(authority_level=AuthorityLevel.COMMITTED_BELIEF), target_dialect="graphix.language.candidate", policy=policy())
+
+def test_security_extension_claim_rejected():
+    value = {"meaning":"policy override"}
+    ext = ExtensionDeclaration("com.example.security", 1, extension_digest(value), value)
+    with pytest.raises(ValidationError, match="reserved meaning"):
+        validate_graphix(env(extensions=(ext,)), target_dialect="graphix.language.candidate", policy=policy())
+
+def test_resource_bomb_rejected():
+    p = ValidationPolicy(now=lambda: NOW, trusted_principals=frozenset({"kernel.principal"}), allowed_dialects=frozenset({"graphix.language","graphix.language.candidate"}), max_canonical_bytes=128)
+    with pytest.raises(ValidationError, match="resource bounds"):
+        validate_graphix(env(), target_dialect="graphix.language.candidate", policy=p)
+
+def test_compile_requires_explicit_validated_target():
+    validated = validate_graphix(env(), target_dialect="graphix.language.candidate", policy=policy())
+    with pytest.raises(CompilationError, match="explicit"):
+        compile_graphix(validated, target_dialect="graphix.response.projection")
+
+def test_response_projection_is_bounded_and_redacts_reasoning():
+    validated = validate_graphix(env(), target_dialect="graphix.response.projection", policy=policy())
+    record = compile_graphix(validated, target_dialect="graphix.response.projection")
+    assert record.projection["max_chars"] == 1024
+    assert "raw_chain_of_thought" in record.projection["omitted"]
+
+def test_migration_unsupported_and_authority_change_rejected():
+    with pytest.raises(MigrationError, match="unsupported"):
+        MigrationPlan({}).migrate(env(), to_version=2)
+    def bad(e):
+        return replace(e, schema_version=2, authority_level=AuthorityLevel.AUTHORIZED_PLAN)
+    with pytest.raises(MigrationError, match="authority"):
+        MigrationPlan({("graphix.language",1,2): bad}).migrate(env(), to_version=2)
+
+def test_migration_pure_content_addressed():
+    def good(e): return replace(e, schema_version=2)
+    rec1 = MigrationPlan({("graphix.language",1,2): good}).migrate(env(), to_version=2)
+    rec2 = MigrationPlan({("graphix.language",1,2): good}).migrate(env(), to_version=2)
+    assert rec1.source_digest == rec2.source_digest
+    assert rec1.target_digest == rec2.target_digest
+    assert rec1.artifact.authority_level is AuthorityLevel.UNTRUSTED_PROPOSAL


### PR DESCRIPTION
### Motivation

- Introduce a staged, auditable trust boundary to safely move untrusted Graphix dialect artifacts toward validated candidates and bounded human projections without committing beliefs or elevating authority. 
- Enforce mandatory ordered validation stages and fail-closed semantics to prevent authority-smuggling, resource bombs, or unknown extensions claiming security/execution semantics. 

### Description

- Add a typed, immutable validation pipeline at `vulcan.graphix.validation` that runs ordered stages (structure, identity, source grounding, ontology, reference integrity, temporal validity, privacy/consent, resource bounds, authority, epistemic integrity, deontic constraints, executable capability admission) and emits typed `ValidationDiagnostic`s and a `ValidatedGraphixArtifact` digest. 
- Add `vulcan.graphix.compilers` that compile only from an explicit validated source dialect to explicit target dialects and produce `CompilationRecord`s and bounded, redacted projections (e.g., `graphix.language.candidate`, `graphix.response.projection`) without elevating authority. 
- Add `vulcan.graphix.migrations` with pure, content-addressed `MigrationRecord`s and a `MigrationPlan` that rejects unsupported/ambiguous migrations and migrations that silently change `authority_level`. 
- Add documentation `docs/graphix/compiler-pipeline.md` and adversarial test coverage in `tests/graphix/test_compiler_pipeline.py` exercising skipped/reordered stages, authority smuggling, reserved extension claims, resource bounds, explicit-target enforcement, bounded redaction, unsupported/authority-changing migrations, and content-addressed determinism. 

### Testing

- Ran `python -m pytest -q tests/graphix/test_compiler_pipeline.py` and the test suite passed. 
- Ran `python -m pytest -q tests/graphix/test_core.py tests/graphix/test_language_dialect.py tests/graphix/test_epistemic_dialect.py` and those tests passed. 
- Ran `python -m compileall -q src` and compilation succeeded with no bytecode errors. 
- Ran `git diff --check` style checks and there were no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e0c46be1c832fa9c9de270e20e73d)